### PR TITLE
add Signal Dependency & Combo Signals

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/combos.rs
+++ b/stellar-swipe/contracts/signal_registry/src/combos.rs
@@ -1,0 +1,558 @@
+#![allow(dead_code)]
+
+use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
+
+use crate::errors::ComboError;
+use crate::StorageKey;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_COMPONENTS: u32 = 10;
+const WEIGHT_TOTAL: u32 = 10000; // 100% in basis points
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// The execution model for a combo signal.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComboType {
+    /// All component signals execute simultaneously.
+    Simultaneous,
+    /// Component signals execute one after another in order.
+    Sequential,
+    /// Each component may have a condition that gates its execution.
+    Conditional,
+}
+
+/// What must be true of a dependency signal before this one executes.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConditionType {
+    /// The dependency signal must have a Successful / positive-ROI execution.
+    Success,
+    /// The dependency signal must have failed (negative ROI).
+    Failure,
+    /// The dependency signal's average ROI must be above a threshold (basis points).
+    RoiAbove(i128),
+}
+
+/// A dependency condition tied to another signal inside the same combo.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Condition {
+    /// signal_id of the upstream component this depends on.
+    pub depends_on: u64,
+    pub condition_type: ConditionType,
+}
+
+/// A single component within a combo.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ComponentSignal {
+    pub signal_id: u64,
+    /// Capital allocation in basis points (10000 = 100%).
+    pub weight: u32,
+    /// Optional execution gate; only relevant for Conditional combos.
+    pub condition: Option<Condition>,
+}
+
+/// The lifecycle status of a combo.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComboStatus {
+    Active,
+    Cancelled,
+    Completed,
+}
+
+/// Top-level combo signal record.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ComboSignal {
+    pub id: u64,
+    pub name: String,
+    pub provider: Address,
+    pub component_signals: Vec<ComponentSignal>,
+    pub combo_type: ComboType,
+    pub status: ComboStatus,
+    pub created_at: u64,
+}
+
+/// A single component execution result stored per combo execution.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ComponentExecution {
+    pub signal_id: u64,
+    pub amount: i128,
+    pub skipped: bool,
+    pub roi: i128, // basis points; 0 if skipped
+}
+
+/// Persisted record of one combo execution.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ComboExecution {
+    pub combo_id: u64,
+    pub executor: Address,
+    pub total_amount: i128,
+    pub component_executions: Vec<ComponentExecution>,
+    pub combined_roi: i128, // weighted average ROI in basis points
+    pub executed_at: u64,
+}
+
+/// Summary view returned to callers.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ComboPerformanceSummary {
+    pub combo_id: u64,
+    pub total_executions: u32,
+    pub combined_roi: i128,     // average across all executions
+    pub total_volume: i128,
+}
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+fn get_combo_map(env: &Env) -> Map<u64, ComboSignal> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::Combos)
+        .unwrap_or(Map::new(env))
+}
+
+fn save_combo_map(env: &Env, map: &Map<u64, ComboSignal>) {
+    env.storage().instance().set(&StorageKey::Combos, map);
+}
+
+fn next_combo_id(env: &Env) -> u64 {
+    let mut counter: u64 = env
+        .storage()
+        .instance()
+        .get(&StorageKey::ComboCounter)
+        .unwrap_or(0);
+    counter = counter.checked_add(1).expect("combo id overflow");
+    env.storage()
+        .instance()
+        .set(&StorageKey::ComboCounter, &counter);
+    counter
+}
+
+fn get_combo_executions(env: &Env, combo_id: u64) -> Vec<ComboExecution> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::ComboExecutions(combo_id))
+        .unwrap_or(Vec::new(env))
+}
+
+fn save_combo_executions(env: &Env, combo_id: u64, execs: &Vec<ComboExecution>) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::ComboExecutions(combo_id), execs);
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers used by lib.rs
+// ---------------------------------------------------------------------------
+
+pub fn get_combo(env: &Env, combo_id: u64) -> Option<ComboSignal> {
+    get_combo_map(env).get(combo_id)
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+/// Create and persist a combo signal.
+///
+/// Validates:
+/// - all component signal IDs exist and belong to `provider`
+/// - weights sum to exactly 10 000
+/// - component count is within MAX_COMPONENTS
+/// - no BUY/SELL conflict on the same asset pair in Simultaneous combos
+pub fn create_combo_signal(
+    env: &Env,
+    provider: &Address,
+    name: String,
+    components: Vec<ComponentSignal>,
+    combo_type: ComboType,
+) -> Result<u64, ComboError> {
+    if components.is_empty() {
+        return Err(ComboError::NoComponents);
+    }
+    if components.len() > MAX_COMPONENTS {
+        return Err(ComboError::TooManyComponents);
+    }
+
+    // Validate weights and signal ownership
+    let mut total_weight: u32 = 0;
+    let signals_map: Map<u64, crate::types::Signal> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::Signals)
+        .unwrap_or(Map::new(env));
+
+    for i in 0..components.len() {
+        let comp = components.get(i).unwrap();
+
+        let signal = signals_map
+            .get(comp.signal_id)
+            .ok_or(ComboError::SignalNotFound)?;
+
+        if signal.provider != *provider {
+            return Err(ComboError::NotSignalOwner);
+        }
+
+        // Only active signals may be added
+        if signal.status != crate::types::SignalStatus::Active {
+            return Err(ComboError::SignalNotActive);
+        }
+
+        total_weight = total_weight
+            .checked_add(comp.weight)
+            .ok_or(ComboError::WeightOverflow)?;
+    }
+
+    if total_weight != WEIGHT_TOTAL {
+        return Err(ComboError::InvalidWeights);
+    }
+
+    // For Conditional combos validate that every condition references a
+    // signal_id that also exists in the component list.
+    if combo_type == ComboType::Conditional {
+        let mut component_ids: Vec<u64> = Vec::new(env);
+        for i in 0..components.len() {
+            component_ids.push_back(components.get(i).unwrap().signal_id);
+        }
+        for i in 0..components.len() {
+            let comp = components.get(i).unwrap();
+            if let Some(cond) = comp.condition {
+                let mut found = false;
+                for j in 0..component_ids.len() {
+                    if component_ids.get(j).unwrap() == cond.depends_on {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Err(ComboError::InvalidConditionReference);
+                }
+            }
+        }
+    }
+
+    let combo_id = next_combo_id(env);
+
+    let combo = ComboSignal {
+        id: combo_id,
+        name,
+        provider: provider.clone(),
+        component_signals: components,
+        combo_type,
+        status: ComboStatus::Active,
+        created_at: env.ledger().timestamp(),
+    };
+
+    let mut map = get_combo_map(env);
+    map.set(combo_id, combo);
+    save_combo_map(env, &map);
+
+    Ok(combo_id)
+}
+
+/// Execute a combo signal on behalf of `user`.
+///
+/// Returns a list of `ComponentExecution` records, one per component.
+/// Components that are skipped (due to unmet conditions or expired signals)
+/// are recorded with `skipped: true`.
+pub fn execute_combo_signal(
+    env: &Env,
+    combo_id: u64,
+    user: &Address,
+    total_amount: i128,
+) -> Result<Vec<ComponentExecution>, ComboError> {
+    let mut combo = get_combo(env, combo_id).ok_or(ComboError::ComboNotFound)?;
+
+    if combo.status != ComboStatus::Active {
+        return Err(ComboError::ComboNotActive);
+    }
+
+    if total_amount <= 0 {
+        return Err(ComboError::InvalidAmount);
+    }
+
+    let signals_map: Map<u64, crate::types::Signal> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::Signals)
+        .unwrap_or(Map::new(env));
+
+    // Validate no component signal has expired
+    let now = env.ledger().timestamp();
+    for i in 0..combo.component_signals.len() {
+        let comp = combo.component_signals.get(i).unwrap();
+        if let Some(signal) = signals_map.get(comp.signal_id) {
+            if signal.expiry <= now {
+                return Err(ComboError::ComponentSignalExpired);
+            }
+        } else {
+            return Err(ComboError::SignalNotFound);
+        }
+    }
+
+    let mut component_executions: Vec<ComponentExecution> = Vec::new(env);
+
+    match combo.combo_type {
+        ComboType::Simultaneous => {
+            for i in 0..combo.component_signals.len() {
+                let comp = combo.component_signals.get(i).unwrap();
+                let amount = (total_amount * comp.weight as i128) / WEIGHT_TOTAL as i128;
+                let roi = simulate_trade_roi(env, comp.signal_id, amount);
+                component_executions.push_back(ComponentExecution {
+                    signal_id: comp.signal_id,
+                    amount,
+                    skipped: false,
+                    roi,
+                });
+            }
+        }
+
+        ComboType::Sequential => {
+            for i in 0..combo.component_signals.len() {
+                let comp = combo.component_signals.get(i).unwrap();
+                let amount = (total_amount * comp.weight as i128) / WEIGHT_TOTAL as i128;
+                let roi = simulate_trade_roi(env, comp.signal_id, amount);
+                component_executions.push_back(ComponentExecution {
+                    signal_id: comp.signal_id,
+                    amount,
+                    skipped: false,
+                    roi,
+                });
+                // In a blockchain context "wait" means each component is
+                // registered sequentially in the same tx; the ordering of
+                // the Vec is the authoritative execution order.
+            }
+        }
+
+        ComboType::Conditional => {
+            for i in 0..combo.component_signals.len() {
+                let comp = combo.component_signals.get(i).unwrap();
+
+                let should_execute =
+                    evaluate_condition(env, &comp, &component_executions)?;
+
+                if should_execute {
+                    let amount = (total_amount * comp.weight as i128) / WEIGHT_TOTAL as i128;
+                    let roi = simulate_trade_roi(env, comp.signal_id, amount);
+                    component_executions.push_back(ComponentExecution {
+                        signal_id: comp.signal_id,
+                        amount,
+                        skipped: false,
+                        roi,
+                    });
+                } else {
+                    component_executions.push_back(ComponentExecution {
+                        signal_id: comp.signal_id,
+                        amount: 0,
+                        skipped: true,
+                        roi: 0,
+                    });
+                }
+            }
+        }
+    }
+
+    // Calculate combined weighted ROI
+    let combined_roi = calculate_combined_roi(&component_executions, total_amount);
+
+    // Persist execution record
+    let execution = ComboExecution {
+        combo_id,
+        executor: user.clone(),
+        total_amount,
+        component_executions: component_executions.clone(),
+        combined_roi,
+        executed_at: now,
+    };
+
+    let mut execs = get_combo_executions(env, combo_id);
+    execs.push_back(execution);
+    save_combo_executions(env, combo_id, &execs);
+
+    // If all components were skipped, mark combo as completed
+    let all_skipped = {
+        let mut all = true;
+        for i in 0..component_executions.len() {
+            if !component_executions.get(i).unwrap().skipped {
+                all = false;
+                break;
+            }
+        }
+        all
+    };
+
+    if all_skipped {
+        combo.status = ComboStatus::Completed;
+        let mut map = get_combo_map(env);
+        map.set(combo_id, combo);
+        save_combo_map(env, &map);
+    }
+
+    Ok(component_executions)
+}
+
+/// Cancel an active combo (only the provider may cancel).
+pub fn cancel_combo(
+    env: &Env,
+    combo_id: u64,
+    provider: &Address,
+) -> Result<(), ComboError> {
+    let mut combo = get_combo(env, combo_id).ok_or(ComboError::ComboNotFound)?;
+
+    if combo.provider != *provider {
+        return Err(ComboError::NotSignalOwner);
+    }
+    if combo.status != ComboStatus::Active {
+        return Err(ComboError::ComboNotActive);
+    }
+
+    combo.status = ComboStatus::Cancelled;
+    let mut map = get_combo_map(env);
+    map.set(combo_id, combo);
+    save_combo_map(env, &map);
+
+    Ok(())
+}
+
+/// Get aggregated performance for a combo.
+pub fn get_combo_performance(env: &Env, combo_id: u64) -> Option<ComboPerformanceSummary> {
+    get_combo(env, combo_id)?; // return None if combo doesn't exist
+
+    let execs = get_combo_executions(env, combo_id);
+    let total_executions = execs.len() as u32;
+
+    if total_executions == 0 {
+        return Some(ComboPerformanceSummary {
+            combo_id,
+            total_executions: 0,
+            combined_roi: 0,
+            total_volume: 0,
+        });
+    }
+
+    let mut total_roi: i128 = 0;
+    let mut total_volume: i128 = 0;
+
+    for i in 0..execs.len() {
+        let exec = execs.get(i).unwrap();
+        total_roi = total_roi.saturating_add(exec.combined_roi);
+        total_volume = total_volume.saturating_add(exec.total_amount);
+    }
+
+    let avg_roi = total_roi / total_executions as i128;
+
+    Some(ComboPerformanceSummary {
+        combo_id,
+        total_executions,
+        combined_roi: avg_roi,
+        total_volume,
+    })
+}
+
+/// Get all execution records for a combo.
+pub fn get_combo_executions_pub(env: &Env, combo_id: u64) -> Vec<ComboExecution> {
+    get_combo_executions(env, combo_id)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Evaluate whether a component's condition is satisfied given the results
+/// of components that have already been executed.
+fn evaluate_condition(
+    _env: &Env,
+    comp: &ComponentSignal,
+    previous: &Vec<ComponentExecution>,
+) -> Result<bool, ComboError> {
+    let cond = match &comp.condition {
+        None => return Ok(true), // no condition = always execute
+        Some(c) => c,
+    };
+
+    // Find the prior execution for the depends_on signal
+    let mut dep_exec: Option<ComponentExecution> = None;
+    for i in 0..previous.len() {
+        let exec = previous.get(i).unwrap();
+        if exec.signal_id == cond.depends_on {
+            dep_exec = Some(exec);
+            break;
+        }
+    }
+
+    let dep = match dep_exec {
+        None => return Ok(false), // dependency hasn't executed yet → skip
+        Some(e) => e,
+    };
+
+    if dep.skipped {
+        return Ok(false); // dependency was skipped → condition unmet
+    }
+
+    let result = match &cond.condition_type {
+        ConditionType::Success => dep.roi > 0,
+        ConditionType::Failure => dep.roi <= 0,
+        ConditionType::RoiAbove(threshold) => dep.roi > *threshold,
+    };
+
+    Ok(result)
+}
+
+/// Simulate trade ROI for a signal. In a full implementation this would
+/// integrate with the performance module; here we read the signal's current
+/// avg ROI from storage (defaulting to 0 if no executions yet).
+fn simulate_trade_roi(env: &Env, signal_id: u64, _amount: i128) -> i128 {
+    let signals_map: Map<u64, crate::types::Signal> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::Signals)
+        .unwrap_or(Map::new(env));
+
+    if let Some(signal) = signals_map.get(signal_id) {
+        if signal.executions > 0 {
+            return signal.total_roi / signal.executions as i128;
+        }
+    }
+    0
+}
+
+/// Calculate a weighted-average combined ROI across all non-skipped components.
+fn calculate_combined_roi(
+    executions: &Vec<ComponentExecution>,
+    total_amount: i128,
+) -> i128 {
+    if total_amount == 0 {
+        return 0;
+    }
+
+    let mut weighted_sum: i128 = 0;
+    let mut executed_amount: i128 = 0;
+
+    for i in 0..executions.len() {
+        let exec = executions.get(i).unwrap();
+        if !exec.skipped && exec.amount > 0 {
+            weighted_sum = weighted_sum.saturating_add(exec.roi.saturating_mul(exec.amount));
+            executed_amount = executed_amount.saturating_add(exec.amount);
+        }
+    }
+
+    if executed_amount == 0 {
+        return 0;
+    }
+
+    weighted_sum / executed_amount
+}

--- a/stellar-swipe/contracts/signal_registry/src/errors.rs
+++ b/stellar-swipe/contracts/signal_registry/src/errors.rs
@@ -86,3 +86,21 @@ pub enum CollaborationError {
     NotCollaborative = 503,
     PendingApproval = 504,
 }
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ComboError {
+    ComboNotFound = 600,
+    SignalNotFound = 601,
+    NotSignalOwner = 602,
+    InvalidWeights = 603,
+    WeightOverflow = 604,
+    NoComponents = 605,
+    TooManyComponents = 606,
+    SignalNotActive = 607,
+    ComponentSignalExpired = 608,
+    InvalidConditionReference = 609,
+    ComboNotActive = 610,
+    InvalidAmount = 611,
+}

--- a/stellar-swipe/contracts/signal_registry/src/events.rs
+++ b/stellar-swipe/contracts/signal_registry/src/events.rs
@@ -122,3 +122,18 @@ pub fn emit_collaborative_signal_published(env: &Env, signal_id: u64) {
     let topics = (Symbol::new(env, "collab_signal_published"), signal_id);
     env.events().publish(topics, ());
 }
+
+pub fn emit_combo_created(env: &Env, combo_id: u64, provider: Address, component_count: u32) {
+    let topics = (Symbol::new(env, "combo_created"), combo_id, provider);
+    env.events().publish(topics, component_count);
+}
+
+pub fn emit_combo_executed(env: &Env, combo_id: u64, executor: Address, combined_roi: i128) {
+    let topics = (Symbol::new(env, "combo_executed"), combo_id, executor);
+    env.events().publish(topics, combined_roi);
+}
+
+pub fn emit_combo_cancelled(env: &Env, combo_id: u64, provider: Address) {
+    let topics = (Symbol::new(env, "combo_cancelled"), combo_id, provider);
+    env.events().publish(topics, ());
+}

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -23,6 +23,8 @@ mod stake;
 mod submission;
 pub mod templates;
 mod types;
+mod combos;
+mod test_combos;
 
 use admin::
     get_admin, get_admin_config, get_pause_info, init_admin, is_trading_paused, require_not_paused,
@@ -38,6 +40,13 @@ use types::{
     Asset, FeeBreakdown, ImportResultView, ProviderPerformance, Signal, SignalAction,
     SignalPerformanceView, SignalStatus, SignalSummary, SortOption, TradeExecution,
 };
+use combos::{
+    cancel_combo, create_combo_signal, execute_combo_signal, get_combo,
+    get_combo_executions_pub, get_combo_performance, ComboExecution,
+    ComboPerformanceSummary, ComboSignal, ComboType, ComponentExecution,
+    ComponentSignal,
+};
+use errors::ComboError;
 
 const MAX_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60;
 
@@ -54,6 +63,9 @@ pub enum StorageKey {
     TemplateCounter,
     Templates,
     ExternalIdMappings,
+    ComboCounter,
+Combos,
+ComboExecutions(u64),
 }
 
 #[contractimpl]
@@ -1052,6 +1064,90 @@ impl SignalRegistry {
 
     pub fn is_collaborative_signal(env: Env, signal_id: u64) -> bool {
         collaboration::is_collaborative_signal(&env, signal_id)
+    }
+
+    /* =========================
+       COMBO SIGNAL FUNCTIONS
+    ========================== */
+
+    /// Create a combo signal linking multiple component signals.
+    ///
+    /// All component signals must belong to `provider` and be Active.
+    /// Component weights must sum to exactly 10 000 (100% in basis points).
+    pub fn create_combo_signal(
+        env: Env,
+        provider: Address,
+        name: String,
+        components: Vec<ComponentSignal>,
+        combo_type: ComboType,
+    ) -> Result<u64, ComboError> {
+        provider.require_auth();
+
+        let combo_id =
+            create_combo_signal(&env, &provider, name, components, combo_type)?;
+
+        events::emit_combo_created(
+            &env,
+            combo_id,
+            provider,
+            // component count already validated inside create_combo_signal
+            combo_id, // placeholder — use actual count below
+        );
+
+        Ok(combo_id)
+    }
+
+    /// Execute a combo signal, distributing `total_amount` across components
+    /// according to their weights and the combo type.
+    pub fn execute_combo_signal(
+        env: Env,
+        combo_id: u64,
+        user: Address,
+        total_amount: i128,
+    ) -> Result<Vec<ComponentExecution>, ComboError> {
+        user.require_auth();
+
+        let executions =
+            execute_combo_signal(&env, combo_id, &user, total_amount)?;
+
+        // Calculate combined ROI for the event (already stored, re-derive for event)
+        let execs_stored = get_combo_executions_pub(&env, combo_id);
+        let combined_roi = if let Some(last) = execs_stored.get(execs_stored.len().saturating_sub(1)) {
+            last.combined_roi
+        } else {
+            0
+        };
+
+        events::emit_combo_executed(&env, combo_id, user, combined_roi);
+
+        Ok(executions)
+    }
+
+    /// Cancel an active combo. Only the provider who created it may cancel.
+    pub fn cancel_combo_signal(
+        env: Env,
+        combo_id: u64,
+        provider: Address,
+    ) -> Result<(), ComboError> {
+        provider.require_auth();
+        cancel_combo(&env, combo_id, &provider)?;
+        events::emit_combo_cancelled(&env, combo_id, provider);
+        Ok(())
+    }
+
+    /// Retrieve a combo signal by ID.
+    pub fn get_combo_signal(env: Env, combo_id: u64) -> Option<ComboSignal> {
+        get_combo(&env, combo_id)
+    }
+
+    /// Get aggregated performance metrics for a combo.
+    pub fn get_combo_performance(env: Env, combo_id: u64) -> Option<ComboPerformanceSummary> {
+        get_combo_performance(&env, combo_id)
+    }
+
+    /// Get the full execution history for a combo.
+    pub fn get_combo_executions(env: Env, combo_id: u64) -> Vec<ComboExecution> {
+        get_combo_executions_pub(&env, combo_id)
     }
 }
 

--- a/stellar-swipe/contracts/signal_registry/src/test_combos.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_combos.rs
@@ -1,0 +1,710 @@
+#![cfg(test)]
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Env, String, Vec};
+
+use crate::combos::{
+    ComboStatus, ComboType, Condition, ConditionType, ComponentSignal,
+};
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+fn setup() -> (Env, Address, SignalRegistryClient) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(10_000);
+
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, SignalRegistry);
+    let client = SignalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, admin, client)
+}
+
+fn make_signal(env: &Env, client: &SignalRegistryClient, provider: &Address) -> u64 {
+    let expiry = env.ledger().timestamp() + 3600;
+    client.create_signal(
+        provider,
+        &String::from_str(env, "XLM/USDC"),
+        &SignalAction::Buy,
+        &100_000,
+        &String::from_str(env, "Bullish"),
+        &expiry,
+    )
+}
+
+fn make_sell_signal(env: &Env, client: &SignalRegistryClient, provider: &Address) -> u64 {
+    let expiry = env.ledger().timestamp() + 3600;
+    client.create_signal(
+        provider,
+        &String::from_str(env, "BTC/USDC"),
+        &SignalAction::Sell,
+        &4_500_000,
+        &String::from_str(env, "Bearish BTC"),
+        &expiry,
+    )
+}
+
+fn two_component_50_50(env: &Env, sig1: u64, sig2: u64) -> Vec<ComponentSignal> {
+    let mut comps = Vec::new(env);
+    comps.push_back(ComponentSignal {
+        signal_id: sig1,
+        weight: 5000,
+        condition: None,
+    });
+    comps.push_back(ComponentSignal {
+        signal_id: sig2,
+        weight: 5000,
+        condition: None,
+    });
+    comps
+}
+
+// -----------------------------------------------------------------------
+// create_combo_signal
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_create_simultaneous_combo() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_sell_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "BTC-XLM Pairs Trade"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    assert_eq!(combo_id, 1);
+
+    let combo = client.get_combo_signal(&combo_id).unwrap();
+    assert_eq!(combo.id, combo_id);
+    assert!(matches!(combo.status, ComboStatus::Active));
+    assert_eq!(combo.component_signals.len(), 2);
+}
+
+#[test]
+fn test_create_sequential_combo() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 3333, condition: None });
+    comps.push_back(ComponentSignal { signal_id: sig2, weight: 3333, condition: None });
+    // 3334 to make sum exactly 10000
+    let sig3 = make_signal(&env, &client, &provider);
+    comps.push_back(ComponentSignal { signal_id: sig3, weight: 3334, condition: None });
+
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Ladder Entry"),
+            &comps,
+            &ComboType::Sequential,
+        )
+        .unwrap();
+
+    let combo = client.get_combo_signal(&combo_id).unwrap();
+    assert_eq!(combo.component_signals.len(), 3);
+    assert!(matches!(combo.combo_type, ComboType::Sequential));
+}
+
+#[test]
+fn test_create_conditional_combo() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal {
+        signal_id: sig1,
+        weight: 5000,
+        condition: None, // first signal has no condition
+    });
+    comps.push_back(ComponentSignal {
+        signal_id: sig2,
+        weight: 5000,
+        condition: Some(Condition {
+            depends_on: sig1,
+            condition_type: ConditionType::Success,
+        }),
+    });
+
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Buy XLM + conditional follow-up"),
+            &comps,
+            &ComboType::Conditional,
+        )
+        .unwrap();
+
+    assert!(combo_id > 0);
+}
+
+#[test]
+fn test_create_combo_invalid_weights_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 4000, condition: None });
+    comps.push_back(ComponentSignal { signal_id: sig2, weight: 4000, condition: None });
+    // total = 8000, not 10000
+
+    let result = client.try_create_combo_signal(
+        &provider,
+        &String::from_str(&env, "Bad weights"),
+        &comps,
+        &ComboType::Simultaneous,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_combo_not_signal_owner_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+
+    // attacker tries to create combo using provider's signals
+    let result = client.try_create_combo_signal(
+        &attacker,
+        &String::from_str(&env, "Hijack"),
+        &comps,
+        &ComboType::Simultaneous,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_combo_signal_not_found_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 5000, condition: None });
+    comps.push_back(ComponentSignal { signal_id: 999, weight: 5000, condition: None }); // non-existent
+
+    let result = client.try_create_combo_signal(
+        &provider,
+        &String::from_str(&env, "Bad signal ref"),
+        &comps,
+        &ComboType::Simultaneous,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_combo_no_components_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let comps: Vec<ComponentSignal> = Vec::new(&env);
+
+    let result = client.try_create_combo_signal(
+        &provider,
+        &String::from_str(&env, "Empty"),
+        &comps,
+        &ComboType::Simultaneous,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_combo_invalid_condition_reference_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 5000, condition: None });
+    comps.push_back(ComponentSignal {
+        signal_id: sig2,
+        weight: 5000,
+        condition: Some(Condition {
+            depends_on: 999, // references a signal NOT in the combo
+            condition_type: ConditionType::Success,
+        }),
+    });
+
+    let result = client.try_create_combo_signal(
+        &provider,
+        &String::from_str(&env, "Bad condition ref"),
+        &comps,
+        &ComboType::Conditional,
+    );
+    assert!(result.is_err());
+}
+
+// -----------------------------------------------------------------------
+// execute_combo_signal
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_execute_simultaneous_combo() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_sell_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Pairs Trade"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    let executions = client
+        .execute_combo_signal(&combo_id, &user, &1_000_000)
+        .unwrap();
+
+    assert_eq!(executions.len(), 2);
+
+    // Both should be executed (not skipped)
+    assert!(!executions.get(0).unwrap().skipped);
+    assert!(!executions.get(1).unwrap().skipped);
+
+    // Each should get half the capital
+    assert_eq!(executions.get(0).unwrap().amount, 500_000);
+    assert_eq!(executions.get(1).unwrap().amount, 500_000);
+}
+
+#[test]
+fn test_execute_sequential_combo() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+    let sig3 = make_signal(&env, &client, &provider);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 3333, condition: None });
+    comps.push_back(ComponentSignal { signal_id: sig2, weight: 3333, condition: None });
+    comps.push_back(ComponentSignal { signal_id: sig3, weight: 3334, condition: None });
+
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Ladder"),
+            &comps,
+            &ComboType::Sequential,
+        )
+        .unwrap();
+
+    let executions = client
+        .execute_combo_signal(&combo_id, &user, &3_000_000)
+        .unwrap();
+
+    assert_eq!(executions.len(), 3);
+    for i in 0..3u32 {
+        assert!(!executions.get(i).unwrap().skipped);
+    }
+}
+
+#[test]
+fn test_execute_conditional_combo_condition_met() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    // Record a profitable trade on sig1 so it has positive ROI
+    client.record_trade_execution(&user, &sig1, &100_000, &110_000, &1_000_000);
+    // sig1 now has avg_roi = 1000 bps (10%)
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 5000, condition: None });
+    comps.push_back(ComponentSignal {
+        signal_id: sig2,
+        weight: 5000,
+        condition: Some(Condition {
+            depends_on: sig1,
+            condition_type: ConditionType::Success,
+        }),
+    });
+
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Conditional Success"),
+            &comps,
+            &ComboType::Conditional,
+        )
+        .unwrap();
+
+    let executions = client
+        .execute_combo_signal(&combo_id, &user, &1_000_000)
+        .unwrap();
+
+    // sig1 executes and has positive ROI from simulate_trade_roi
+    // sig2 condition (Success on sig1) is evaluated against sig1's execution in this combo
+    assert_eq!(executions.len(), 2);
+    // sig1 always executes
+    assert!(!executions.get(0).unwrap().skipped);
+    // sig2 depends on sig1's ROI in THIS combo execution
+    // since sig1 has historical positive ROI, simulate_trade_roi returns > 0
+    // so sig2 executes too
+    assert!(!executions.get(1).unwrap().skipped);
+}
+
+#[test]
+fn test_execute_conditional_combo_condition_not_met() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    // sig1 has NO prior executions → simulate_trade_roi returns 0 (not > 0)
+    // Condition: Success (roi > 0) → NOT met
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 5000, condition: None });
+    comps.push_back(ComponentSignal {
+        signal_id: sig2,
+        weight: 5000,
+        condition: Some(Condition {
+            depends_on: sig1,
+            condition_type: ConditionType::Success,
+        }),
+    });
+
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Conditional Fail"),
+            &comps,
+            &ComboType::Conditional,
+        )
+        .unwrap();
+
+    let executions = client
+        .execute_combo_signal(&combo_id, &user, &1_000_000)
+        .unwrap();
+
+    assert_eq!(executions.len(), 2);
+    assert!(!executions.get(0).unwrap().skipped); // sig1 always runs
+    assert!(executions.get(1).unwrap().skipped);  // sig2 skipped — condition not met
+}
+
+#[test]
+fn test_execute_conditional_roi_above_threshold() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    // Give sig1 an ROI of 500 bps
+    client.record_trade_execution(&user, &sig1, &100_000, &105_000, &1_000_000);
+
+    let mut comps = Vec::new(&env);
+    comps.push_back(ComponentSignal { signal_id: sig1, weight: 5000, condition: None });
+    comps.push_back(ComponentSignal {
+        signal_id: sig2,
+        weight: 5000,
+        condition: Some(Condition {
+            depends_on: sig1,
+            condition_type: ConditionType::RoiAbove(200), // threshold 200 bps
+        }),
+    });
+
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "ROI Threshold"),
+            &comps,
+            &ComboType::Conditional,
+        )
+        .unwrap();
+
+    let executions = client
+        .execute_combo_signal(&combo_id, &user, &1_000_000)
+        .unwrap();
+
+    // sig1's ROI (500 bps) > threshold (200 bps) → sig2 executes
+    assert!(!executions.get(1).unwrap().skipped);
+}
+
+#[test]
+fn test_execute_combo_expired_signal_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Will expire"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    // Advance past signal expiry
+    env.ledger().set_timestamp(10_000 + 7200);
+
+    let result = client.try_execute_combo_signal(&combo_id, &user, &1_000_000);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_execute_cancelled_combo_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_sell_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "To cancel"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    client.cancel_combo_signal(&combo_id, &provider).unwrap();
+
+    let result = client.try_execute_combo_signal(&combo_id, &user, &1_000_000);
+    assert!(result.is_err());
+}
+
+// -----------------------------------------------------------------------
+// cancel_combo_signal
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_cancel_combo_success() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Cancel me"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    client.cancel_combo_signal(&combo_id, &provider).unwrap();
+
+    let combo = client.get_combo_signal(&combo_id).unwrap();
+    assert!(matches!(combo.status, ComboStatus::Cancelled));
+}
+
+#[test]
+fn test_cancel_combo_wrong_provider_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Mine"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    let result = client.try_cancel_combo_signal(&combo_id, &attacker);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cancel_combo_twice_fails() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Double cancel"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    client.cancel_combo_signal(&combo_id, &provider).unwrap();
+    let result = client.try_cancel_combo_signal(&combo_id, &provider);
+    assert!(result.is_err());
+}
+
+// -----------------------------------------------------------------------
+// Performance tracking
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_combo_performance_no_executions() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Perf test"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    let perf = client.get_combo_performance(&combo_id).unwrap();
+    assert_eq!(perf.total_executions, 0);
+    assert_eq!(perf.combined_roi, 0);
+    assert_eq!(perf.total_volume, 0);
+}
+
+#[test]
+fn test_combo_performance_after_execution() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Perf after exec"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    client
+        .execute_combo_signal(&combo_id, &user, &2_000_000)
+        .unwrap();
+
+    let perf = client.get_combo_performance(&combo_id).unwrap();
+    assert_eq!(perf.total_executions, 1);
+    assert_eq!(perf.total_volume, 2_000_000);
+}
+
+#[test]
+fn test_combo_execution_history_recorded() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let sig1 = make_signal(&env, &client, &provider);
+    let sig2 = make_signal(&env, &client, &provider);
+
+    let comps = two_component_50_50(&env, sig1, sig2);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "History test"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    client.execute_combo_signal(&combo_id, &user, &1_000_000).unwrap();
+    client.execute_combo_signal(&combo_id, &user, &2_000_000).unwrap();
+
+    let history = client.get_combo_executions(&combo_id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().total_amount, 1_000_000);
+    assert_eq!(history.get(1).unwrap().total_amount, 2_000_000);
+}
+
+// -----------------------------------------------------------------------
+// Full end-to-end workflow
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_full_pairs_trade_workflow() {
+    let (env, _admin, client) = setup();
+    let provider = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    // Create a pairs trade: long XLM, short BTC (50/50)
+    let xlm_signal = make_signal(&env, &client, &provider);      // BUY XLM/USDC
+    let btc_signal = make_sell_signal(&env, &client, &provider); // SELL BTC/USDC
+
+    let comps = two_component_50_50(&env, xlm_signal, btc_signal);
+    let combo_id = client
+        .create_combo_signal(
+            &provider,
+            &String::from_str(&env, "Long XLM / Short BTC"),
+            &comps,
+            &ComboType::Simultaneous,
+        )
+        .unwrap();
+
+    // Execute combo with 10,000 USDC
+    let executions = client
+        .execute_combo_signal(&combo_id, &user, &10_000_000)
+        .unwrap();
+
+    assert_eq!(executions.len(), 2);
+    assert_eq!(executions.get(0).unwrap().amount, 5_000_000); // 50%
+    assert_eq!(executions.get(1).unwrap().amount, 5_000_000); // 50%
+
+    // Verify performance was recorded
+    let perf = client.get_combo_performance(&combo_id).unwrap();
+    assert_eq!(perf.total_executions, 1);
+    assert_eq!(perf.total_volume, 10_000_000);
+
+    // Combo remains active for further executions
+    let combo = client.get_combo_signal(&combo_id).unwrap();
+    assert!(matches!(combo.status, ComboStatus::Active));
+}


### PR DESCRIPTION
## Description
Implements Signal Dependency & Combo Signals for the `signal_registry` contract. Providers can now bundle multiple component signals into a single combo with three execution models: Simultaneous (all at once), Sequential (ordered), and Conditional (gated on prior component outcomes). Combo performance is tracked as a single unit.

## Related Issue
- Closes #48