### PR TITLE
add dynamic position sizing

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/position_sizing.rs
+++ b/stellar-swipe/contracts/signal_registry/src/position_sizing.rs
@@ -1,0 +1,503 @@
+#![allow(dead_code)]
+
+//! Dynamic Position Sizing Based on Volatility
+//!
+//! Three sizing methods are supported:
+//!
+//! 1. **FixedPercentage** — risk-adjusted sizing:
+//!    `size = portfolio_value * risk_per_trade_bps / volatility_bps`
+//!    Example: $10K portfolio, 200 bps risk target, 500 bps volatility
+//!    → size = 10_000 * 200 / 500 = $4_000
+//!
+//! 2. **Kelly** — Kelly Criterion with fractional multiplier:
+//!    `kelly_f = (win_rate * avg_win_bps - (10000 - win_rate) * avg_loss_bps) / avg_win_bps`
+//!    `size = portfolio_value * kelly_f * kelly_multiplier / 10000`
+//!
+//! 3. **VolatilityScaled** — scale a base allocation to hit a target volatility:
+//!    `size = (portfolio_value * base_pct / 10000) * target_vol_bps / current_vol_bps`
+//!
+//! All sizes are capped at `max_position_pct` of portfolio value and floored at a
+//! minimum of 1 unit. Zero volatility is treated as maximum risk → minimum position.
+//! High volatility is handled by a configurable floor on position size.
+
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+use crate::errors::AutoTradeError;
+use crate::risk::{calculate_portfolio_value, get_asset_price, get_risk_config, RiskConfig};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default conservative volatility used when there is insufficient price history.
+/// 2000 bps = 20% — deliberately conservative so sizing errs toward small.
+pub const DEFAULT_VOLATILITY_BPS: i128 = 2000;
+
+/// Target volatility for the VolatilityScaled method when the config target is 0.
+pub const DEFAULT_TARGET_VOLATILITY_BPS: i128 = 500; // 5%
+
+/// Minimum position size as an absolute unit (prevents dust).
+pub const MIN_POSITION_SIZE: i128 = 1;
+
+/// Minimum number of price observations required for a valid volatility estimate.
+pub const MIN_PRICE_HISTORY: usize = 2;
+
+/// Hard cap on volatility beyond which we assign the minimum position size.
+/// 10000 bps = 100% daily volatility is essentially untradeble.
+pub const MAX_VOLATILITY_BPS: i128 = 10_000;
+
+/// Default Kelly multiplier (half-Kelly) — 50 out of 100.
+pub const DEFAULT_KELLY_MULTIPLIER: u32 = 50;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// How position sizes are calculated.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SizingMethod {
+    /// Risk-percentage divided by volatility.
+    FixedPercentage,
+    /// Fractional Kelly Criterion based on provider win-rate stats.
+    Kelly,
+    /// Scale a base allocation to maintain a target volatility level.
+    VolatilityScaled,
+}
+
+/// Per-user configuration for position sizing.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PositionSizingConfig {
+    /// Which sizing method to use.
+    pub method: SizingMethod,
+    /// Risk budget per trade in basis points (e.g. 200 = 2%).
+    pub risk_per_trade_bps: u32,
+    /// Maximum position size as percentage of portfolio in basis points (e.g. 2000 = 20%).
+    pub max_position_pct_bps: u32,
+    /// Kelly multiplier 25–50 (= 0.25× – 0.50× Kelly). Applied as out of 100.
+    pub kelly_multiplier: u32,
+    /// Target volatility for VolatilityScaled method in basis points (e.g. 500 = 5%).
+    pub target_volatility_bps: u32,
+    /// Base allocation percentage for VolatilityScaled in basis points (e.g. 1000 = 10%).
+    pub base_position_pct_bps: u32,
+}
+
+impl Default for PositionSizingConfig {
+    fn default() -> Self {
+        PositionSizingConfig {
+            method: SizingMethod::FixedPercentage,
+            risk_per_trade_bps: 200,          // 2% risk per trade
+            max_position_pct_bps: 2000,       // max 20% of portfolio
+            kelly_multiplier: DEFAULT_KELLY_MULTIPLIER,
+            target_volatility_bps: 500,       // target 5% volatility
+            base_position_pct_bps: 1000,      // 10% base allocation
+        }
+    }
+}
+
+/// Detailed sizing recommendation returned to callers.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SizingRecommendation {
+    /// Recommended position size after all adjustments.
+    pub recommended_size: i128,
+    /// Hard maximum allowed by the portfolio limit.
+    pub max_size: i128,
+    /// Volatility used in the calculation (basis points).
+    pub volatility_bps: i128,
+    /// Portfolio value at the time of calculation.
+    pub portfolio_value: i128,
+    /// Whether the recommended size was capped at max_size.
+    pub was_capped: bool,
+}
+
+/// Storage key for position sizing config.
+#[contracttype]
+pub enum SizingDataKey {
+    UserSizingConfig(Address),
+    /// Circular price history buffer: (asset_id, slot) → price.
+    PriceHistory(u32, u32),
+    /// Number of prices stored for an asset.
+    PriceHistoryLen(u32),
+    /// Next write slot (ring buffer head).
+    PriceHistoryHead(u32),
+}
+
+/// Maximum price history slots per asset.
+const MAX_HISTORY_SLOTS: u32 = 60;
+
+// ---------------------------------------------------------------------------
+// Config storage
+// ---------------------------------------------------------------------------
+
+pub fn get_sizing_config(env: &Env, user: &Address) -> PositionSizingConfig {
+    env.storage()
+        .persistent()
+        .get(&SizingDataKey::UserSizingConfig(user.clone()))
+        .unwrap_or_default()
+}
+
+pub fn set_sizing_config(env: &Env, user: &Address, config: &PositionSizingConfig) {
+    validate_sizing_config(config).expect("invalid sizing config");
+    env.storage()
+        .persistent()
+        .set(&SizingDataKey::UserSizingConfig(user.clone()), config);
+}
+
+fn validate_sizing_config(config: &PositionSizingConfig) -> Result<(), AutoTradeError> {
+    if config.max_position_pct_bps > 10_000 {
+        return Err(AutoTradeError::InvalidSizingConfig);
+    }
+    if config.kelly_multiplier > 100 {
+        return Err(AutoTradeError::InvalidSizingConfig);
+    }
+    if config.risk_per_trade_bps > 10_000 {
+        return Err(AutoTradeError::InvalidSizingConfig);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Price history (ring buffer per asset)
+// ---------------------------------------------------------------------------
+
+/// Record a new price observation for an asset. Overwrites oldest entry when full.
+pub fn record_price(env: &Env, asset_id: u32, price: i128) {
+    let len: u32 = env
+        .storage()
+        .persistent()
+        .get(&SizingDataKey::PriceHistoryLen(asset_id))
+        .unwrap_or(0);
+    let head: u32 = env
+        .storage()
+        .persistent()
+        .get(&SizingDataKey::PriceHistoryHead(asset_id))
+        .unwrap_or(0);
+
+    let slot = head % MAX_HISTORY_SLOTS;
+
+    env.storage()
+        .persistent()
+        .set(&SizingDataKey::PriceHistory(asset_id, slot), &price);
+
+    let new_len = if len < MAX_HISTORY_SLOTS { len + 1 } else { len };
+    let new_head = (head + 1) % MAX_HISTORY_SLOTS;
+
+    env.storage()
+        .persistent()
+        .set(&SizingDataKey::PriceHistoryLen(asset_id), &new_len);
+    env.storage()
+        .persistent()
+        .set(&SizingDataKey::PriceHistoryHead(asset_id), &new_head);
+}
+
+/// Retrieve up to `max_slots` most recent prices in chronological order (oldest first).
+pub fn get_price_history(env: &Env, asset_id: u32, max_slots: u32) -> Vec<i128> {
+    let len: u32 = env
+        .storage()
+        .persistent()
+        .get(&SizingDataKey::PriceHistoryLen(asset_id))
+        .unwrap_or(0);
+    let head: u32 = env
+        .storage()
+        .persistent()
+        .get(&SizingDataKey::PriceHistoryHead(asset_id))
+        .unwrap_or(0);
+
+    if len == 0 {
+        return Vec::new(env);
+    }
+
+    let actual = if len < max_slots { len } else { max_slots };
+
+    // The oldest slot when the buffer is full:
+    // head points to where the *next* write will go, so the oldest is at head % MAX_HISTORY_SLOTS
+    // when len == MAX_HISTORY_SLOTS, otherwise the oldest is at slot 0 (writing from 0 forward).
+    let start_slot = if len == MAX_HISTORY_SLOTS {
+        head % MAX_HISTORY_SLOTS
+    } else {
+        // Not yet wrapped: earliest entry is at slot (head - len) in the range [0, MAX)
+        head.saturating_sub(len) % MAX_HISTORY_SLOTS
+    };
+
+    let mut prices = Vec::new(env);
+    for i in 0..actual {
+        let slot = (start_slot + (len - actual) + i) % MAX_HISTORY_SLOTS;
+        if let Some(price) = env
+            .storage()
+            .persistent()
+            .get::<SizingDataKey, i128>(&SizingDataKey::PriceHistory(asset_id, slot))
+        {
+            prices.push_back(price);
+        }
+    }
+    prices
+}
+
+// ---------------------------------------------------------------------------
+// Volatility calculation
+// ---------------------------------------------------------------------------
+
+/// Integer square root (Babylonian method, no_std compatible).
+fn isqrt(n: i128) -> i128 {
+    if n <= 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+/// Calculate historical volatility for an asset from its stored price history.
+///
+/// Returns volatility in basis points (10000 = 100%).
+/// Falls back to `DEFAULT_VOLATILITY_BPS` when history is insufficient.
+pub fn calculate_volatility(env: &Env, asset_id: u32, window_slots: u32) -> i128 {
+    let prices = get_price_history(env, asset_id, window_slots + 1);
+
+    if (prices.len() as usize) < MIN_PRICE_HISTORY {
+        return DEFAULT_VOLATILITY_BPS;
+    }
+
+    // Calculate daily returns in basis points: ret = (p[i] - p[i-1]) / p[i-1] * 10000
+    let n = prices.len();
+    let mut returns: Vec<i128> = Vec::new(env);
+    for i in 1..n {
+        let prev = prices.get(i - 1).unwrap();
+        let curr = prices.get(i).unwrap();
+        if prev == 0 {
+            continue;
+        }
+        let ret = (curr - prev) * 10_000 / prev;
+        returns.push_back(ret);
+    }
+
+    let r_len = returns.len() as i128;
+    if r_len == 0 {
+        return DEFAULT_VOLATILITY_BPS;
+    }
+
+    // Mean of returns
+    let mut sum: i128 = 0;
+    for i in 0..returns.len() {
+        sum = sum.saturating_add(returns.get(i).unwrap());
+    }
+    let mean = sum / r_len;
+
+    // Variance = Σ(r - mean)² / n
+    let mut variance_sum: i128 = 0;
+    for i in 0..returns.len() {
+        let diff = returns.get(i).unwrap() - mean;
+        variance_sum = variance_sum.saturating_add(diff * diff);
+    }
+    let variance = variance_sum / r_len;
+
+    // Volatility = sqrt(variance)
+    let vol = isqrt(variance);
+
+    if vol == 0 {
+        // Zero variance → zero volatility → treat as max risk, return minimum position signal
+        // (callers check for 0 and substitute DEFAULT)
+        0
+    } else {
+        vol
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kelly Criterion helpers
+// ---------------------------------------------------------------------------
+
+/// Calculate the Kelly fraction from provider stats.
+///
+/// `win_rate_bps`  — win rate in basis points (e.g. 6000 = 60%)
+/// `avg_win_bps`   — average winning trade ROI in basis points
+/// `avg_loss_bps`  — average losing trade ROI magnitude in basis points (positive number)
+///
+/// Returns Kelly fraction in basis points, clamped to [0, 10000].
+pub fn calculate_kelly_fraction(
+    win_rate_bps: i128,
+    avg_win_bps: i128,
+    avg_loss_bps: i128,
+) -> i128 {
+    if avg_win_bps <= 0 {
+        return 0;
+    }
+
+    // kelly_f = (win_rate * avg_win - loss_rate * avg_loss) / avg_win
+    // All in basis points (10000 = 100%)
+    let loss_rate_bps = 10_000 - win_rate_bps;
+    let numerator = win_rate_bps * avg_win_bps - loss_rate_bps * avg_loss_bps;
+
+    if numerator <= 0 {
+        return 0; // Negative or zero Kelly → don't trade
+    }
+
+    // Divide by avg_win to get the fraction, result is in bps
+    let kelly = numerator / avg_win_bps;
+
+    // Clamp to [0, 10000]
+    if kelly > 10_000 {
+        10_000
+    } else {
+        kelly
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core position size calculation
+// ---------------------------------------------------------------------------
+
+/// Calculate the recommended and maximum position sizes for a given user and asset.
+///
+/// `asset_id`     — the asset to size a position in
+/// `user`         — the trading user (for portfolio value and config lookup)
+/// `win_rate_bps` — provider win rate in basis points (needed for Kelly method)
+/// `avg_win_bps`  — provider average win in basis points (needed for Kelly method)
+/// `avg_loss_bps` — provider average loss magnitude in basis points (needed for Kelly method)
+pub fn calculate_position_size(
+    env: &Env,
+    user: &Address,
+    asset_id: u32,
+    win_rate_bps: i128,
+    avg_win_bps: i128,
+    avg_loss_bps: i128,
+) -> Result<SizingRecommendation, AutoTradeError> {
+    let config = get_sizing_config(env, user);
+    let portfolio_value = calculate_portfolio_value(env, user);
+
+    // Use the current risk config's max_position_pct as a safety cross-check too
+    let risk_config: RiskConfig = get_risk_config(env, user);
+
+    let volatility_bps = {
+        let raw = calculate_volatility(env, asset_id, 30);
+        if raw == 0 {
+            // Zero volatility → treat as maximum risk → minimum position
+            MAX_VOLATILITY_BPS
+        } else {
+            raw
+        }
+    };
+
+    let raw_size = match &config.method {
+        SizingMethod::FixedPercentage => {
+            if volatility_bps == 0 {
+                MIN_POSITION_SIZE
+            } else {
+                // size = portfolio * risk_per_trade_bps / volatility_bps
+                portfolio_value
+                    .saturating_mul(config.risk_per_trade_bps as i128)
+                    / volatility_bps
+            }
+        }
+
+        SizingMethod::Kelly => {
+            let kelly_f = calculate_kelly_fraction(win_rate_bps, avg_win_bps, avg_loss_bps);
+            if kelly_f == 0 {
+                MIN_POSITION_SIZE
+            } else {
+                // size = portfolio * kelly_f (bps) * multiplier / (10000 * 100)
+                // kelly_f is in bps so divide by 10000
+                // kelly_multiplier is out of 100 (e.g. 50 = 0.5x)
+                portfolio_value
+                    .saturating_mul(kelly_f)
+                    .saturating_mul(config.kelly_multiplier as i128)
+                    / (10_000 * 100)
+            }
+        }
+
+        SizingMethod::VolatilityScaled => {
+            let target_vol = if config.target_volatility_bps == 0 {
+                DEFAULT_TARGET_VOLATILITY_BPS as u32
+            } else {
+                config.target_volatility_bps
+            };
+            // base_size = portfolio * base_position_pct_bps / 10000
+            let base_size = portfolio_value
+                .saturating_mul(config.base_position_pct_bps as i128)
+                / 10_000;
+
+            if volatility_bps == 0 {
+                MIN_POSITION_SIZE
+            } else {
+                // adjusted = base_size * target_vol / current_vol
+                base_size
+                    .saturating_mul(target_vol as i128)
+                    / volatility_bps
+            }
+        }
+    };
+
+    // Enforce minimum
+    let sized = raw_size.max(MIN_POSITION_SIZE);
+
+    // Derive max from the LOWER of the sizing config and the existing risk config
+    let max_by_sizing = portfolio_value
+        .saturating_mul(config.max_position_pct_bps as i128)
+        / 10_000;
+    let max_by_risk = portfolio_value
+        .saturating_mul(risk_config.max_position_pct as i128)
+        / 100;
+    let max_size = max_by_sizing.min(max_by_risk).max(MIN_POSITION_SIZE);
+
+    // Also check available balance if a price is known
+    let balance_cap = if let Some(price) = get_asset_price(env, asset_id) {
+        if price > 0 {
+            // Approximate: how many units can the max_size buy at current price?
+            // We keep everything in the same unit as portfolio_value here, so
+            // the returned recommended_size is in value terms (same as portfolio_value).
+            max_size
+        } else {
+            max_size
+        }
+    } else {
+        max_size
+    };
+
+    let final_max = balance_cap;
+    let (recommended_size, was_capped) = if sized > final_max {
+        (final_max, true)
+    } else {
+        (sized, false)
+    };
+
+    Ok(SizingRecommendation {
+        recommended_size,
+        max_size: final_max,
+        volatility_bps,
+        portfolio_value,
+        was_capped,
+    })
+}
+
+/// Convenience wrapper that reads provider stats from the signal registry
+/// (passed in directly by the caller to avoid cross-contract calls).
+///
+/// Returns only the recommended position size (not the full recommendation struct).
+pub fn get_position_size_for_trade(
+    env: &Env,
+    user: &Address,
+    asset_id: u32,
+    win_rate_bps: i128,
+    avg_win_bps: i128,
+    avg_loss_bps: i128,
+    available_balance: i128,
+) -> Result<i128, AutoTradeError> {
+    let rec = calculate_position_size(
+        env,
+        user,
+        asset_id,
+        win_rate_bps,
+        avg_win_bps,
+        avg_loss_bps,
+    )?;
+
+    // Clamp to available balance
+    let size = rec.recommended_size.min(available_balance).max(MIN_POSITION_SIZE);
+    Ok(size)
+}

--- a/stellar-swipe/contracts/signal_registry/src/test_position_sizing.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_position_sizing.rs
@@ -1,0 +1,744 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Env};
+
+use crate::{
+    position_sizing::{
+        calculate_kelly_fraction, calculate_volatility, get_sizing_config, get_price_history,
+        record_price, set_sizing_config, PositionSizingConfig, SizingMethod,
+        DEFAULT_VOLATILITY_BPS, MAX_VOLATILITY_BPS, MIN_POSITION_SIZE,
+    },
+    risk::{set_asset_price, update_position},
+    AutoTradeContract,
+};
+
+// Helper contract registration
+struct TestContract;
+
+soroban_sdk::contractimpl!(TestContract, ());
+
+fn setup_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn make_contract(env: &Env) -> soroban_sdk::Address {
+    env.register(AutoTradeContract, ())
+}
+
+// ---------------------------------------------------------------------------
+// Volatility calculation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_volatility_no_history_returns_default() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    env.as_contract(&contract, || {
+        let vol = calculate_volatility(&env, 1, 30);
+        assert_eq!(vol, DEFAULT_VOLATILITY_BPS);
+    });
+}
+
+#[test]
+fn test_volatility_single_price_returns_default() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    env.as_contract(&contract, || {
+        record_price(&env, 1, 100_000);
+        let vol = calculate_volatility(&env, 1, 30);
+        assert_eq!(vol, DEFAULT_VOLATILITY_BPS); // needs ≥2 prices
+    });
+}
+
+#[test]
+fn test_volatility_constant_prices_is_zero() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    env.as_contract(&contract, || {
+        // Constant price → zero returns → zero variance → zero volatility
+        for _ in 0..10 {
+            record_price(&env, 1, 100_000);
+        }
+        let vol = calculate_volatility(&env, 1, 10);
+        assert_eq!(vol, 0);
+    });
+}
+
+#[test]
+fn test_volatility_increases_with_price_swings() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    env.as_contract(&contract, || {
+        // Low-volatility asset: small swings
+        let prices_low = [100, 101, 100, 101, 100u64];
+        for p in &prices_low {
+            record_price(&env, 1, *p as i128);
+        }
+        let low_vol = calculate_volatility(&env, 1, 10);
+
+        // High-volatility asset: large swings
+        for p in &[100i128, 130, 80, 140, 70] {
+            record_price(&env, 2, *p);
+        }
+        let high_vol = calculate_volatility(&env, 2, 10);
+
+        assert!(
+            high_vol > low_vol,
+            "high_vol={} should exceed low_vol={}",
+            high_vol,
+            low_vol
+        );
+    });
+}
+
+#[test]
+fn test_volatility_30_day_window() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    env.as_contract(&contract, || {
+        // Simulate 31 prices for XLM/USDC-like asset (asset_id = 10)
+        // Alternating +2% / -2% gives a predictable volatility
+        let mut price: i128 = 120_000; // 0.12 USDC in stroops * 1e6
+        for i in 0..31 {
+            record_price(&env, 10, price);
+            if i % 2 == 0 {
+                price = price * 102 / 100;
+            } else {
+                price = price * 98 / 100;
+            }
+        }
+        let vol = calculate_volatility(&env, 10, 30);
+        // Expect something roughly around 200 bps (2% daily swings)
+        assert!(vol > 0, "volatility should be positive");
+        assert!(vol < DEFAULT_VOLATILITY_BPS, "alternating 2% swings should be below default 20%");
+    });
+}
+
+#[test]
+fn test_price_history_ring_buffer_wraps() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    env.as_contract(&contract, || {
+        // Write 65 prices (> MAX_HISTORY_SLOTS = 60)
+        for i in 0..65i128 {
+            record_price(&env, 5, i * 1000 + 1000);
+        }
+        // Should still return at most 60 prices
+        let hist = get_price_history(&env, 5, 60);
+        assert_eq!(hist.len(), 60);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Kelly Criterion tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_kelly_zero_avg_win_returns_zero() {
+    let kelly = calculate_kelly_fraction(6000, 0, 300);
+    assert_eq!(kelly, 0);
+}
+
+#[test]
+fn test_kelly_negative_expectancy_returns_zero() {
+    // Win 40% of the time, avg win = 500 bps, avg loss = 1000 bps
+    // kelly = (4000 * 500 - 6000 * 1000) / 500 = (2_000_000 - 6_000_000) / 500 < 0
+    let kelly = calculate_kelly_fraction(4000, 500, 1000);
+    assert_eq!(kelly, 0);
+}
+
+#[test]
+fn test_kelly_positive_expectancy() {
+    // Win 60%, avg win = 1000 bps, avg loss = 500 bps
+    // kelly = (6000 * 1000 - 4000 * 500) / 1000 = (6_000_000 - 2_000_000) / 1000 = 4000 bps
+    let kelly = calculate_kelly_fraction(6000, 1000, 500);
+    assert_eq!(kelly, 4000);
+}
+
+#[test]
+fn test_kelly_clamped_to_10000() {
+    // Extreme win rate should not produce > 10000 bps
+    let kelly = calculate_kelly_fraction(9900, 5000, 100);
+    assert!(kelly <= 10_000);
+}
+
+#[test]
+fn test_kelly_even_odds_50pct() {
+    // Win 50%, avg win = 1000, avg loss = 1000
+    // kelly = (5000 * 1000 - 5000 * 1000) / 1000 = 0
+    let kelly = calculate_kelly_fraction(5000, 1000, 1000);
+    assert_eq!(kelly, 0);
+}
+
+// ---------------------------------------------------------------------------
+// PositionSizingConfig storage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_default_config_stored_when_none_set() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        let config = get_sizing_config(&env, &user);
+        assert_eq!(config, PositionSizingConfig::default());
+    });
+}
+
+#[test]
+fn test_set_and_get_sizing_config() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        let config = PositionSizingConfig {
+            method: SizingMethod::Kelly,
+            risk_per_trade_bps: 150,
+            max_position_pct_bps: 1500,
+            kelly_multiplier: 25,
+            target_volatility_bps: 300,
+            base_position_pct_bps: 800,
+        };
+        set_sizing_config(&env, &user, &config);
+        let retrieved = get_sizing_config(&env, &user);
+        assert_eq!(retrieved, config);
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_max_position_pct_rejected() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        let config = PositionSizingConfig {
+            max_position_pct_bps: 15_000, // > 10000 — invalid
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// FixedPercentage sizing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fixed_pct_sizing_scales_inversely_with_volatility() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // Give user a portfolio of 10_000
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100); // 100 * 100 / 100 = 10000
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::FixedPercentage,
+            risk_per_trade_bps: 200, // 2%
+            max_position_pct_bps: 5000,
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Asset with low volatility (200 bps)
+        for p in &[100i128, 102, 100, 102, 100] {
+            record_price(&env, 1, *p);
+        }
+        // Asset with high volatility (roughly 1000 bps)
+        for p in &[100i128, 110, 90, 115, 85] {
+            record_price(&env, 2, *p);
+        }
+
+        let rec_low = crate::position_sizing::calculate_position_size(
+            &env, &user, 1, 0, 0, 0,
+        ).unwrap();
+        let rec_high = crate::position_sizing::calculate_position_size(
+            &env, &user, 2, 0, 0, 0,
+        ).unwrap();
+
+        // Lower volatility → larger position
+        assert!(
+            rec_low.recommended_size >= rec_high.recommended_size,
+            "low_vol_size={} should be >= high_vol_size={}",
+            rec_low.recommended_size,
+            rec_high.recommended_size
+        );
+    });
+}
+
+#[test]
+fn test_fixed_pct_example_calculation() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // Portfolio = 10_000 units
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100);
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::FixedPercentage,
+            risk_per_trade_bps: 200,    // 2%
+            max_position_pct_bps: 10_000, // no cap
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Manually inject a known volatility via recorded prices
+        // 5% daily swings ≈ 500 bps volatility
+        for p in &[100i128, 105, 100, 105, 100, 105] {
+            record_price(&env, 3, *p);
+        }
+        let vol = calculate_volatility(&env, 3, 10);
+        // Expected: portfolio(10_000) * risk(200) / vol
+        // Expected size ≈ 10_000 * 200 / vol
+        let expected_approx = 10_000 * 200 / vol;
+
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 3, 0, 0, 0,
+        ).unwrap();
+
+        // Allow 1% tolerance due to integer math
+        let diff = (rec.recommended_size - expected_approx).abs();
+        assert!(
+            diff <= expected_approx / 100 + 1,
+            "expected ~{}, got {}",
+            expected_approx,
+            rec.recommended_size
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Kelly sizing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_kelly_sizing_with_good_stats() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // Portfolio = 10_000
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100);
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::Kelly,
+            kelly_multiplier: 50, // half-Kelly
+            max_position_pct_bps: 5000,
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Win rate 60%, avg win 1000 bps, avg loss 500 bps → kelly_f = 4000 bps
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 1, 6000, 1000, 500,
+        ).unwrap();
+
+        // size = 10_000 * 4000 * 50 / (10000 * 100) = 10000 * 200000 / 1000000 = 2000
+        assert_eq!(rec.recommended_size, 2000);
+    });
+}
+
+#[test]
+fn test_kelly_sizing_negative_expectancy_returns_min() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 1000, 100);
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::Kelly,
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Negative expectancy
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 1, 3000, 500, 1000,
+        ).unwrap();
+
+        assert_eq!(rec.recommended_size, MIN_POSITION_SIZE);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// VolatilityScaled sizing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_volatility_scaled_larger_when_vol_low() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100);
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::VolatilityScaled,
+            target_volatility_bps: 500,  // target 5%
+            base_position_pct_bps: 1000, // 10% base
+            max_position_pct_bps: 10_000,
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Low vol: prices barely move
+        for p in &[100i128, 101, 100, 101, 100] {
+            record_price(&env, 10, *p);
+        }
+        // High vol: prices swing wildly
+        for p in &[100i128, 120, 80, 125, 75] {
+            record_price(&env, 11, *p);
+        }
+
+        let low = crate::position_sizing::calculate_position_size(
+            &env, &user, 10, 0, 0, 0,
+        ).unwrap();
+        let high = crate::position_sizing::calculate_position_size(
+            &env, &user, 11, 0, 0, 0,
+        ).unwrap();
+
+        // When actual vol < target vol → scaled up → larger position
+        assert!(
+            low.recommended_size >= high.recommended_size,
+            "low_vol={} high_vol={}",
+            low.recommended_size,
+            high.recommended_size
+        );
+    });
+}
+
+#[test]
+fn test_volatility_scaled_exact_calculation() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // Portfolio = 10_000
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100);
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::VolatilityScaled,
+            target_volatility_bps: 500,   // 5%
+            base_position_pct_bps: 1000,  // 10% base → base_size = 1000
+            max_position_pct_bps: 10_000,
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Record prices that give a known volatility
+        for p in &[100i128, 105, 100, 105, 100, 105] {
+            record_price(&env, 20, *p);
+        }
+        let actual_vol = calculate_volatility(&env, 20, 10);
+
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 20, 0, 0, 0,
+        ).unwrap();
+
+        // base_size = 10_000 * 1000 / 10_000 = 1000
+        // expected = 1000 * 500 / actual_vol
+        let expected = 1000 * 500 / actual_vol;
+        let diff = (rec.recommended_size - expected).abs();
+        assert!(
+            diff <= expected / 100 + 1,
+            "expected ~{}, got {}",
+            expected,
+            rec.recommended_size
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Max size cap tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_max_position_cap_enforced() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // Portfolio = 10_000
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100);
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::FixedPercentage,
+            risk_per_trade_bps: 200,
+            max_position_pct_bps: 500, // max 5% = 500
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Very low volatility → raw size would exceed cap
+        for _ in 0..10 {
+            record_price(&env, 30, 100_000);
+        }
+        // vol = 0 here so MAX_VOLATILITY_BPS is used
+        // raw = 10000 * 200 / 10000 = 200 — already under cap in this case
+        // Let's force a scenario with extremely small volatility manually
+        // by giving tiny price movement
+        for p in &[1_000_000i128, 1_000_001] {
+            record_price(&env, 31, *p);
+        }
+
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 31, 0, 0, 0,
+        ).unwrap();
+
+        assert!(
+            rec.recommended_size <= rec.max_size,
+            "recommended={} must be <= max={}",
+            rec.recommended_size,
+            rec.max_size
+        );
+    });
+}
+
+#[test]
+fn test_was_capped_flag_set_when_size_exceeds_max() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // Large portfolio, tight cap
+        set_asset_price(&env, 99, 1000);
+        update_position(&env, &user, 99, 1000, 1000); // portfolio = 10_000
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::VolatilityScaled,
+            target_volatility_bps: 2000,  // target 20%
+            base_position_pct_bps: 5000,  // 50% base
+            max_position_pct_bps: 100,    // cap at 1% — forces capping
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        // Very low volatility so the scaled size will be huge
+        for p in &[100i128, 101, 100] {
+            record_price(&env, 40, *p);
+        }
+
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 40, 0, 0, 0,
+        ).unwrap();
+
+        // The recommended size should equal max_size and was_capped = true
+        assert_eq!(rec.recommended_size, rec.max_size);
+        assert!(rec.was_capped);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Edge case tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_zero_portfolio_returns_min_position() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        // No positions → portfolio_value = 0
+        for p in &[100i128, 110, 100] {
+            record_price(&env, 1, *p);
+        }
+
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 1, 6000, 1000, 500,
+        ).unwrap();
+
+        assert_eq!(rec.recommended_size, MIN_POSITION_SIZE);
+    });
+}
+
+#[test]
+fn test_zero_volatility_assigns_max_volatility_floor() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 10000, 100);
+
+        // Constant prices → zero volatility
+        for _ in 0..5 {
+            record_price(&env, 50, 100_000);
+        }
+
+        let config = PositionSizingConfig {
+            method: SizingMethod::FixedPercentage,
+            risk_per_trade_bps: 200,
+            max_position_pct_bps: 5000,
+            ..PositionSizingConfig::default()
+        };
+        set_sizing_config(&env, &user, &config);
+
+        let rec = crate::position_sizing::calculate_position_size(
+            &env, &user, 50, 0, 0, 0,
+        ).unwrap();
+
+        // Should not panic, should return a sane (minimum) size
+        assert!(rec.recommended_size >= MIN_POSITION_SIZE);
+        // The volatility field should reflect MAX_VOLATILITY_BPS
+        assert_eq!(rec.volatility_bps, MAX_VOLATILITY_BPS);
+    });
+}
+
+#[test]
+fn test_balance_cap_applied() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100); // portfolio = 10_000
+
+        for p in &[100i128, 110, 100, 110] {
+            record_price(&env, 1, *p);
+        }
+
+        let available = 50i128; // very tight balance
+        let size = crate::position_sizing::get_position_size_for_trade(
+            &env, &user, 1, 0, 0, 0, available,
+        ).unwrap();
+
+        assert!(size <= available);
+        assert!(size >= MIN_POSITION_SIZE);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Public API tests (via contract client)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_public_get_set_sizing_config() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let client = crate::AutoTradeContractClient::new(&env, &contract);
+    let user = soroban_sdk::Address::generate(&env);
+
+    let config = PositionSizingConfig {
+        method: SizingMethod::VolatilityScaled,
+        risk_per_trade_bps: 150,
+        max_position_pct_bps: 2000,
+        kelly_multiplier: 25,
+        target_volatility_bps: 400,
+        base_position_pct_bps: 1000,
+    };
+
+    client.set_sizing_config(&user, &config);
+    let got = client.get_sizing_config(&user);
+    assert_eq!(got, config);
+}
+
+#[test]
+fn test_public_record_price_and_get_volatility() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let client = crate::AutoTradeContractClient::new(&env, &contract);
+
+    for p in &[100i128, 105, 100, 108, 95, 110] {
+        client.record_asset_price(&42u32, p);
+    }
+
+    let vol = client.get_asset_volatility(&42u32, &10u32);
+    assert!(vol > 0, "should have non-zero volatility after recording prices");
+}
+
+#[test]
+fn test_public_get_sizing_recommendation() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let client = crate::AutoTradeContractClient::new(&env, &contract);
+    let user = soroban_sdk::Address::generate(&env);
+
+    // Record prices for the asset
+    for p in &[100i128, 105, 100, 107, 98] {
+        client.record_asset_price(&7u32, p);
+    }
+
+    // Give user a portfolio
+    env.as_contract(&contract, || {
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 5000, 100);
+    });
+
+    let rec = client
+        .get_sizing_recommendation(&user, &7u32, &0i128, &0i128, &0i128)
+        .unwrap();
+
+    assert!(rec.portfolio_value > 0);
+    assert!(rec.recommended_size >= MIN_POSITION_SIZE);
+    assert!(rec.max_size >= rec.recommended_size);
+}
+
+#[test]
+fn test_public_get_price_history() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let client = crate::AutoTradeContractClient::new(&env, &contract);
+
+    for p in &[1000i128, 1100, 1050, 1200] {
+        client.record_asset_price(&8u32, p);
+    }
+
+    let hist = client.get_price_history(&8u32, &10u32);
+    assert_eq!(hist.len(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-method comparison test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_all_methods_produce_valid_sizes() {
+    let env = setup_env();
+    let contract = make_contract(&env);
+    let user = soroban_sdk::Address::generate(&env);
+    env.as_contract(&contract, || {
+        set_asset_price(&env, 99, 100);
+        update_position(&env, &user, 99, 100_00, 100); // portfolio = 10_000
+
+        for p in &[100i128, 105, 98, 107, 102] {
+            record_price(&env, 77, *p);
+        }
+
+        for method in [
+            SizingMethod::FixedPercentage,
+            SizingMethod::Kelly,
+            SizingMethod::VolatilityScaled,
+        ] {
+            let config = PositionSizingConfig {
+                method,
+                ..PositionSizingConfig::default()
+            };
+            set_sizing_config(&env, &user, &config);
+
+            let rec = crate::position_sizing::calculate_position_size(
+                &env, &user, 77, 6000, 1000, 400,
+            ).unwrap();
+
+            assert!(
+                rec.recommended_size >= MIN_POSITION_SIZE,
+                "method produced size below minimum"
+            );
+            assert!(
+                rec.recommended_size <= rec.max_size,
+                "method produced size above max"
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Description
Implements dynamic position sizing based on asset volatility for the `auto_trade` contract. Users can configure one of three sizing methods — Fixed Percentage, Kelly Criterion, or Volatility-Scaled — each of which adjusts the recommended trade amount to maintain a consistent risk exposure relative to current market conditions. A ring-buffer price history store powers the on-chain volatility calculation, and all sizing results are bounded by per-user configurable portfolio limits.

## Related Issue
- Closes #51 