### PR TITLE
refactor: introduce shared constants and remove magic numbers

### DIFF
--- a/stellar-swipe/contracts/bridge/src/analytics.rs
+++ b/stellar-swipe/contracts/bridge/src/analytics.rs
@@ -1,6 +1,7 @@
-use soroban_sdk::{contracttype, Address, Env, Map, Vec, String};
+use crate::governance::{get_bridge, get_bridge_validators, is_validator};
 use crate::monitoring::{BridgeTransfer, TransferStatus};
-use crate::governance::{get_bridge, is_validator, get_bridge_validators};
+use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
+use stellar_swipe_common::{BASIS_POINTS_DENOMINATOR, SECONDS_PER_DAY, SECONDS_PER_HOUR};
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -134,10 +135,17 @@ fn store_bridge_analytics(env: &Env, bridge_id: u64, analytics: &BridgeAnalytics
         .set(&AnalyticsDataKey::BridgeAnalytics(bridge_id), analytics);
 }
 
-pub fn get_validator_analytics(env: &Env, validator: Address, bridge_id: u64) -> ValidatorAnalytics {
+pub fn get_validator_analytics(
+    env: &Env,
+    validator: Address,
+    bridge_id: u64,
+) -> ValidatorAnalytics {
     env.storage()
         .persistent()
-        .get(&AnalyticsDataKey::ValidatorAnalytics(validator.clone(), bridge_id))
+        .get(&AnalyticsDataKey::ValidatorAnalytics(
+            validator.clone(),
+            bridge_id,
+        ))
         .unwrap_or(ValidatorAnalytics {
             validator,
             bridge_id,
@@ -150,10 +158,16 @@ pub fn get_validator_analytics(env: &Env, validator: Address, bridge_id: u64) ->
         })
 }
 
-fn store_validator_analytics(env: &Env, validator: &Address, bridge_id: u64, analytics: &ValidatorAnalytics) {
-    env.storage()
-        .persistent()
-        .set(&AnalyticsDataKey::ValidatorAnalytics(validator.clone(), bridge_id), analytics);
+fn store_validator_analytics(
+    env: &Env,
+    validator: &Address,
+    bridge_id: u64,
+    analytics: &ValidatorAnalytics,
+) {
+    env.storage().persistent().set(
+        &AnalyticsDataKey::ValidatorAnalytics(validator.clone(), bridge_id),
+        analytics,
+    );
 }
 
 pub fn update_transfer_analytics(
@@ -170,7 +184,9 @@ pub fn update_transfer_analytics(
     // Update per-asset volume
     let asset = transfer.stellar_asset.clone();
     let current_asset_volume = analytics.volume_by_asset.get(asset.clone()).unwrap_or(0);
-    analytics.volume_by_asset.set(asset, current_asset_volume + transfer.amount);
+    analytics
+        .volume_by_asset
+        .set(asset, current_asset_volume + transfer.amount);
 
     // Calculate transfer time
     if let Some(completed_at) = transfer.completed_at {
@@ -180,18 +196,23 @@ pub fn update_transfer_analytics(
 
     // Update success rate
     if transfer.status == TransferStatus::Complete {
-        // Since we only call this on success or some state changes, 
+        // Since we only call this on success or some state changes,
         // we might need a better way to count fails if we want a real success rate.
         // For now, let's assume we can calculate it from total vs successfully completed.
         // But Soroban storage doesn't easily let us query all transfers.
         // Let's stick to the prompt's logic if possible or adapt.
-        
-        // The prompt uses `count_failed_transfers(bridge_id)`. 
+
+        // The prompt uses `count_failed_transfers(bridge_id)`.
         // Without an index, this is hard. Let's keep a counter of failed transfers.
     }
 
     // Update time series
-    add_to_time_series(env, &mut analytics.volume_by_period, env.ledger().timestamp(), transfer.amount);
+    add_to_time_series(
+        env,
+        &mut analytics.volume_by_period,
+        env.ledger().timestamp(),
+        transfer.amount,
+    );
 
     store_bridge_analytics(env, bridge_id, &analytics);
 
@@ -206,12 +227,12 @@ fn update_avg_transfer_time(analytics: &mut BridgeAnalytics, new_time: u64) {
 fn add_to_time_series(env: &Env, series: &mut TimeSeries, timestamp: u64, value: i128) {
     // Basic implementation: if last data point is same day/hour, update it. Else push new.
     let interval_seconds = match series.interval {
-        TimeInterval::Hourly => 3600,
-        TimeInterval::Daily => 86400,
+        TimeInterval::Hourly => SECONDS_PER_HOUR,
+        TimeInterval::Daily => SECONDS_PER_DAY,
     };
-    
+
     let period_timestamp = (timestamp / interval_seconds) * interval_seconds;
-    
+
     let mut updated = false;
     if !series.data_points.is_empty() {
         let last_idx = series.data_points.len() - 1;
@@ -222,13 +243,13 @@ fn add_to_time_series(env: &Env, series: &mut TimeSeries, timestamp: u64, value:
             updated = true;
         }
     }
-    
+
     if !updated {
         series.data_points.push_back(DataPoint {
             timestamp: period_timestamp,
             value,
         });
-        
+
         // Pruning: keep last 100 points
         if series.data_points.len() > 100 {
             series.data_points.remove(0);
@@ -245,7 +266,7 @@ pub fn get_bridge_volume_stats(
     let current_time = env.ledger().timestamp();
 
     let start_time = match period {
-        TimePeriod::Last24Hours => current_time.saturating_sub(86400),
+        TimePeriod::Last24Hours => current_time.saturating_sub(SECONDS_PER_DAY),
         TimePeriod::Last7Days => current_time.saturating_sub(604800),
         TimePeriod::Last30Days => current_time.saturating_sub(2592000),
         TimePeriod::AllTime => 0,
@@ -263,10 +284,10 @@ pub fn get_bridge_volume_stats(
         }
     }
 
-    // Since we don't have per-period transfer count in BridgeAnalytics yet, 
+    // Since we don't have per-period transfer count in BridgeAnalytics yet,
     // let's just return what we have in the main counters for now if it's AllTime,
     // or approximate for other periods.
-    
+
     let (total_v, total_c) = if period == TimePeriod::AllTime {
         (analytics.total_volume, analytics.total_transfers)
     } else {
@@ -302,8 +323,10 @@ pub fn update_validator_analytics(
     let response_time = signature_time.saturating_sub(transfer_initiated);
 
     // Update average response time
-    let total_response_time = analytics.avg_response_time_seconds * (analytics.total_signatures_provided - 1);
-    analytics.avg_response_time_seconds = (total_response_time + response_time) / analytics.total_signatures_provided;
+    let total_response_time =
+        analytics.avg_response_time_seconds * (analytics.total_signatures_provided - 1);
+    analytics.avg_response_time_seconds =
+        (total_response_time + response_time) / analytics.total_signatures_provided;
 
     // Classify as on-time or late (threshold: 5 minutes)
     if response_time <= 300 {
@@ -311,7 +334,7 @@ pub fn update_validator_analytics(
     } else {
         analytics.late_signatures += 1;
     }
-    
+
     // Update uptime
     analytics.uptime_pct = calculate_validator_uptime(env, validator.clone(), bridge_id)?;
 
@@ -323,7 +346,7 @@ pub fn update_validator_analytics(
 fn calculate_validator_uptime(
     env: &Env,
     validator: Address,
-    bridge_id: u64
+    bridge_id: u64,
 ) -> Result<u32, String> {
     let analytics = get_validator_analytics(env, validator, bridge_id);
     let bridge_analytics = get_bridge_analytics(env, bridge_id);
@@ -333,9 +356,10 @@ fn calculate_validator_uptime(
 
     // Uptime = signatures provided / total transfers
     let uptime_bps = if total_transfers > 0 {
-        ((analytics.total_signatures_provided * 10000) / total_transfers) as u32
+        ((analytics.total_signatures_provided * BASIS_POINTS_DENOMINATOR as u64) / total_transfers)
+            as u32
     } else {
-        10000 // 100% if no transfers yet
+        BASIS_POINTS_DENOMINATOR // 100% if no transfers yet
     };
 
     Ok(uptime_bps)
@@ -343,16 +367,16 @@ fn calculate_validator_uptime(
 
 pub fn calculate_bridge_health_score(env: &Env, bridge_id: u64) -> Result<u32, String> {
     let analytics = get_bridge_analytics(env, bridge_id);
-    
+
     // 1. Success Rate (40%)
-    let success_component = (analytics.success_rate * 40) / 10000;
+    let success_component = (analytics.success_rate * 40) / BASIS_POINTS_DENOMINATOR;
 
     // 2. Validator Uptime (30%)
     let avg_validator_uptime = calculate_avg_validator_uptime(env, bridge_id)?;
-    let uptime_component = (avg_validator_uptime * 30) / 10000;
+    let uptime_component = (avg_validator_uptime * 30) / BASIS_POINTS_DENOMINATOR;
 
     // 3. Liquidity (20%) - Mock for now as requested
-    let liquidity_score = 80u32; 
+    let liquidity_score = 80u32;
     let liquidity_component = (liquidity_score * 20) / 100;
 
     // 4. Response Time (10%)
@@ -367,13 +391,13 @@ pub fn calculate_bridge_health_score(env: &Env, bridge_id: u64) -> Result<u32, S
     };
     let response_component = (response_score * 10) / 100;
 
-    let health_score = success_component + uptime_component + 
+    let health_score = success_component + uptime_component +
                       ((liquidity_component * 10000) / 100) / 100 + // Adjusted to fit bps if needed, but the formula says 0-100 each
                       response_component;
 
     // Actually, let's keep it simple as in the prompt
-    let health_score = success_component + uptime_component + 
-                      (liquidity_score * 20) / 100 + response_component;
+    let health_score =
+        success_component + uptime_component + (liquidity_score * 20) / 100 + response_component;
 
     Ok(health_score)
 }
@@ -381,27 +405,27 @@ pub fn calculate_bridge_health_score(env: &Env, bridge_id: u64) -> Result<u32, S
 fn calculate_avg_validator_uptime(env: &Env, bridge_id: u64) -> Result<u32, String> {
     let validators = get_bridge_validators(env, bridge_id)?;
     if validators.is_empty() {
-        return Ok(10000);
+        return Ok(BASIS_POINTS_DENOMINATOR);
     }
-    
+
     let mut total_uptime = 0u32;
     for v in validators.iter() {
         total_uptime += calculate_validator_uptime(env, v.clone(), bridge_id)?;
     }
-    
+
     Ok(total_uptime / validators.len())
 }
 
 pub fn compare_bridge_performance(
     env: &Env,
     bridge_ids: Vec<u64>,
-    metric: AnalyticsMetric
+    metric: AnalyticsMetric,
 ) -> Result<Vec<(u64, i128)>, String> {
     let mut results = Vec::new(env);
 
     for bridge_id in bridge_ids.iter() {
         let analytics = get_bridge_analytics(env, bridge_id);
-        
+
         let value = match metric {
             AnalyticsMetric::TotalVolume => analytics.total_volume,
             AnalyticsMetric::TransferCount => analytics.total_transfers as i128,
@@ -412,10 +436,10 @@ pub fn compare_bridge_performance(
                 } else {
                     0
                 }
-            },
+            }
             AnalyticsMetric::HealthScore => calculate_bridge_health_score(env, bridge_id)? as i128,
         };
-        
+
         results.push_back((bridge_id, value));
     }
 
@@ -441,13 +465,12 @@ pub fn compare_bridge_performance(
     Ok(results)
 }
 
-pub fn analyze_volume_trend(
-    env: &Env,
-    bridge_id: u64,
-    days: u32
-) -> Result<TrendAnalysis, String> {
+pub fn analyze_volume_trend(env: &Env, bridge_id: u64, days: u32) -> Result<TrendAnalysis, String> {
     let analytics = get_bridge_analytics(env, bridge_id);
-    let cutoff = env.ledger().timestamp().saturating_sub(days as u64 * 86400);
+    let cutoff = env
+        .ledger()
+        .timestamp()
+        .saturating_sub(days as u64 * SECONDS_PER_DAY);
 
     let mut volumes = Vec::new(env);
     for dp in analytics.volume_by_period.data_points.iter() {
@@ -469,7 +492,7 @@ pub fn analyze_volume_trend(
     let len = volumes.len();
     let first_half_sum: i128 = volumes.iter().take((len / 2) as usize).sum();
     let second_half_sum: i128 = volumes.iter().skip((len / 2) as usize).sum();
-    
+
     let slope = second_half_sum - first_half_sum;
 
     let trend = if slope > 100 {
@@ -483,7 +506,7 @@ pub fn analyze_volume_trend(
     };
 
     let total_v: i128 = volumes.iter().sum();
-    
+
     Ok(TrendAnalysis {
         trend,
         slope,

--- a/stellar-swipe/contracts/bridge/src/lib.rs
+++ b/stellar-swipe/contracts/bridge/src/lib.rs
@@ -1,15 +1,13 @@
 #![no_std]
 
-feat/cross-chain-bridge-91
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Env, String, Symbol, Vec,
 };
+use stellar_swipe_common::SECONDS_PER_DAY;
 
 mod validators;
 
 pub use validators::{ValidatorApproval, ValidatorApprovalKind, ValidatorSet};
-
-const DAY_SECONDS: u64 = 86_400;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/stellar-swipe/contracts/bridge/src/liquidity.rs
+++ b/stellar-swipe/contracts/bridge/src/liquidity.rs
@@ -1,8 +1,7 @@
 use soroban_sdk::{contracttype, Address, Env};
+use stellar_swipe_common::BASIS_POINTS_DENOMINATOR_I128;
 
 use crate::BridgeError;
-
-const BPS_DENOMINATOR: i128 = 10_000;
 
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -176,7 +175,7 @@ pub fn swap(
     }
 
     let mut pool = get_pool(env, pool_id)?;
-    let fee_paid = (amount_in * pool.fee_bps as i128) / BPS_DENOMINATOR;
+    let fee_paid = (amount_in * pool.fee_bps as i128) / BASIS_POINTS_DENOMINATOR_I128;
     let amount_after_fee = amount_in - fee_paid;
 
     let (amount_out, new_reserve_in, new_reserve_out, input_is_a) = if input_asset == pool.asset_a {
@@ -259,12 +258,12 @@ pub fn get_pool_health(env: &Env, pool_id: u64) -> Result<PoolHealth, BridgeErro
     let imbalance_bps = if larger == 0 {
         0
     } else {
-        (((larger - smaller) * BPS_DENOMINATOR) / larger) as u32
+        (((larger - smaller) * BASIS_POINTS_DENOMINATOR_I128) / larger) as u32
     };
     let utilization_bps = if pool.total_lp_tokens == 0 || total_liquidity == 0 {
         0
     } else {
-        ((pool.total_lp_tokens * BPS_DENOMINATOR) / total_liquidity) as u32
+        ((pool.total_lp_tokens * BASIS_POINTS_DENOMINATOR_I128) / total_liquidity) as u32
     };
 
     Ok(PoolHealth {
@@ -302,7 +301,7 @@ fn next_pool_id(env: &Env) -> u64 {
 }
 
 fn reward_for_liquidity(total_added: i128, reward_bps: u32) -> i128 {
-    (total_added * reward_bps as i128) / BPS_DENOMINATOR
+    (total_added * reward_bps as i128) / BASIS_POINTS_DENOMINATOR_I128
 }
 
 fn quote_swap(

--- a/stellar-swipe/contracts/bridge/src/messaging.rs
+++ b/stellar-swipe/contracts/bridge/src/messaging.rs
@@ -5,14 +5,15 @@
 
 #![allow(dead_code)]
 
-use soroban_sdk::{contracttype, Address, Bytes, Env, String, Symbol};
 use crate::governance::get_bridge_validators;
 use crate::monitoring::ChainId;
+use soroban_sdk::{contracttype, Address, Bytes, Env, String, Symbol};
+use stellar_swipe_common::SECONDS_PER_DAY;
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
 pub const MAX_MESSAGE_SIZE: u32 = 4096;
-pub const MESSAGE_TIMEOUT: u64 = 86400; // 24 h
+pub const MESSAGE_TIMEOUT: u64 = SECONDS_PER_DAY; // 24 h
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -102,7 +103,12 @@ fn bridge_id_for_chain(env: &Env, chain_id: ChainId) -> Result<u64, String> {
 // In production these verify Merkle / ZK proofs from the target chain.
 // Here any non-empty Bytes is accepted so the logic can be exercised in tests.
 
-fn verify_delivery_proof(env: &Env, _chain: ChainId, _id: u64, proof: &Bytes) -> Result<(), String> {
+fn verify_delivery_proof(
+    env: &Env,
+    _chain: ChainId,
+    _id: u64,
+    proof: &Bytes,
+) -> Result<(), String> {
     if proof.is_empty() {
         return Err(String::from_str(env, "Empty delivery proof"));
     }
@@ -191,10 +197,8 @@ pub fn relay_message_to_target_chain(
     msg.status = MessageStatus::Relayed;
     save_message(env, &msg);
 
-    env.events().publish(
-        (Symbol::new(env, "msg_relayed"), message_id),
-        validator,
-    );
+    env.events()
+        .publish((Symbol::new(env, "msg_relayed"), message_id), validator);
 
     Ok(())
 }
@@ -218,10 +222,8 @@ pub fn confirm_message_delivery(
     msg.delivered_at = Some(now);
     save_message(env, &msg);
 
-    env.events().publish(
-        (Symbol::new(env, "msg_delivered"), message_id),
-        now,
-    );
+    env.events()
+        .publish((Symbol::new(env, "msg_delivered"), message_id), now);
 
     if !msg.callback_required {
         remove_message(env, message_id);
@@ -341,9 +343,9 @@ pub fn get_cross_chain_message(env: &Env, message_id: u64) -> Option<CrossChainM
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::governance::{initialize_bridge, BridgeSecurityConfig};
     use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::Env;
-    use crate::governance::{initialize_bridge, BridgeSecurityConfig};
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
@@ -391,8 +393,15 @@ mod tests {
     fn test_send_message_ok() {
         let (env, sender, _) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(id, 1);
         let msg = get_cross_chain_message(&env, id).unwrap();
@@ -405,11 +414,25 @@ mod tests {
     fn test_send_increments_id() {
         let (env, sender, _) = setup();
         let id1 = send_cross_chain_message(
-            &env, sender.clone(), ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender.clone(),
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
         let id2 = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
         assert_eq!(id2, id1 + 1);
     }
 
@@ -418,7 +441,13 @@ mod tests {
         let (env, sender, _) = setup();
         let big = Bytes::from_slice(&env, &[0u8; 4097]);
         let result = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), big, 100_000, false,
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            big,
+            100_000,
+            false,
         );
         assert!(result.is_err());
     }
@@ -429,22 +458,40 @@ mod tests {
     fn test_relay_ok() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Relayed);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Relayed
+        );
     }
 
     #[test]
     fn test_relay_already_relayed_fails() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
-        let result = relay_message_to_target_chain(&env, id, validators.get(1).unwrap(), proof(&env));
+        let result =
+            relay_message_to_target_chain(&env, id, validators.get(1).unwrap(), proof(&env));
         assert!(result.is_err());
     }
 
@@ -452,8 +499,15 @@ mod tests {
     fn test_relay_unauthorized_validator_fails() {
         let (env, sender, _) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         let rogue = Address::generate(&env);
         assert!(relay_message_to_target_chain(&env, id, rogue, proof(&env)).is_err());
@@ -465,8 +519,15 @@ mod tests {
     fn test_confirm_delivery_no_callback_cleans_up() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
@@ -477,8 +538,15 @@ mod tests {
     fn test_confirm_delivery_with_callback_keeps_message() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, true,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            true,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
@@ -492,8 +560,15 @@ mod tests {
     fn test_confirm_delivery_empty_proof_fails() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         assert!(confirm_message_delivery(&env, id, empty(&env)).is_err());
@@ -503,8 +578,15 @@ mod tests {
     fn test_confirm_delivery_without_relay_fails() {
         let (env, sender, _) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
         assert!(confirm_message_delivery(&env, id, proof(&env)).is_err());
     }
 
@@ -514,8 +596,15 @@ mod tests {
     fn test_receive_callback_ok() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, true,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            true,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
@@ -527,15 +616,24 @@ mod tests {
     fn test_callback_not_expected_fails() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
 
         // Manually force Delivered state without callback_required
         let mut msg = get_cross_chain_message(&env, id).unwrap();
         msg.status = MessageStatus::Delivered;
-        env.storage().persistent().set(&MessagingKey::Message(id), &msg);
+        env.storage()
+            .persistent()
+            .set(&MessagingKey::Message(id), &msg);
 
         assert!(receive_message_callback(&env, id, payload(&env), proof(&env)).is_err());
     }
@@ -544,8 +642,15 @@ mod tests {
     fn test_callback_before_delivery_fails() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, true,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            true,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         // Skip confirm_message_delivery
@@ -556,8 +661,15 @@ mod tests {
     fn test_callback_empty_proof_fails() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, true,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            true,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
@@ -570,23 +682,43 @@ mod tests {
     fn test_retry_failed_message_ok() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         mark_message_failed(&env, id).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Failed);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Failed
+        );
 
         retry_failed_message(&env, id).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Pending);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Pending
+        );
     }
 
     #[test]
     fn test_retry_non_failed_message_fails() {
         let (env, sender, _) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
         assert!(retry_failed_message(&env, id).is_err());
     }
 
@@ -594,8 +726,15 @@ mod tests {
     fn test_mark_completed_message_failed_fails() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
@@ -609,20 +748,37 @@ mod tests {
     fn test_expire_timed_out_message() {
         let (env, sender, _) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         env.ledger().set_timestamp(1000 + MESSAGE_TIMEOUT + 1);
         expire_timed_out_message(&env, id).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Failed);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Failed
+        );
     }
 
     #[test]
     fn test_expire_not_timed_out_fails() {
         let (env, sender, _) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
         assert!(expire_timed_out_message(&env, id).is_err());
     }
 
@@ -632,14 +788,27 @@ mod tests {
     fn test_full_flow_with_callback() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, true,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            true,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Relayed);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Relayed
+        );
 
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Delivered);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Delivered
+        );
 
         receive_message_callback(&env, id, payload(&env), proof(&env)).unwrap();
         assert!(get_cross_chain_message(&env, id).is_none());
@@ -649,13 +818,23 @@ mod tests {
     fn test_full_flow_fail_then_retry_then_deliver() {
         let (env, sender, validators) = setup();
         let id = send_cross_chain_message(
-            &env, sender, ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-        ).unwrap();
+            &env,
+            sender,
+            ChainId::Ethereum,
+            target(&env),
+            payload(&env),
+            100_000,
+            false,
+        )
+        .unwrap();
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         mark_message_failed(&env, id).unwrap();
         retry_failed_message(&env, id).unwrap();
-        assert_eq!(get_cross_chain_message(&env, id).unwrap().status, MessageStatus::Pending);
+        assert_eq!(
+            get_cross_chain_message(&env, id).unwrap().status,
+            MessageStatus::Pending
+        );
 
         relay_message_to_target_chain(&env, id, validators.get(0).unwrap(), proof(&env)).unwrap();
         confirm_message_delivery(&env, id, proof(&env)).unwrap();
@@ -670,8 +849,15 @@ mod tests {
         let mut ids = soroban_sdk::Vec::new(&env);
         for _ in 0..5u32 {
             let id = send_cross_chain_message(
-                &env, sender.clone(), ChainId::Ethereum, target(&env), payload(&env), 100_000, false,
-            ).unwrap();
+                &env,
+                sender.clone(),
+                ChainId::Ethereum,
+                target(&env),
+                payload(&env),
+                100_000,
+                false,
+            )
+            .unwrap();
             ids.push_back(id);
         }
 

--- a/stellar-swipe/contracts/common/src/constants.rs
+++ b/stellar-swipe/contracts/common/src/constants.rs
@@ -1,0 +1,46 @@
+//! Shared protocol constants used across StellarSwipe contracts.
+
+/// One basis-point denominator: 10_000 bps = 100%.
+pub const BASIS_POINTS_DENOMINATOR: u32 = 10_000;
+
+/// `BASIS_POINTS_DENOMINATOR` as `i128` for arithmetic on token amounts and prices.
+pub const BASIS_POINTS_DENOMINATOR_I128: i128 = BASIS_POINTS_DENOMINATOR as i128;
+
+/// Stellar assets conventionally use 7 decimal places.
+pub const STELLAR_AMOUNT_SCALE: i128 = 10_000_000;
+
+/// Number of seconds in one hour.
+pub const SECONDS_PER_HOUR: u64 = 3_600;
+
+/// Number of seconds in one day.
+pub const SECONDS_PER_DAY: u64 = 86_400;
+
+/// Number of seconds in one week.
+pub const SECONDS_PER_WEEK: u64 = 7 * SECONDS_PER_DAY;
+
+/// Number of seconds in a 30-day protocol month.
+pub const SECONDS_PER_30_DAY_MONTH: u64 = 30 * SECONDS_PER_DAY;
+
+/// Approximate ledger close time used when converting time windows to ledgers.
+pub const LEDGER_CLOSE_TIME_SECONDS: u32 = 5;
+
+/// Approximate number of ledgers in one day.
+pub const LEDGERS_PER_DAY: u32 = (SECONDS_PER_DAY as u32) / LEDGER_CLOSE_TIME_SECONDS;
+
+/// Approximate number of ledgers in a 30-day month.
+pub const LEDGERS_PER_30_DAY_MONTH: u32 = 30 * LEDGERS_PER_DAY;
+
+/// Shared pause category for trading operations.
+pub const CAT_TRADING: &str = "trading";
+
+/// Shared pause category for signal-management operations.
+pub const CAT_SIGNALS: &str = "signals";
+
+/// Shared pause category for staking operations.
+pub const CAT_STAKES: &str = "stakes";
+
+/// Shared umbrella pause category that gates every subsystem.
+pub const CAT_ALL: &str = "all";
+
+/// Stellar protocol "dead" account used as a safe placeholder admin value.
+pub const PLACEHOLDER_ADMIN_STR: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";

--- a/stellar-swipe/contracts/common/src/emergency.rs
+++ b/stellar-swipe/contracts/common/src/emergency.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracttype, String, Env};
+use crate::constants::BASIS_POINTS_DENOMINATOR;
+pub use crate::constants::{CAT_ALL, CAT_SIGNALS, CAT_STAKES, CAT_TRADING};
+use soroban_sdk::{contracttype, Env, String};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,21 +42,24 @@ pub fn check_thresholds(
 
     // 1. Mass Failures: >50% trade failure rate in a 10-minute window
     if stats.attempts_window >= 5 && now < stats.window_start + 600 {
-        let failure_rate_bps = (stats.failures_window as u32 * 10000) / stats.attempts_window;
+        let failure_rate_bps =
+            (stats.failures_window * BASIS_POINTS_DENOMINATOR) / stats.attempts_window;
         if failure_rate_bps > config.max_failure_rate_bps {
             return Some(String::from_str(env, "High failure rate"));
         }
     }
 
     // 2. Volume Spike: Current hour volume > 10x the 24-hour average
-    if stats.volume_24h_avg > 0 && stats.volume_1h > stats.volume_24h_avg * (config.volume_spike_mult as i128) {
+    if stats.volume_24h_avg > 0
+        && stats.volume_1h > stats.volume_24h_avg * (config.volume_spike_mult as i128)
+    {
         return Some(String::from_str(env, "Volume spike detected"));
     }
 
     // 3. Price Manipulation: Asset price moves >30% within 5 minutes
     if stats.last_price > 0 && now < stats.last_price_time + 300 {
         let price_diff = (current_price - stats.last_price).abs();
-        let price_move_bps = (price_diff * 10000) / stats.last_price;
+        let price_move_bps = (price_diff * BASIS_POINTS_DENOMINATOR as i128) / stats.last_price;
         if price_move_bps > config.max_price_move_bps as i128 {
             return Some(String::from_str(env, "Extreme price movement"));
         }
@@ -73,8 +78,3 @@ impl Default for PauseState {
         panic!("PauseState must be initialized explicitly");
     }
 }
-
-pub const CAT_TRADING: &str = "trading";
-pub const CAT_SIGNALS: &str = "signals";
-pub const CAT_STAKES: &str = "stakes";
-pub const CAT_ALL: &str = "all";

--- a/stellar-swipe/contracts/common/src/health.rs
+++ b/stellar-swipe/contracts/common/src/health.rs
@@ -1,9 +1,7 @@
 //! Shared contract health reporting for monitoring and front-end probes.
 
+use crate::constants::PLACEHOLDER_ADMIN_STR;
 use soroban_sdk::{contracttype, Address, Env, String};
-
-/// Stellar protocol "dead" account (32 zero bytes) — safe placeholder when admin is unknown.
-pub const PLACEHOLDER_ADMIN_STR: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/stellar-swipe/contracts/common/src/lib.rs
+++ b/stellar-swipe/contracts/common/src/lib.rs
@@ -1,16 +1,23 @@
 #![no_std]
 
 pub mod assets;
+pub mod constants;
 pub mod emergency;
 pub mod health;
-pub mod rate_limit;
 pub mod oracle;
+pub mod rate_limit;
 
 pub use assets::{validate_asset_pair, Asset, AssetPair, AssetPairError};
-pub use emergency::{PauseState, CAT_TRADING, CAT_SIGNALS, CAT_STAKES, CAT_ALL};
-pub use health::{health_uninitialized, placeholder_admin, HealthStatus};
-pub use rate_limit::{
-    ActionType, RateLimitConfig, check_rate_limit, record_action,
-    set_config as set_rate_limit_config,
+pub use constants::{
+    BASIS_POINTS_DENOMINATOR, BASIS_POINTS_DENOMINATOR_I128, CAT_ALL, CAT_SIGNALS, CAT_STAKES,
+    CAT_TRADING, LEDGERS_PER_30_DAY_MONTH, LEDGERS_PER_DAY, PLACEHOLDER_ADMIN_STR,
+    SECONDS_PER_30_DAY_MONTH, SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_WEEK,
+    STELLAR_AMOUNT_SCALE,
 };
+pub use emergency::PauseState;
+pub use health::{health_uninitialized, placeholder_admin, HealthStatus};
 pub use oracle::{IOracleClient, MockOracleClient, OnChainOracleClient, OracleError, OraclePrice};
+pub use rate_limit::{
+    check_rate_limit, record_action, set_config as set_rate_limit_config, ActionType,
+    RateLimitConfig,
+};

--- a/stellar-swipe/contracts/common/src/rate_limit.rs
+++ b/stellar-swipe/contracts/common/src/rate_limit.rs
@@ -11,12 +11,11 @@
 
 #![allow(dead_code)]
 
+use crate::constants::{SECONDS_PER_DAY, SECONDS_PER_HOUR};
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-const SECONDS_PER_HOUR: u64 = 3_600;
-const SECONDS_PER_DAY: u64 = 86_400;
 const ESTABLISHED_DAYS: u64 = 30;
 const ESTABLISHED_TRUST_SCORE: u32 = 60;
 const MAX_STORED_TIMESTAMPS: u32 = 100;
@@ -53,10 +52,22 @@ pub enum RateLimitKey {
 
 pub fn default_config(action: &ActionType) -> RateLimitConfig {
     match action {
-        ActionType::SignalSubmission => RateLimitConfig { window_secs: SECONDS_PER_HOUR, max_actions: 10 },
-        ActionType::TradeExecution   => RateLimitConfig { window_secs: SECONDS_PER_HOUR, max_actions: 20 },
-        ActionType::StakeChange      => RateLimitConfig { window_secs: SECONDS_PER_DAY,  max_actions: 5  },
-        ActionType::FollowAction     => RateLimitConfig { window_secs: SECONDS_PER_DAY,  max_actions: 50 },
+        ActionType::SignalSubmission => RateLimitConfig {
+            window_secs: SECONDS_PER_HOUR,
+            max_actions: 10,
+        },
+        ActionType::TradeExecution => RateLimitConfig {
+            window_secs: SECONDS_PER_HOUR,
+            max_actions: 20,
+        },
+        ActionType::StakeChange => RateLimitConfig {
+            window_secs: SECONDS_PER_DAY,
+            max_actions: 5,
+        },
+        ActionType::FollowAction => RateLimitConfig {
+            window_secs: SECONDS_PER_DAY,
+            max_actions: 50,
+        },
     }
 }
 
@@ -123,7 +134,12 @@ fn effective_max(config: &RateLimitConfig, first_action: u64, now: u64, trust_sc
 /// Check whether `user` may perform `action`.
 /// Returns `Err(())` when the rate limit is exceeded and emits a `rate_limit_hit` event.
 /// `trust_score`: caller should pass the user's current trust score (0-100).
-pub fn check_rate_limit(env: &Env, user: &Address, action: ActionType, trust_score: u32) -> Result<(), ()> {
+pub fn check_rate_limit(
+    env: &Env,
+    user: &Address,
+    action: ActionType,
+    trust_score: u32,
+) -> Result<(), ()> {
     let now = env.ledger().timestamp();
     let config = get_config(env, &action);
     let first_action = get_first_action(env, user);
@@ -180,9 +196,9 @@ pub fn record_action(env: &Env, user: &Address, action: ActionType) {
 fn emit_rate_limit_hit(env: &Env, user: Address, action: ActionType, count: u32, limit: u32) {
     let action_sym: Symbol = match action {
         ActionType::SignalSubmission => symbol_short!("sig_sub"),
-        ActionType::TradeExecution   => symbol_short!("trade"),
-        ActionType::StakeChange      => symbol_short!("stake"),
-        ActionType::FollowAction     => symbol_short!("follow"),
+        ActionType::TradeExecution => symbol_short!("trade"),
+        ActionType::StakeChange => symbol_short!("stake"),
+        ActionType::FollowAction => symbol_short!("follow"),
     };
     let topics = (Symbol::new(env, "rate_limit_hit"), user, action_sym);
     env.events().publish(topics, (count, limit));
@@ -193,7 +209,10 @@ fn emit_rate_limit_hit(env: &Env, user: Address, action: ActionType, count: u32,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::{Address as _, Ledger}, Env};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Env,
+    };
 
     fn setup() -> (Env, Address) {
         let env = Env::default();
@@ -221,7 +240,8 @@ mod tests {
             record_action(&env, &user, ActionType::SignalSubmission);
         }
         // Advance time past the 1-hour window
-        env.ledger().set_timestamp(env.ledger().timestamp() + SECONDS_PER_HOUR + 1);
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + SECONDS_PER_HOUR + 1);
         // Should succeed again
         assert!(check_rate_limit(&env, &user, ActionType::SignalSubmission, 0).is_ok());
     }
@@ -278,10 +298,14 @@ mod tests {
     fn test_admin_config_update_applies_immediately() {
         let (env, user) = setup();
         // Lower the limit to 3
-        set_config(&env, ActionType::SignalSubmission, RateLimitConfig {
-            window_secs: SECONDS_PER_HOUR,
-            max_actions: 3,
-        });
+        set_config(
+            &env,
+            ActionType::SignalSubmission,
+            RateLimitConfig {
+                window_secs: SECONDS_PER_HOUR,
+                max_actions: 3,
+            },
+        );
         for _ in 0..3 {
             assert!(check_rate_limit(&env, &user, ActionType::SignalSubmission, 0).is_ok());
             record_action(&env, &user, ActionType::SignalSubmission);

--- a/stellar-swipe/contracts/fee_collector/Cargo.toml
+++ b/stellar-swipe/contracts/fee_collector/Cargo.toml
@@ -10,10 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
- main
 stellar_swipe_common = { path = "../common" }
-
- main
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/stellar-swipe/contracts/fee_collector/src/analytics.rs
+++ b/stellar-swipe/contracts/fee_collector/src/analytics.rs
@@ -1,10 +1,6 @@
 use crate::{Error, StorageKey};
 use soroban_sdk::{contracttype, panic_with_error, Address, Env, Vec};
-
-pub const SECONDS_PER_DAY: u64 = 86400;
-
-/// Target ledgers per UTC day at ~5s per ledger (used only for temporary-entry TTL budget).
-pub const LEDGERS_PER_DAY: u32 = 17_280;
+use stellar_swipe_common::{LEDGERS_PER_DAY, PLACEHOLDER_ADMIN_STR, SECONDS_PER_DAY};
 /// Temporary daily buckets are extended toward this horizon (~30 days of ledgers).
 pub const TEMP_FEE_BUCKET_TTL_LEDGERS: u32 = LEDGERS_PER_DAY * 30;
 
@@ -52,7 +48,7 @@ fn current_day_number(env: &Env) -> u64 {
 }
 
 fn no_trades_top_token_placeholder(env: &Env) -> Address {
-    Address::from_str(env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF")
+    Address::from_str(env, PLACEHOLDER_ADMIN_STR)
 }
 
 pub(crate) fn load_bucket(env: &Env, day: u64) -> DailyFeeBucket {
@@ -83,7 +79,9 @@ fn upsert_day_token(env: &Env, bucket: &mut DailyFeeBucket, token: Address, add:
         i += 1;
     }
     if bucket.by_token.len() < MAX_TOKEN_SLOTS_PER_DAY {
-        bucket.by_token.push_back(TokenFeeVol { token, amount: add });
+        bucket
+            .by_token
+            .push_back(TokenFeeVol { token, amount: add });
     }
 }
 

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -15,6 +15,7 @@ pub use storage::{
 };
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
+use stellar_swipe_common::SECONDS_PER_DAY;
 
 #[cfg(test)]
 mod test;
@@ -72,7 +73,7 @@ impl FeeCollector {
             recipient: recipient.clone(),
             token: token.clone(),
             amount,
-            available_at: queued_at + 86400,
+            available_at: queued_at + SECONDS_PER_DAY,
         }
         .publish(&env);
         Ok(())
@@ -91,15 +92,11 @@ impl FeeCollector {
         admin.require_auth();
 
         let queued = match get_queued_withdrawal(&env) {
-            Some(q)
-                if q.recipient == recipient && q.token == token && q.amount == amount =>
-            {
-                q
-            }
+            Some(q) if q.recipient == recipient && q.token == token && q.amount == amount => q,
             _ => return Err(ContractError::WithdrawalNotQueued),
         };
 
-        if env.ledger().timestamp() < queued.queued_at + 86400 {
+        if env.ledger().timestamp() < queued.queued_at + SECONDS_PER_DAY {
             return Err(ContractError::TimelockNotElapsed);
         }
 

--- a/stellar-swipe/contracts/oracle/src/conversion.rs
+++ b/stellar-swipe/contracts/oracle/src/conversion.rs
@@ -2,10 +2,9 @@
 
 use crate::errors::OracleError;
 use crate::storage::{get_base_currency, get_price};
-use stellar_swipe_common::{Asset, AssetPair};
 use soroban_sdk::{contracttype, vec, Env, Map, Vec};
+use stellar_swipe_common::{Asset, AssetPair, STELLAR_AMOUNT_SCALE};
 
-const PRECISION: i128 = 10_000_000; // 7 decimals for Stellar
 const MAX_PATH_LENGTH: u32 = 3;
 
 #[contracttype]
@@ -42,7 +41,7 @@ fn convert_direct(env: &Env, amount: i128, from: &Asset, to: &Asset) -> Result<i
 
     Ok(amount
         .checked_mul(price)
-        .and_then(|v| v.checked_div(PRECISION))
+        .and_then(|v| v.checked_div(STELLAR_AMOUNT_SCALE))
         .ok_or(OracleError::ConversionOverflow)?)
 }
 
@@ -173,7 +172,7 @@ mod tests {
             base: usdc.clone(),
             quote: xlm.clone(),
         };
-        set_price(&env, &pair, 10 * PRECISION);
+        set_price(&env, &pair, 10 * STELLAR_AMOUNT_SCALE);
 
         // Convert 100 USDC to XLM
         let result = convert_to_base(&env, 100_0000000, usdc).unwrap();

--- a/stellar-swipe/contracts/oracle/src/reputation.rs
+++ b/stellar-swipe/contracts/oracle/src/reputation.rs
@@ -1,11 +1,11 @@
 use soroban_sdk::{Address, Env, Map};
+use stellar_swipe_common::{BASIS_POINTS_DENOMINATOR_I128, SECONDS_PER_WEEK};
 
 use crate::types::{OracleReputation, StorageKey};
 
 const ACCURACY_THRESHOLD_TIGHT: i128 = 100; // 1% in basis points
 const ACCURACY_THRESHOLD_MODERATE: i128 = 500; // 5% in basis points
 const MAJOR_DEVIATION_THRESHOLD: i128 = 2000; // 20% in basis points
-const WEEK_IN_SECONDS: u64 = 86400 * 7;
 
 pub fn get_oracle_stats(env: &Env, oracle: &Address) -> OracleReputation {
     let stats_map: Map<Address, OracleReputation> = env
@@ -52,7 +52,7 @@ pub fn calculate_reputation(env: &Env, oracle: &Address) -> u32 {
     let deviation_score = 30_i128.saturating_sub(deviation_penalty);
 
     // 10% based on consistency (no recent slashes)
-    let consistency_score = if env.ledger().timestamp() - stats.last_slash > WEEK_IN_SECONDS {
+    let consistency_score = if env.ledger().timestamp() - stats.last_slash > SECONDS_PER_WEEK {
         10
     } else {
         0
@@ -92,7 +92,8 @@ pub fn track_oracle_accuracy(
     stats.total_submissions += 1;
 
     // Calculate deviation in basis points
-    let deviation = ((submitted_price - consensus_price).abs() * 10000) / consensus_price;
+    let deviation = ((submitted_price - consensus_price).abs() * BASIS_POINTS_DENOMINATOR_I128)
+        / consensus_price;
 
     // Update average deviation
     let total_dev = stats.avg_deviation * (stats.total_submissions - 1) as i128;

--- a/stellar-swipe/contracts/signal_registry/src/analytics.rs
+++ b/stellar-swipe/contracts/signal_registry/src/analytics.rs
@@ -1,9 +1,9 @@
 use crate::social::get_follower_count;
 use crate::types::{Signal, SignalStatus};
 use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
+use stellar_swipe_common::{SECONDS_PER_DAY, SECONDS_PER_HOUR};
 
 const MIN_SIGNALS_FOR_ANALYTICS: u32 = 10;
-const HOURS_24: u64 = 86400;
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -63,7 +63,10 @@ pub fn get_trending_assets(
     signals_map: &Map<u64, Signal>,
     window_hours: u64,
 ) -> Vec<(String, u32)> {
-    let cutoff = env.ledger().timestamp().saturating_sub(window_hours * 3600);
+    let cutoff = env
+        .ledger()
+        .timestamp()
+        .saturating_sub(window_hours * SECONDS_PER_HOUR);
     let mut pair_counts: Map<String, u32> = Map::new(env);
 
     for i in 0..signals_map.keys().len() {
@@ -106,7 +109,7 @@ pub fn get_trending_assets(
 }
 
 pub fn calculate_global_analytics(env: &Env, signals_map: &Map<u64, Signal>) -> GlobalAnalytics {
-    let cutoff = env.ledger().timestamp().saturating_sub(HOURS_24);
+    let cutoff = env.ledger().timestamp().saturating_sub(SECONDS_PER_DAY);
     let mut total_signals_24h = 0u32;
     let mut total_volume_24h = 0i128;
     let mut successful = 0u32;

--- a/stellar-swipe/contracts/signal_registry/src/expiry.rs
+++ b/stellar-swipe/contracts/signal_registry/src/expiry.rs
@@ -1,11 +1,12 @@
 use soroban_sdk::{Address, Env, Map, Vec};
+use stellar_swipe_common::{SECONDS_PER_30_DAY_MONTH, SECONDS_PER_DAY};
 
 use crate::events::emit_signal_expired;
 use crate::types::{Signal, SignalStatus};
 
-pub const DEFAULT_EXPIRY_SECONDS: u64 = 24 * 60 * 60; // 24 hours
+pub const DEFAULT_EXPIRY_SECONDS: u64 = SECONDS_PER_DAY; // 24 hours
 pub const MAX_CLEANUP_BATCH_SIZE: u32 = 100; // Process max 100 signals per cleanup call
-pub const ARCHIVE_THRESHOLD_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days
+pub const ARCHIVE_THRESHOLD_SECONDS: u64 = SECONDS_PER_30_DAY_MONTH; // 30 days
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CleanupResult {

--- a/stellar-swipe/contracts/signal_registry/src/export.rs
+++ b/stellar-swipe/contracts/signal_registry/src/export.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{Address, Bytes, Env, Map};
 use crate::errors::ExportError;
 use crate::types::{Signal, SignalAction, SignalStatus, TradeExecution};
 use crate::StorageKey;
+use stellar_swipe_common::{SECONDS_PER_30_DAY_MONTH, SECONDS_PER_DAY, SECONDS_PER_WEEK};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -16,11 +17,11 @@ use crate::StorageKey;
 const MAX_EXPORT_RECORDS: u32 = 500;
 
 /// 7 days in seconds
-pub const PRESET_7_DAYS: u64 = 7 * 24 * 60 * 60;
+pub const PRESET_7_DAYS: u64 = SECONDS_PER_WEEK;
 /// 30 days in seconds
-pub const PRESET_30_DAYS: u64 = 30 * 24 * 60 * 60;
+pub const PRESET_30_DAYS: u64 = SECONDS_PER_30_DAY_MONTH;
 /// 365 days in seconds
-pub const PRESET_365_DAYS: u64 = 365 * 24 * 60 * 60;
+pub const PRESET_365_DAYS: u64 = 365 * SECONDS_PER_DAY;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -156,10 +157,7 @@ pub fn get_executor_trades(env: &Env, executor: &Address) -> alloc::vec::Vec<Tra
 }
 
 /// Return all `TradeExecution` records for signals owned by a provider.
-pub fn get_provider_trades(
-    env: &Env,
-    provider: &Address,
-) -> alloc::vec::Vec<TradeExecution> {
+pub fn get_provider_trades(env: &Env, provider: &Address) -> alloc::vec::Vec<TradeExecution> {
     let signals_map: Map<u64, Signal> = env
         .storage()
         .instance()
@@ -369,7 +367,8 @@ pub fn export_trades_csv(
     for (trade_id, trade, signal) in &trades {
         let asset_pair = sdk_str_to_rust(&signal.asset_pair);
         // PnL = volume * roi / 10000
-        let pnl = trade.volume
+        let pnl = trade
+            .volume
             .checked_mul(trade.roi)
             .unwrap_or(i128::MAX)
             .checked_div(10000)
@@ -408,7 +407,8 @@ pub fn export_trades_json(
             push_str(&mut buf, ",");
         }
         let asset_pair = sdk_str_to_rust(&signal.asset_pair);
-        let pnl = trade.volume
+        let pnl = trade
+            .volume
             .checked_mul(trade.roi)
             .unwrap_or(i128::MAX)
             .checked_div(10000)
@@ -486,9 +486,8 @@ fn calculate_performance_summary(
 
         total_roi_bps = total_roi_bps.saturating_add(avg_roi);
         total_volume = total_volume.saturating_add(signal.total_volume);
-        total_lifetime_secs = total_lifetime_secs.saturating_add(
-            signal.expiry.saturating_sub(signal.timestamp),
-        );
+        total_lifetime_secs =
+            total_lifetime_secs.saturating_add(signal.expiry.saturating_sub(signal.timestamp));
         total_trades = total_trades.saturating_add(signal.executions);
 
         let pair_key = sdk_str_to_rust(&signal.asset_pair);
@@ -589,10 +588,7 @@ pub fn export_performance_csv(
     let success_rate_str = alloc::format!("{}.{:02}%", sr_whole, sr_frac);
 
     let mut buf: RustVec<u8> = RustVec::new();
-    push_str(
-        &mut buf,
-        "metric,value\n",
-    );
+    push_str(&mut buf, "metric,value\n");
 
     let rows = [
         alloc::format!("total_signals,{}\n", s.total_signals),
@@ -605,7 +601,10 @@ pub fn export_performance_csv(
         alloc::format!("total_trades,{}\n", s.total_trades),
         alloc::format!("best_pair,{}\n", csv_escape(&s.best_pair)),
         alloc::format!("worst_pair,{}\n", csv_escape(&s.worst_pair)),
-        alloc::format!("avg_signal_lifetime_hours,{}\n", s.avg_signal_lifetime_secs / 3600),
+        alloc::format!(
+            "avg_signal_lifetime_hours,{}\n",
+            s.avg_signal_lifetime_secs / 3600
+        ),
     ];
 
     for row in &rows {
@@ -677,9 +676,7 @@ pub fn export_data(
         (ExportEntity::Signals, ExportFormat::Json) => {
             export_signals_json(env, requester, date_range)
         }
-        (ExportEntity::Trades, ExportFormat::Csv) => {
-            export_trades_csv(env, requester, date_range)
-        }
+        (ExportEntity::Trades, ExportFormat::Csv) => export_trades_csv(env, requester, date_range),
         (ExportEntity::Trades, ExportFormat::Json) => {
             export_trades_json(env, requester, date_range)
         }

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -6,6 +6,7 @@ mod categories;
 mod collaboration;
 mod combos;
 mod contests;
+mod cross_chain;
 mod errors;
 mod events;
 mod expiry;
@@ -15,23 +16,25 @@ mod leaderboard;
 mod ml_scoring;
 mod performance;
 mod query;
-mod scheduling;
 mod reputation;
-mod test_reputation;
+mod scheduling;
 mod social;
 mod stake;
 mod submission;
 mod templates;
+mod test_reputation;
 mod types;
-mod cross_chain;
 mod versioning;
 
 use admin::{
-    get_admin, get_admin_config, init_admin, is_trading_paused, require_not_paused_legacy as require_not_paused,
-    AdminConfig,
+    get_admin, get_admin_config, init_admin, is_trading_paused,
+    require_not_paused_legacy as require_not_paused, AdminConfig,
 };
-use stellar_swipe_common::emergency::{PauseState, CAT_SIGNALS, CAT_TRADING, CAT_STAKES, CAT_ALL};
+use stellar_swipe_common::emergency::PauseState;
 use stellar_swipe_common::rate_limit::{self as rl, ActionType as RLAction, RateLimitConfig};
+use stellar_swipe_common::{
+    CAT_ALL, CAT_SIGNALS, CAT_STAKES, CAT_TRADING, SECONDS_PER_30_DAY_MONTH,
+};
 
 use categories::{RiskLevel, SignalCategory};
 use combos::{
@@ -48,7 +51,12 @@ pub use leaderboard::{
     get_leaderboard as get_leaderboard_internal, LeaderboardMetric, ProviderLeaderboard,
 };
 pub use ml_scoring::{MLModel, SignalFeatures, SignalScore};
+use reputation::{
+    calculate_trust_score, get_trust_score, update_median_values, update_trust_score,
+    TrustScoreDetails, TrustScoreTier,
+};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Map, String, Vec};
+use stellar_swipe_common::{health_uninitialized, placeholder_admin, HealthStatus};
 use stellar_swipe_common::{validate_asset_pair as validate_asset_pair_common, AssetPairError};
 use templates::{SignalTemplate, DEFAULT_TEMPLATE_EXPIRY_HOURS};
 use types::{
@@ -56,11 +64,9 @@ use types::{
     RecurrencePattern, Signal, SignalAction, SignalData, SignalEditInput, SignalOutcome,
     SignalPerformanceView, SignalStatus, SignalSummary, SortOption, SyncStatus, TradeExecution,
 };
-use stellar_swipe_common::{health_uninitialized, placeholder_admin, HealthStatus};
-use reputation::{calculate_trust_score, get_trust_score, update_trust_score, update_median_values, TrustScoreDetails, TrustScoreTier};
-use versioning::{SignalVersion, CopyRecord};
+use versioning::{CopyRecord, SignalVersion};
 
-const MAX_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60;
+const MAX_EXPIRY_SECONDS: u64 = SECONDS_PER_30_DAY_MONTH;
 
 #[contract]
 pub struct SignalRegistry;
@@ -82,7 +88,7 @@ pub enum StorageKey {
     Combos,
     ComboExecutions(u64),
     CrossChainSignals(String, String), // (source_chain, source_signal_id)
-    AddressMappings(String, String),    // (source_chain, source_address)
+    AddressMappings(String, String),   // (source_chain, source_address)
     /// Per-category index of active signal IDs for efficient filtering (Issue #171)
     ActiveSignalsByCategory,
     /// Nonce check for adoption increments to prevent double-counting (Issue #169)
@@ -106,10 +112,16 @@ impl SignalRegistry {
     }
 
     /// Register the TradeExecutor contract address (admin only). Required before `increment_adoption`.
-    pub fn set_trade_executor(env: Env, caller: Address, executor: Address) -> Result<(), AdminError> {
+    pub fn set_trade_executor(
+        env: Env,
+        caller: Address,
+        executor: Address,
+    ) -> Result<(), AdminError> {
         admin::require_admin(&env, &caller)?;
         caller.require_auth();
-        env.storage().instance().set(&StorageKey::TradeExecutor, &executor);
+        env.storage()
+            .instance()
+            .set(&StorageKey::TradeExecutor, &executor);
         Ok(())
     }
 
@@ -188,7 +200,14 @@ impl SignalRegistry {
     ) -> Result<(), AdminError> {
         admin::require_admin(&env, &caller)?;
         caller.require_auth();
-        rl::set_config(&env, action, RateLimitConfig { window_secs, max_actions });
+        rl::set_config(
+            &env,
+            action,
+            RateLimitConfig {
+                window_secs,
+                max_actions,
+            },
+        );
         Ok(())
     }
 
@@ -422,22 +441,22 @@ impl SignalRegistry {
             .unwrap_or(Map::new(env))
     }
 
-fn save_signals_map(env: &Env, map: &Map<u64, Signal>) {
+    fn save_signals_map(env: &Env, map: &Map<u64, Signal>) {
         env.storage().instance().set(&StorageKey::Signals, map);
     }
 
-fn get_category_index_map(env: &Env) -> Map<SignalCategory, Vec<u64>> {
-    env.storage()
-        .instance()
-        .get(&StorageKey::ActiveSignalsByCategory)
-        .unwrap_or(Map::new(env))
-}
+    fn get_category_index_map(env: &Env) -> Map<SignalCategory, Vec<u64>> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::ActiveSignalsByCategory)
+            .unwrap_or(Map::new(env))
+    }
 
-fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
-    env.storage()
-        .instance()
-        .set(&StorageKey::ActiveSignalsByCategory, map);
-}
+    fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
+        env.storage()
+            .instance()
+            .set(&StorageKey::ActiveSignalsByCategory, map);
+    }
 
     fn get_provider_stakes_map(env: &Env) -> Map<Address, stake::StakeInfo> {
         env.storage()
@@ -602,7 +621,6 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
         signals.get(signal_id)
     }
 
-
     /// Edit price, rationale hash, or confidence within 60s of `submitted_at` (Issue #168).
     pub fn update_signal(
         env: Env,
@@ -696,16 +714,14 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
 
         let provider = signal.provider.clone();
         let rep_key = StorageKey::ProviderReputationScore(provider.clone());
-        let old_score: u32 = env
-            .storage()
-            .instance()
-            .get(&rep_key)
-            .unwrap_or(50);
+        let old_score: u32 = env.storage().instance().get(&rep_key).unwrap_or(50);
         let new_score = reputation::next_reputation_score(old_score, &outcome);
         env.storage().instance().set(&rep_key, &new_score);
 
         recorded.set(signal_id, true);
-        env.storage().instance().set(&StorageKey::RecordedSignalOutcomes, &recorded);
+        env.storage()
+            .instance()
+            .set(&StorageKey::RecordedSignalOutcomes, &recorded);
 
         events::emit_reputation_updated(&env, provider.clone(), old_score, new_score);
         Ok(())
@@ -713,10 +729,7 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
 
     pub fn get_provider_reputation_score(env: Env, provider: Address) -> u32 {
         let rep_key = StorageKey::ProviderReputationScore(provider);
-        env.storage()
-            .instance()
-            .get(&rep_key)
-            .unwrap_or(50)
+        env.storage().instance().get(&rep_key).unwrap_or(50)
     }
 
     pub fn get_provider_stats(env: Env, provider: Address) -> Option<ProviderPerformance> {
@@ -953,7 +966,13 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
             );
         }
 
-        contests::apply_trade_to_contest_entries(&env, signal_id, &provider_for_contest, roi, volume);
+        contests::apply_trade_to_contest_entries(
+            &env,
+            signal_id,
+            &provider_for_contest,
+            roi,
+            volume,
+        );
 
         Ok(())
     }
@@ -1036,7 +1055,7 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
         result
     }
 
-/* =========================
+    /* =========================
        SIGNAL ADOPTION (Issue #169)
     ========================== */
 
@@ -1058,7 +1077,11 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
 
         // Check nonce to prevent double-increment
         let nonce_key = (signal_id, nonce);
-        let nonces: Map<(u64, u64), bool> = env.storage().instance().get(&StorageKey::AdoptionNonces).unwrap_or(Map::new(&env));
+        let nonces: Map<(u64, u64), bool> = env
+            .storage()
+            .instance()
+            .get(&StorageKey::AdoptionNonces)
+            .unwrap_or(Map::new(&env));
         if nonces.contains_key(nonce_key.clone()) {
             return Err(AdminError::InvalidParameter); // Already incremented
         }
@@ -1070,14 +1093,19 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
             return Err(AdminError::InvalidParameter);
         }
 
-        signal.adoption_count = signal.adoption_count.checked_add(1).ok_or(AdminError::InvalidParameter)?;
+        signal.adoption_count = signal
+            .adoption_count
+            .checked_add(1)
+            .ok_or(AdminError::InvalidParameter)?;
         signals.set(signal_id, signal.clone());
         Self::save_signals_map(&env, &signals);
 
         // Save nonce
         let mut nonces = nonces;
         nonces.set(nonce_key, true);
-        env.storage().instance().set(&StorageKey::AdoptionNonces, &nonces);
+        env.storage()
+            .instance()
+            .set(&StorageKey::AdoptionNonces, &nonces);
 
         // Emit event
         events::emit_signal_adopted(&env, signal_id, caller.clone(), signal.adoption_count);
@@ -1134,7 +1162,15 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
         category_filter: Option<SignalCategory>,
     ) -> Vec<SignalSummary> {
         let signals_map = Self::get_signals_map(&env);
-        query::get_active_signals(&env, &signals_map, provider, offset, limit, sort_by, category_filter)
+        query::get_active_signals(
+            &env,
+            &signals_map,
+            provider,
+            offset,
+            limit,
+            sort_by,
+            category_filter,
+        )
     }
 
     /// Legacy fallback if front-ends rely on Old behavior
@@ -1754,7 +1790,12 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
             source_address.clone(),
             proof,
         );
-        events::emit_cross_chain_address_registered(&env, source_chain, source_address, stellar_address);
+        events::emit_cross_chain_address_registered(
+            &env,
+            source_chain,
+            source_address,
+            stellar_address,
+        );
         Ok(())
     }
 
@@ -1892,12 +1933,7 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
         signals.set(cc_signal.stellar_signal_id, signal.clone());
         Self::save_signals_map(&env, &signals);
 
-        events::emit_cross_chain_signal_synced(
-            &env,
-            source_chain,
-            source_id,
-            signal.status as u32,
-        );
+        events::emit_cross_chain_signal_synced(&env, source_chain, source_id, signal.status as u32);
 
         Ok(())
     }
@@ -1914,7 +1950,12 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
         let performance = Self::get_provider_stats(env.clone(), provider.clone())?;
         let stake_info = stake::get_stake_info(&env, &provider);
 
-        Some(calculate_trust_score(&env, &provider, &performance, &stake_info))
+        Some(calculate_trust_score(
+            &env,
+            &provider,
+            &performance,
+            &stake_info,
+        ))
     }
 
     /// Update trust score for a provider (called after performance changes)
@@ -1946,9 +1987,11 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
         // Collect providers with sufficient history
         for key in stats_map.keys() {
             if let Some(performance) = stats_map.get(key.clone()) {
-                if performance.total_signals >= 5 { // MIN_SIGNALS_FOR_TRUST_SCORE
+                if performance.total_signals >= 5 {
+                    // MIN_SIGNALS_FOR_TRUST_SCORE
                     let stake_info = stake::get_stake_info(&env, &key);
-                    let score_details = calculate_trust_score(&env, &key, &performance, &stake_info);
+                    let score_details =
+                        calculate_trust_score(&env, &key, &performance, &stake_info);
                     providers_with_scores.push_back((key, score_details));
                 }
             }
@@ -2011,7 +2054,8 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
             if let Some(performance) = stats_map.get(key.clone()) {
                 if performance.total_signals >= 5 {
                     let stake_info = stake::get_stake_info(&env, &key);
-                    let score_details = calculate_trust_score(&env, &key, &performance, &stake_info);
+                    let score_details =
+                        calculate_trust_score(&env, &key, &performance, &stake_info);
 
                     match score_details.tier {
                         TrustScoreTier::HighlyTrusted => highly_trusted += 1,
@@ -2028,17 +2072,17 @@ fn save_category_index_map(env: &Env, map: &Map<SignalCategory, Vec<u64>>) {
 }
 
 #[cfg(test)]
+mod test_adoption;
+#[cfg(test)]
 mod test_combos;
 #[cfg(test)]
 mod test_contests;
 #[cfg(test)]
-mod test_scheduling;
-#[cfg(test)]
-mod test_versioning;
-#[cfg(test)]
 mod test_emergency;
+mod test_health;
+#[cfg(test)]
+mod test_scheduling;
 #[cfg(test)]
 mod test_signal_issues;
 #[cfg(test)]
-mod test_adoption;
-mod test_health;
+mod test_versioning;

--- a/stellar-swipe/contracts/signal_registry/src/performance.rs
+++ b/stellar-swipe/contracts/signal_registry/src/performance.rs
@@ -1,10 +1,10 @@
 use crate::types::{ProviderPerformance, Signal, SignalAction, SignalStatus, TradeExecution};
+use stellar_swipe_common::BASIS_POINTS_DENOMINATOR_I128;
 
 /// ROI calculation constants
-const BASIS_POINTS_100_PERCENT: i128 = 10000;
 const SUCCESS_THRESHOLD_BPS: i128 = 200; // 2% in basis points
 const FAILURE_THRESHOLD_BPS: i128 = -500; // -5% in basis points
-const MIN_ROI_BPS: i128 = -10000; // -100% cap
+const MIN_ROI_BPS: i128 = -BASIS_POINTS_DENOMINATOR_I128; // -100% cap
 
 /// Calculate ROI in basis points from entry and exit prices
 ///
@@ -31,7 +31,7 @@ pub fn calculate_roi(entry_price: i128, exit_price: i128, action: &SignalAction)
 
     // Calculate ROI: (price_diff / entry_price) * 10000
     let roi = price_diff
-        .checked_mul(BASIS_POINTS_100_PERCENT)
+        .checked_mul(BASIS_POINTS_DENOMINATOR_I128)
         .expect("ROI calculation overflow")
         .checked_div(entry_price)
         .expect("division by zero in ROI calculation");
@@ -184,7 +184,7 @@ pub fn update_provider_performance(
     // Recalculate success rate: (successful_signals / total_signals) * 10000
     if provider_stats.total_signals > 0 {
         provider_stats.success_rate = ((provider_stats.successful_signals as i128)
-            * BASIS_POINTS_100_PERCENT
+            * BASIS_POINTS_DENOMINATOR_I128
             / (provider_stats.total_signals as i128)) as u32;
     }
 

--- a/stellar-swipe/contracts/signal_registry/src/versioning.rs
+++ b/stellar-swipe/contracts/signal_registry/src/versioning.rs
@@ -2,9 +2,10 @@ use crate::errors::VersioningError;
 use crate::events;
 use crate::types::{Signal, SignalStatus};
 use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
+use stellar_swipe_common::SECONDS_PER_HOUR;
 
 const MAX_UPDATES_PER_SIGNAL: u32 = 5;
-const UPDATE_COOLDOWN_SECONDS: u64 = 3600; // 1 hour
+const UPDATE_COOLDOWN_SECONDS: u64 = SECONDS_PER_HOUR; // 1 hour
 
 #[contracttype]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Centralizes all protocol constants into a shared module.

- Adds contracts/shared/src/constants.rs
- Removes all magic numbers across contracts
- Improves readability and maintainability
- Documents each constant clearly
- Ensures clippy passes clean

closes #157