### PR TITLE
feat: Add per-network config and network-aware deploy script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,20 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  STELLAR_NETWORK: testnet
 
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
+      # Safety: ensure mainnet config is never loaded in CI
+      - name: Guard — reject mainnet in CI
+        run: |
+          if [ "${STELLAR_NETWORK}" = "mainnet" ]; then
+            echo "ERROR: STELLAR_NETWORK=mainnet is not allowed in CI" && exit 1
+          fi
+
       # Checkout repository
       - uses: actions/checkout@v4
 

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Mainnet configuration — NEVER used in automated tests or CI. Deploy manually with explicit STELLAR_NETWORK=mainnet.",
+  "network": "mainnet",
+  "min_stake": 100000000,
+  "max_fee_rate": 100,
+  "oracle_address": "REPLACE_WITH_MAINNET_ORACLE_ADDRESS",
+  "admin": "REPLACE_WITH_MAINNET_ADMIN_ADDRESS"
+}

--- a/config/testnet.json
+++ b/config/testnet.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Testnet configuration — safe for automated tests and CI. Never use mainnet values here.",
+  "network": "testnet",
+  "min_stake": 10000000,
+  "max_fee_rate": 500,
+  "oracle_address": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  "admin": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+}

--- a/docs/PR_NETWORK_CONFIG.md
+++ b/docs/PR_NETWORK_CONFIG.md
@@ -1,0 +1,60 @@
+# feat: Add per-network config and network-aware deploy script
+
+## Summary
+
+Parameters like `MIN_STAKE`, `MAX_FEE_RATE`, and oracle addresses differ between testnet and mainnet. Hardcoding these values caused confusing test failures and potential financial risk.
+
+This PR introduces a `NetworkConfig` structure stored in per-network JSON files, loaded at deploy time based on the `STELLAR_NETWORK` environment variable. Mainnet config is explicitly blocked from ever running in automated tests or CI.
+
+## Changes
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `config/testnet.json` | Testnet config — safe for CI and automated tests |
+| `config/mainnet.json` | Mainnet config — guarded by `REPLACE_WITH_` sentinels |
+| `scripts/deploy.ts` | Network-aware deploy script that reads config by network |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | Added `STELLAR_NETWORK: testnet` env default + mainnet guard step |
+
+## Config fields (NetworkConfig)
+
+```ts
+interface NetworkConfig {
+  min_stake: number;      // Minimum stake in stroops (i128)
+  max_fee_rate: number;   // Max fee in basis points (u32)
+  oracle_address: string; // Soroban oracle contract address
+  admin: string;          // Admin account StrKey (G...)
+}
+```
+
+## Testnet vs Mainnet values
+
+| Field | Testnet | Mainnet |
+|-------|---------|---------|
+| `min_stake` | `10_000_000` (10 XLM) | `100_000_000` (100 XLM) |
+| `max_fee_rate` | `500` (5%) | `100` (1%) |
+| `oracle_address` | Testnet placeholder | `REPLACE_WITH_MAINNET_ORACLE_ADDRESS` |
+| `admin` | Testnet placeholder | `REPLACE_WITH_MAINNET_ADMIN_ADDRESS` |
+
+## Mainnet safety
+
+- `config/mainnet.json` uses `REPLACE_WITH_` sentinels — `deploy.ts` hard-fails if any are unset
+- `deploy.ts` exits with an error if `CI=true` and `STELLAR_NETWORK=mainnet`
+- CI workflow pins `STELLAR_NETWORK: testnet` at the env level
+- A dedicated guard step runs before checkout and fails the job if mainnet is ever set in CI
+
+## Checklist
+
+- [x] `config/testnet.json` and `config/mainnet.json` present with documented field explanations
+- [x] Deploy script uses correct config based on `STELLAR_NETWORK` flag
+- [x] Testnet and mainnet configs have clearly different values (especially `admin` and `min_stake`)
+- [x] CI only ever uses testnet config (env default + guard step)
+- [x] No secrets or real mainnet keys committed
+- [ ] Tests / `cargo check` pass for crates touched
+- [ ] Linked issue / ticket (if any):

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env ts-node
+/**
+ * deploy.ts — Network-aware deploy script for StellarSwipe contracts.
+ *
+ * Usage:
+ *   STELLAR_NETWORK=testnet STELLAR_SOURCE_ACCOUNT=<key> STELLAR_ADMIN_ADDRESS=<G...> npx ts-node scripts/deploy.ts
+ *   STELLAR_NETWORK=mainnet STELLAR_SOURCE_ACCOUNT=<key> STELLAR_ADMIN_ADDRESS=<G...> npx ts-node scripts/deploy.ts
+ *
+ * Reads config from config/{network}.json. Mainnet is blocked in automated tests.
+ */
+
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface NetworkConfig {
+  /** Minimum stake amount in stroops (i128) */
+  min_stake: number;
+  /** Maximum fee rate in basis points (u32) */
+  max_fee_rate: number;
+  /** Soroban contract address of the oracle */
+  oracle_address: string;
+  /** Admin account StrKey (G...) */
+  admin: string;
+}
+
+// ── Guards ───────────────────────────────────────────────────────────────────
+
+const NETWORK = process.env.STELLAR_NETWORK ?? "testnet";
+
+if (process.env.CI === "true" && NETWORK === "mainnet") {
+  console.error("ERROR: mainnet config must never be used in automated tests.");
+  process.exit(1);
+}
+
+// ── Load config ──────────────────────────────────────────────────────────────
+
+const configPath = path.resolve(__dirname, `../config/${NETWORK}.json`);
+if (!fs.existsSync(configPath)) {
+  console.error(`ERROR: No config found for network "${NETWORK}" at ${configPath}`);
+  process.exit(1);
+}
+
+const config: NetworkConfig = JSON.parse(fs.readFileSync(configPath, "utf8"));
+
+// Validate no placeholder values slipped through
+for (const [key, val] of Object.entries(config)) {
+  if (typeof val === "string" && val.startsWith("REPLACE_WITH_")) {
+    console.error(`ERROR: config field "${key}" has not been set (value: ${val})`);
+    process.exit(1);
+  }
+}
+
+// ── Deploy ───────────────────────────────────────────────────────────────────
+
+const SOURCE = process.env.STELLAR_SOURCE_ACCOUNT ?? process.env.STELLAR_ACCOUNT;
+if (!SOURCE) {
+  console.error("ERROR: set STELLAR_SOURCE_ACCOUNT or STELLAR_ACCOUNT");
+  process.exit(1);
+}
+
+console.log(`Deploying to ${NETWORK} with config:`, config);
+
+function stellar(args: string): string {
+  return execSync(`stellar ${args}`, { encoding: "utf8" }).trim();
+}
+
+function deployContract(wasmPath: string): string {
+  const out = stellar(
+    `contract deploy --wasm ${wasmPath} --source-account ${SOURCE} --network ${NETWORK}`
+  );
+  const match = out.match(/C[2-7A-Z]{55}/);
+  if (!match) throw new Error(`Could not parse contract ID from: ${out}`);
+  return match[0];
+}
+
+// Deploy signal_registry
+const wasmDir = path.resolve(
+  __dirname,
+  "../stellar-swipe/target/wasm32-unknown-unknown/release"
+);
+
+const signalRegistryId = deployContract(`${wasmDir}/signal_registry.wasm`);
+console.log(`signal_registry deployed: ${signalRegistryId}`);
+
+stellar(
+  `contract invoke --id ${signalRegistryId} --source-account ${SOURCE} --network ${NETWORK} ` +
+  `-- initialize --admin ${config.admin}`
+);
+
+console.log("Done.");


### PR DESCRIPTION
## Summary

Parameters like `MIN_STAKE`, `MAX_FEE_RATE`, and oracle addresses differ between testnet and mainnet. Hardcoding these values caused confusing test failures and potential financial risk.

This PR introduces a `NetworkConfig` structure stored in per-network JSON files, loaded at deploy time based on the `STELLAR_NETWORK` environment variable. Mainnet config is explicitly blocked from ever running in automated tests or CI.

## Changes

### New files

| File | Purpose |
|------|---------|
| `config/testnet.json` | Testnet config — safe for CI and automated tests |
| `config/mainnet.json` | Mainnet config — guarded by `REPLACE_WITH_` sentinels |
| `scripts/deploy.ts` | Network-aware deploy script that reads config by network |

### Modified files

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `STELLAR_NETWORK: testnet` env default + mainnet guard step |

## Config fields (NetworkConfig)

```ts
interface NetworkConfig {
  min_stake: number;      // Minimum stake in stroops (i128)
  max_fee_rate: number;   // Max fee in basis points (u32)
  oracle_address: string; // Soroban oracle contract address
  admin: string;          // Admin account StrKey (G...)
}
```

## Testnet vs Mainnet values

| Field | Testnet | Mainnet |
|-------|---------|---------|
| `min_stake` | `10_000_000` (10 XLM) | `100_000_000` (100 XLM) |
| `max_fee_rate` | `500` (5%) | `100` (1%) |
| `oracle_address` | Testnet placeholder | `REPLACE_WITH_MAINNET_ORACLE_ADDRESS` |
| `admin` | Testnet placeholder | `REPLACE_WITH_MAINNET_ADMIN_ADDRESS` |

## Mainnet safety

- `config/mainnet.json` uses `REPLACE_WITH_` sentinels — `deploy.ts` hard-fails if any are unset
- `deploy.ts` exits with an error if `CI=true` and `STELLAR_NETWORK=mainnet`
- CI workflow pins `STELLAR_NETWORK: testnet` at the env level
- A dedicated guard step runs before checkout and fails the job if mainnet is ever set in CI

## Checklist

- [x] `config/testnet.json` and `config/mainnet.json` present with documented field explanations
- [x] Deploy script uses correct config based on `STELLAR_NETWORK` flag
- [x] Testnet and mainnet configs have clearly different values (especially `admin` and `min_stake`)
- [x] CI only ever uses testnet config (env default + guard step)
- [x] No secrets or real mainnet keys committed
- [ ] Tests / `cargo check` pass for crates touched
- [ ] Linked issue / ticket (if any):

Close #164