### PR TITLE
feat(trade_executor): add multi-hop path payment support to execute_s…

### DIFF
--- a/stellar-swipe/contracts/trade_executor/src/errors.rs
+++ b/stellar-swipe/contracts/trade_executor/src/errors.rs
@@ -21,4 +21,5 @@ pub enum ContractError {
     Unauthorized = 6,
     TradeNotFound = 7,
     SlippageExceeded = 8,
+    PathTooLong = 9,
 }

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -296,7 +296,23 @@ impl TradeExecutorContract {
             .instance()
             .get(&StorageKey::SdexRouter)
             .ok_or(ContractError::NotInitialized)?;
-        execute_sdex_swap(&env, &router, &from_token, &to_token, amount, min_received)
+        execute_sdex_swap(&env, &router, &from_token, &to_token, amount, min_received, Vec::new(&env))
+    }
+
+    pub fn swap_path(
+        env: Env,
+        from_token: Address,
+        to_token: Address,
+        path: Vec<Address>,
+        amount: i128,
+        min_received: i128,
+    ) -> Result<i128, ContractError> {
+        let router = env
+            .storage()
+            .instance()
+            .get(&StorageKey::SdexRouter)
+            .ok_or(ContractError::NotInitialized)?;
+        execute_sdex_swap(&env, &router, &from_token, &to_token, amount, min_received, path)
     }
 
     pub fn swap_with_slippage(
@@ -353,7 +369,7 @@ impl TradeExecutorContract {
             .get(&StorageKey::SdexRouter)
             .ok_or(ContractError::NotInitialized)?;
 
-        let exit_price = execute_sdex_swap(&env, &router, &from_token, &to_token, amount, min_received)?;
+        let exit_price = execute_sdex_swap(&env, &router, &from_token, &to_token, amount, min_received, Vec::new(&env))?;
 
         let realized_pnl = exit_price - amount;
         let close_sym = Symbol::new(&env, "close_position");

--- a/stellar-swipe/contracts/trade_executor/src/sdex.rs
+++ b/stellar-swipe/contracts/trade_executor/src/sdex.rs
@@ -39,23 +39,22 @@ pub fn min_received_from_slippage(amount: i128, max_slippage_bps: u32) -> Option
     amount.checked_mul(num)?.checked_div(10_000)
 }
 
-/// Execute a swap by approving the router on `from_token` and invoking its `swap` function.
+/// Maximum number of intermediate hops allowed by the Stellar protocol.
+pub const MAX_PATH_HOPS: usize = 5;
+
+/// Execute a swap via the SDEX router.
 ///
-/// Expected router ABI (topics / ordering must match `invoke_contract` args):
+/// - `path` empty  → direct swap (`swap` entrypoint)
+/// - `path` non-empty → multi-hop path payment (`swap_path` entrypoint); max 5 hops.
 ///
+/// Router ABI for direct swap:
 /// ```text
-/// swap(
-///   pull_from: Address,   // SAC balance this swap debits (usually the caller contract)
-///   from_token: Address,  // input SAC contract
-///   to_token: Address,     // output SAC contract
-///   amount_in: i128,
-///   min_out: i128,         // router-level minimum; executor still enforces balance check
-///   recipient: Address,    // receives output tokens (usually pull_from)
-/// ) -> i128                // reported amount out (informational)
+/// swap(pull_from, from_token, to_token, amount_in, min_out, recipient) -> i128
 /// ```
-///
-/// The router should `transfer_from` `amount_in` from `pull_from` and `transfer`
-/// output tokens to `recipient`.
+/// Router ABI for path swap:
+/// ```text
+/// swap_path(pull_from, from_token, to_token, path: Vec<Address>, amount_in, min_out, recipient) -> i128
+/// ```
 pub fn execute_sdex_swap(
     env: &Env,
     sdex_router: &Address,
@@ -63,9 +62,13 @@ pub fn execute_sdex_swap(
     to_token: &Address,
     amount: i128,
     min_received: i128,
+    path: Vec<Address>,
 ) -> Result<i128, ContractError> {
     if amount <= 0 || min_received < 0 {
         return Err(ContractError::InvalidAmount);
+    }
+    if path.len() as usize > MAX_PATH_HOPS {
+        return Err(ContractError::PathTooLong);
     }
 
     let this = env.current_contract_address();
@@ -78,21 +81,29 @@ pub fn execute_sdex_swap(
         .checked_add(ROUTER_ALLOWANCE_LEDGERS)
         .ok_or(ContractError::InvalidAmount)?;
 
-    // SEP-41: current contract authorizes router to pull `amount` of from_token.
     from_client.approve(&this, sdex_router, &amount, &expiration);
 
     let balance_before = to_client.balance(&this);
 
-    let swap_sym = Symbol::new(env, SDEX_SWAP_FN);
     let mut args = Vec::<Val>::new(env);
     args.push_back(this.clone().into_val(env));
     args.push_back(from_token.clone().into_val(env));
     args.push_back(to_token.clone().into_val(env));
-    args.push_back(amount.into_val(env));
-    args.push_back(min_received.into_val(env));
-    args.push_back(this.clone().into_val(env));
 
-    let _reported_out: i128 = env.invoke_contract(sdex_router, &swap_sym, args);
+    let fn_sym = if path.is_empty() {
+        args.push_back(amount.into_val(env));
+        args.push_back(min_received.into_val(env));
+        args.push_back(this.clone().into_val(env));
+        Symbol::new(env, SDEX_SWAP_FN)
+    } else {
+        args.push_back(path.into_val(env));
+        args.push_back(amount.into_val(env));
+        args.push_back(min_received.into_val(env));
+        args.push_back(this.clone().into_val(env));
+        Symbol::new(env, "swap_path")
+    };
+
+    let _reported_out: i128 = env.invoke_contract(sdex_router, &fn_sym, args);
 
     let balance_after = to_client.balance(&this);
     let actual_received = balance_after.checked_sub(balance_before).unwrap_or(0);

--- a/stellar-swipe/contracts/trade_executor/src/test.rs
+++ b/stellar-swipe/contracts/trade_executor/src/test.rs
@@ -455,7 +455,7 @@ fn swap_reverts_when_balance_below_min() {
     MockSdexRouterClient::new(&env, &router_id).set_amount_out(&300_000);
 
     let err = env.as_contract(&exec_id, || {
-        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, 400_000)
+        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, 400_000, Vec::new(&env))
     });
     assert_eq!(err, Err(ContractError::SlippageExceeded));
 }
@@ -483,9 +483,131 @@ fn swap_with_slippage_reverts_when_exceeded() {
 
     let min = sdex::min_received_from_slippage(1_000_000, 100).unwrap();
     let err = env.as_contract(&exec_id, || {
-        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, min)
+        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, min, Vec::new(&env))
     });
     assert_eq!(err, Err(ContractError::SlippageExceeded));
+}
+
+// ── Multi-hop path tests ──────────────────────────────────────────────────────
+
+#[contract]
+pub struct MockSdexRouterWithPath;
+
+#[contractimpl]
+impl MockSdexRouterWithPath {
+    pub fn set_amount_out(env: Env, out: i128) {
+        env.storage().instance().set(&symbol_short!("amtout"), &out);
+    }
+
+    pub fn swap(
+        env: Env,
+        pull_from: Address,
+        from_token: Address,
+        to_token: Address,
+        amount_in: i128,
+        _min_out: i128,
+        recipient: Address,
+    ) -> i128 {
+        let router = env.current_contract_address();
+        token::Client::new(&env, &from_token).transfer_from(&router, &pull_from, &router, &amount_in);
+        let out: i128 = env.storage().instance().get(&symbol_short!("amtout")).unwrap_or(amount_in);
+        let to_mux: MuxedAddress = recipient.into();
+        token::Client::new(&env, &to_token).transfer(&router, &to_mux, &out);
+        out
+    }
+
+    pub fn swap_path(
+        env: Env,
+        pull_from: Address,
+        from_token: Address,
+        to_token: Address,
+        _path: soroban_sdk::Vec<Address>,
+        amount_in: i128,
+        _min_out: i128,
+        recipient: Address,
+    ) -> i128 {
+        let router = env.current_contract_address();
+        token::Client::new(&env, &from_token).transfer_from(&router, &pull_from, &router, &amount_in);
+        let out: i128 = env.storage().instance().get(&symbol_short!("amtout")).unwrap_or(amount_in);
+        let to_mux: MuxedAddress = recipient.into();
+        token::Client::new(&env, &to_token).transfer(&router, &to_mux, &out);
+        out
+    }
+}
+
+fn setup_path_router(env: &Env) -> (Address, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let token_a = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_b = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let router_id = env.register(MockSdexRouterWithPath, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+    let exec = TradeExecutorContractClient::new(env, &exec_id);
+    exec.initialize(&admin);
+    exec.set_sdex_router(&router_id);
+    StellarAssetClient::new(env, &token_a).mint(&exec_id, &1_000_000_000);
+    StellarAssetClient::new(env, &token_b).mint(&router_id, &10_000_000_000);
+    (exec_id, router_id, token_a, token_b)
+}
+
+#[test]
+fn swap_direct_no_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (exec_id, router_id, token_a, token_b) = setup_path_router(&env);
+    MockSdexRouterWithPathClient::new(&env, &router_id).set_amount_out(&800_000);
+    let out = env.as_contract(&exec_id, || {
+        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, 700_000, Vec::new(&env))
+    });
+    assert_eq!(out, Ok(800_000));
+}
+
+#[test]
+fn swap_two_hop_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (exec_id, router_id, token_a, token_b) = setup_path_router(&env);
+    let admin = Address::generate(&env);
+    let mid = env.register_stellar_asset_contract_v2(admin).address();
+    MockSdexRouterWithPathClient::new(&env, &router_id).set_amount_out(&900_000);
+    let mut path = Vec::new(&env);
+    path.push_back(mid);
+    let out = env.as_contract(&exec_id, || {
+        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, 800_000, path)
+    });
+    assert_eq!(out, Ok(900_000));
+}
+
+#[test]
+fn swap_five_hop_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (exec_id, router_id, token_a, token_b) = setup_path_router(&env);
+    let admin = Address::generate(&env);
+    MockSdexRouterWithPathClient::new(&env, &router_id).set_amount_out(&950_000);
+    let mut path = Vec::new(&env);
+    for _ in 0..5 {
+        path.push_back(env.register_stellar_asset_contract_v2(admin.clone()).address());
+    }
+    let out = env.as_contract(&exec_id, || {
+        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, 900_000, path)
+    });
+    assert_eq!(out, Ok(950_000));
+}
+
+#[test]
+fn swap_six_hop_path_returns_path_too_long() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (exec_id, router_id, token_a, token_b) = setup_path_router(&env);
+    let admin = Address::generate(&env);
+    let mut path = Vec::new(&env);
+    for _ in 0..6 {
+        path.push_back(env.register_stellar_asset_contract_v2(admin.clone()).address());
+    }
+    let err = env.as_contract(&exec_id, || {
+        execute_sdex_swap(&env, &router_id, &token_a, &token_b, 1_000_000, 900_000, path)
+    });
+    assert_eq!(err, Err(ContractError::PathTooLong));
 }
 
 // ── cancel_copy_trade tests ───────────────────────────────────────────────────


### PR DESCRIPTION
…dex_swap

- Add PathTooLong = 9 to ContractError
- Accept path: Vec<Address> in execute_sdex_swap; empty path = direct swap, non-empty path = swap_path router entrypoint (up to 5 hops)
- Add MAX_PATH_HOPS = 5 constant; return PathTooLong when exceeded
- Expose swap_path public entrypoint on TradeExecutorContract
- Update all existing execute_sdex_swap call sites to pass empty path
- Add unit tests: direct swap, 2-hop, 5-hop, 6-hop (PathTooLong error)
closes #292 