### PR TITLE
feat(security): audit admin privilege escalation paths (#267)

### DIFF
--- a/docs/security/privilege_escalation_analysis.md
+++ b/docs/security/privilege_escalation_analysis.md
@@ -1,0 +1,128 @@
+# Admin Privilege Escalation Analysis
+
+**Issue:** #267  
+**Status:** Audited & Mitigated
+
+---
+
+## 1. Scope
+
+All paths that write to the `Admin` / `AdminStorageKey::Admin` storage key across the five contracts:
+
+| Contract | Admin Key |
+|---|---|
+| `auto_trade` | `AdminStorageKey::Admin` |
+| `signal_registry` | `AdminStorageKey::Admin` |
+| `oracle` | `StorageKey::Admin` |
+| `governance` | `StorageKey::Admin` |
+| `trade_executor` | `StorageKey::Admin` |
+
+---
+
+## 2. Identified Paths That Write the Admin Key
+
+### 2.1 `auto_trade` — `contracts/auto_trade/src/admin.rs`
+
+| Function | Who can call | Guard |
+|---|---|---|
+| `init_admin` | Anyone (once) | Panics if already set — one-time init only |
+| `accept_admin_transfer` | Pending admin only | `caller == pending_admin`, expiry check, `caller.require_auth()` |
+
+**No other function writes `AdminStorageKey::Admin`.**
+
+### 2.2 `signal_registry` — `contracts/signal_registry/src/admin.rs`
+
+| Function | Who can call | Guard |
+|---|---|---|
+| `init_admin` | Anyone (once) | Returns `AlreadyInitialized` if already set |
+| `accept_admin_transfer` | Pending admin only | `caller == pending.pending_admin`, expiry check, `caller.require_auth()` |
+
+**No other function writes `AdminStorageKey::Admin`.**
+
+### 2.3 `oracle` — `contracts/oracle/src/lib.rs` + `admin.rs`
+
+| Function | Who can call | Guard |
+|---|---|---|
+| `initialize` | Anyone (once) | Panics if `StorageKey::Admin` already set |
+| `accept_admin_transfer` | Pending admin only | `caller == pending_admin`, expiry check, `caller.require_auth()` |
+
+**No other function writes `StorageKey::Admin`.**
+
+### 2.4 `governance` — `contracts/governance/src/lib.rs`
+
+| Function | Who can call | Guard |
+|---|---|---|
+| `initialize` | Anyone (once) | Returns `AlreadyInitialized` if `StorageKey::Initialized` is set |
+
+**Governance has no admin transfer mechanism — admin is immutable post-init.**  
+Governance proposals (`execute_proposal_action`) can write `GovernanceParameters`, `GovernanceFeatures`, `GovernanceUpgrades`, and `Treasury` — **but never `StorageKey::Admin`.**
+
+### 2.5 `trade_executor` — `contracts/trade_executor/src/lib.rs`
+
+| Function | Who can call | Guard |
+|---|---|---|
+| `initialize` | Anyone (once) | Panics if `StorageKey::Admin` already set |
+
+**No admin transfer mechanism. Admin is immutable post-init.**
+
+---
+
+## 3. Governance Proposal Escalation Path — Analysis
+
+`ProposalType::ContractUpgrade` stores a `(contract_name, new_hash)` pair in `GovernanceUpgrades` map. It does **not** call `env.deployer()` or write `StorageKey::Admin`. The upgrade hash is informational only — actual Wasm replacement requires a separate privileged host call that is not wired to any proposal executor.
+
+`ProposalType::ParameterChange` writes to `GovernanceParameters` (a `Map<String, i128>`). The key is a plain string — it cannot alias `StorageKey::Admin` (which is a `contracttype` enum variant, not a string).
+
+`ProposalType::TreasurySpend` calls `add_balance` on a recipient — this writes `StorageKey::Balances`, not `StorageKey::Admin`.
+
+**Conclusion: No governance proposal type can set or overwrite the admin key.**
+
+---
+
+## 4. Timelock Bypass Analysis
+
+`emergency_execute` in `timelock.rs` is restricted to `ActionType::EmergencyPause` only — it panics with `InvalidCommitteeAction` for any other action type. It cannot execute a `ContractUpgrade` or `ParameterChange` without the timelock delay.
+
+`execute_queued_action` enforces `execution_available` timestamp before executing. The guardian can only cancel actions, not execute them early (except `EmergencyPause`).
+
+**Conclusion: No timelock bypass path exists for admin escalation.**
+
+---
+
+## 5. Guardian Role Analysis
+
+The guardian role (present in `auto_trade`, `signal_registry`, `oracle`) can:
+- Pause categories (emergency response)
+- Cancel queued timelock actions (governance only)
+
+The guardian **cannot**:
+- Set or change the admin key
+- Propose or accept admin transfers
+- Execute proposals
+
+Guardian is set and revoked exclusively by the current admin (`require_admin` guard on both `set_guardian` and `revoke_guardian`).
+
+---
+
+## 6. Multi-Sig Analysis (`signal_registry`)
+
+`enable_multisig` requires existing admin auth. Once enabled, `require_admin` checks `is_multisig_signer`. Adding/removing signers also requires `require_admin`. A signer cannot unilaterally escalate to sole admin — the admin key itself is only changed via the two-step transfer flow.
+
+---
+
+## 7. Mitigations in Place
+
+| Risk | Mitigation |
+|---|---|
+| Re-initialization | All contracts guard `init_admin` / `initialize` with an "already set" check |
+| Unauthorized admin transfer | Two-step transfer: propose (admin only) → accept (pending admin only) with 48h expiry |
+| Governance proposal sets admin | `execute_proposal_action` never writes the admin storage key |
+| Timelock bypass | `emergency_execute` restricted to `EmergencyPause` action type only |
+| Guardian escalation | Guardian cannot propose/accept admin transfers |
+
+---
+
+## 8. Residual Risk
+
+- `governance` has no admin rotation mechanism. If the admin key is compromised, governance admin is permanently lost. **Recommendation:** add a two-step admin transfer to governance (low priority, no current escalation path).
+- `trade_executor` has no admin rotation. Same recommendation.

--- a/stellar-swipe/contracts/auto_trade/src/test_admin_transfer.rs
+++ b/stellar-swipe/contracts/auto_trade/src/test_admin_transfer.rs
@@ -119,3 +119,116 @@ fn test_transfer_expiry_auto_trade() {
     let result = client.try_accept_admin_transfer(&new_admin);
     assert!(result.is_err(), "Cannot accept expired transfer");
 }
+
+// ── Issue #267: Admin Privilege Escalation Path Tests ────────────────────────
+
+/// Non-admin cannot propose an admin transfer.
+#[test]
+fn test_non_admin_cannot_propose_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AutoTradeContract);
+    let client = AutoTradeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let victim = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let result = client.try_propose_admin_transfer(&attacker, &victim);
+    assert!(result.is_err(), "Non-admin must not be able to propose admin transfer");
+}
+
+/// Guardian cannot propose or accept an admin transfer.
+#[test]
+fn test_guardian_cannot_escalate_to_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AutoTradeContract);
+    let client = AutoTradeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let guardian = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.set_guardian(&admin, &guardian);
+
+    // Guardian cannot propose a transfer
+    let propose_result = client.try_propose_admin_transfer(&guardian, &guardian);
+    assert!(propose_result.is_err(), "Guardian must not propose admin transfer");
+
+    // Guardian cannot accept a transfer that was never proposed
+    let accept_result = client.try_accept_admin_transfer(&guardian);
+    assert!(accept_result.is_err(), "Guardian must not accept non-existent transfer");
+}
+
+/// Double-initialization is blocked — admin cannot be overwritten via re-init.
+#[test]
+fn test_reinitialize_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AutoTradeContract);
+    let client = AutoTradeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Second initialize must panic (already initialized guard)
+    let result = std::panic::catch_unwind(|| {
+        let env2 = env.clone();
+        let client2 = AutoTradeContractClient::new(&env2, &contract_id);
+        client2.initialize(&attacker);
+    });
+    assert!(result.is_err(), "Re-initialization must be blocked");
+}
+
+/// Pending admin cannot use admin privileges before accepting.
+#[test]
+fn test_pending_admin_has_no_privileges_before_accept() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AutoTradeContract);
+    let client = AutoTradeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.propose_admin_transfer(&admin, &new_admin);
+
+    // Pending admin cannot set guardian before accepting
+    let result = client.try_set_guardian(&new_admin, &Address::generate(&env));
+    assert!(result.is_err(), "Pending admin must not have admin privileges before accepting");
+
+    // Pending admin cannot cancel the transfer
+    let cancel_result = client.try_cancel_admin_transfer(&new_admin);
+    assert!(cancel_result.is_err(), "Pending admin must not cancel transfer");
+}
+
+/// After a completed transfer, the old admin loses all privileges.
+#[test]
+fn test_old_admin_loses_privileges_after_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AutoTradeContract);
+    let client = AutoTradeContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.propose_admin_transfer(&admin, &new_admin);
+    client.accept_admin_transfer(&new_admin);
+
+    // Old admin can no longer set guardian
+    let result = client.try_set_guardian(&admin, &Address::generate(&env));
+    assert!(result.is_err(), "Old admin must lose privileges after transfer");
+}


### PR DESCRIPTION
- Add docs/security/privilege_escalation_analysis.md covering all five contracts
- Map every function that writes the Admin storage key
- Verify governance proposals cannot set admin key
- Verify timelock emergency_execute is restricted to EmergencyPause only
- Add unit tests: non-admin cannot propose transfer, guardian cannot escalate, re-init blocked, pending admin has no privileges, old admin loses privileges closes #267