### PR TITLE
docs(contracts): add rustdoc to all public contract entry points (#277)

### DIFF
--- a/stellar-swipe/contracts/auto_trade/src/lib.rs
+++ b/stellar-swipe/contracts/auto_trade/src/lib.rs
@@ -97,7 +97,16 @@ pub struct AutoTradeContract;
 
 #[contractimpl]
 impl AutoTradeContract {
-    /// Initialize the contract with an admin
+    /// # Summary
+    /// One-time contract initialization. Sets the admin address and initializes
+    /// pause states and circuit breaker statistics.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `admin`: Address that will hold admin privileges.
+    ///
+    /// # Returns
+    /// Nothing. Panics if already initialized.
     pub fn initialize(env: Env, admin: Address) {
         admin::init_admin(&env, admin);
     }
@@ -240,7 +249,37 @@ impl AutoTradeContract {
         admin::set_cb_config(&env, &caller, config)
     }
 
-    /// Execute a trade on behalf of a user based on a signal
+    /// # Summary
+    /// Execute a trade on behalf of a user based on a signal. Performs oracle
+    /// circuit-breaker check, risk validation (stop-loss, position limits,
+    /// daily trade limit), smart routing, and records the trade.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `user`: Address of the trader (must authorize).
+    /// - `signal_id`: ID of the signal to trade on.
+    /// - `order_type`: [`OrderType::Market`] or [`OrderType::Limit`].
+    /// - `amount`: Amount to trade (must be > 0).
+    ///
+    /// # Returns
+    /// [`TradeResult`] containing the executed trade details.
+    ///
+    /// # Errors
+    /// - [`AutoTradeError::TradingPaused`] — trading category is paused.
+    /// - [`AutoTradeError::OracleUnavailable`] — oracle circuit breaker is tripped.
+    /// - [`AutoTradeError::InvalidAmount`] — amount <= 0.
+    /// - [`AutoTradeError::SignalNotFound`] — signal_id does not exist.
+    /// - [`AutoTradeError::SignalExpired`] — signal has expired.
+    /// - [`AutoTradeError::Unauthorized`] — user is not authorized to trade.
+    /// - [`AutoTradeError::InsufficientBalance`] — user has insufficient balance.
+    /// - [`AutoTradeError::PositionLimitExceeded`] — trade would exceed position limit.
+    /// - [`AutoTradeError::DailyTradeLimitExceeded`] — daily trade limit reached.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let result = client.execute_trade(&user, &signal_id, &OrderType::Market, &1_000_0000000i128);
+    /// assert_eq!(result.trade.status, TradeStatus::Filled);
+    /// ```
     pub fn execute_trade(
         env: Env,
         user: Address,

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -32,6 +32,18 @@ pub struct FeeCollector;
 
 #[contractimpl]
 impl FeeCollector {
+    /// # Summary
+    /// One-time contract initialization. Sets the admin address.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `admin`: Address that will hold admin privileges.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`ContractError::AlreadyInitialized`] if the contract has already been initialized.
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
         admin.require_auth();
         if is_initialized(&env) {
@@ -42,6 +54,18 @@ impl FeeCollector {
         Ok(())
     }
 
+    /// # Summary
+    /// Set the oracle contract address used for price-based fee calculations.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `oracle_contract`: Address of the oracle contract.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
     pub fn set_oracle_contract(env: Env, oracle_contract: Address) -> Result<(), ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
@@ -52,6 +76,19 @@ impl FeeCollector {
         Ok(())
     }
 
+    /// # Summary
+    /// Returns the effective fee rate in basis points for a specific user,
+    /// accounting for any volume-based rebates.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `user`: Address of the trader.
+    ///
+    /// # Returns
+    /// Fee rate in basis points (e.g. `30` = 0.30%).
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
     pub fn fee_rate_for_user(env: Env, user: Address) -> Result<u32, ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
@@ -59,6 +96,19 @@ impl FeeCollector {
         Ok(rebates::get_fee_rate_for_user(&env, &user))
     }
 
+    /// # Summary
+    /// Returns the 30-day rolling trade volume in USD for a user.
+    /// Used to determine rebate tier eligibility.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `user`: Address of the trader.
+    ///
+    /// # Returns
+    /// Volume in USD (scaled by asset decimals).
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
     pub fn monthly_trade_volume(env: Env, user: Address) -> Result<i128, ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
@@ -66,6 +116,18 @@ impl FeeCollector {
         Ok(rebates::get_active_volume_usd(&env, &user))
     }
 
+    /// # Summary
+    /// Returns the current treasury balance for a given token.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `token`: SEP-41 token contract address.
+    ///
+    /// # Returns
+    /// Balance in the token's native units.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
     pub fn treasury_balance(env: Env, token: Address) -> Result<i128, ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
@@ -73,6 +135,23 @@ impl FeeCollector {
         Ok(get_treasury_balance(&env, &token))
     }
 
+    /// # Summary
+    /// Queue a treasury withdrawal. The withdrawal becomes executable after a
+    /// 24-hour timelock. Admin auth required.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `recipient`: Address that will receive the tokens.
+    /// - `token`: SEP-41 token contract address.
+    /// - `amount`: Amount to withdraw (must be > 0 and <= treasury balance).
+    ///
+    /// # Returns
+    /// `Ok(())` on success. Emits a [`WithdrawalQueued`] event.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — contract not initialized.
+    /// - [`ContractError::InvalidAmount`] — amount <= 0.
+    /// - [`ContractError::InsufficientTreasuryBalance`] — amount exceeds balance.
     pub fn queue_withdrawal(
         env: Env,
         recipient: Address,
@@ -110,6 +189,24 @@ impl FeeCollector {
         Ok(())
     }
 
+    /// # Summary
+    /// Execute a previously queued treasury withdrawal after the 24-hour timelock.
+    /// Admin auth required. Parameters must exactly match the queued withdrawal.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `recipient`: Must match the queued recipient.
+    /// - `token`: Must match the queued token.
+    /// - `amount`: Must match the queued amount.
+    ///
+    /// # Returns
+    /// `Ok(())` on success. Transfers tokens and emits [`TreasuryWithdrawal`].
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — contract not initialized.
+    /// - [`ContractError::WithdrawalNotQueued`] — no matching queued withdrawal.
+    /// - [`ContractError::TimelockNotElapsed`] — 24-hour timelock has not passed.
+    /// - [`ContractError::InsufficientTreasuryBalance`] — balance changed since queuing.
     pub fn withdraw_treasury_fees(
         env: Env,
         recipient: Address,
@@ -220,6 +317,26 @@ impl FeeCollector {
         Ok(())
     }
 
+    /// # Summary
+    /// Collect a fee from a trader for a completed trade. Transfers the fee
+    /// from the trader to this contract, burns the configured burn slice,
+    /// and credits the remainder to the treasury.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `trader`: Address of the trader (must authorize).
+    /// - `token`: SEP-41 token used to pay the fee.
+    /// - `trade_amount`: Gross trade amount (fee is calculated as a percentage).
+    /// - `trade_asset`: Asset pair traded (used for volume tracking).
+    ///
+    /// # Returns
+    /// The total fee amount collected (before burn).
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — contract not initialized.
+    /// - [`ContractError::InvalidAmount`] — trade_amount <= 0.
+    /// - [`ContractError::FeeRoundedToZero`] — fee rounds to zero at current rate.
+    /// - [`ContractError::ArithmeticOverflow`] — overflow in fee calculation.
     pub fn collect_fee(
         env: Env,
         trader: Address,

--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -115,6 +115,26 @@ pub enum StorageKey {
 #[allow(clippy::too_many_arguments)]
 #[contractimpl]
 impl GovernanceContract {
+    /// # Summary
+    /// One-time governance contract initialization. Sets admin, token metadata,
+    /// initial token distribution, and all governance subsystem state.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `admin`: Address that will hold admin privileges (must authorize).
+    /// - `name`: Token name (e.g. `"StellarSwipe Gov"`).
+    /// - `symbol`: Token symbol (e.g. `"SSG"`).
+    /// - `decimals`: Token decimal places.
+    /// - `total_supply`: Total token supply (must be > 0).
+    /// - `recipients`: Addresses for each distribution category.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::AlreadyInitialized`] — contract already initialized.
+    /// - [`GovernanceError::InvalidSupply`] — total_supply <= 0.
+    /// - [`GovernanceError::InvalidMetadata`] — name or symbol is empty.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -311,6 +331,26 @@ impl GovernanceContract {
         proposals::configure_governance(&env, &admin, config)
     }
 
+    /// # Summary
+    /// Create a new governance proposal. Proposer must have staked voting power
+    /// >= `min_proposal_threshold`.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `proposer`: Address creating the proposal (must authorize).
+    /// - `proposal_type`: Type and parameters of the proposal.
+    /// - `title`: Short human-readable title.
+    /// - `description`: Full proposal description.
+    /// - `execution_payload`: Arbitrary bytes attached to the proposal (e.g. migration notes hash).
+    ///
+    /// # Returns
+    /// The new proposal ID.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] — contract not initialized.
+    /// - [`GovernanceError::NoVotingPower`] — proposer has insufficient staked balance.
+    /// - [`GovernanceError::InvalidProposal`] — title/description empty or proposal validation failed.
+    /// - [`GovernanceError::BudgetExceeded`] — TreasurySpend amount exceeds 10% of treasury.
     pub fn create_proposal(
         env: Env,
         proposer: Address,
@@ -342,6 +382,26 @@ impl GovernanceContract {
         Ok(get_all_proposals(&env))
     }
 
+    /// # Summary
+    /// Cast a vote on an active proposal. Voter must have staked voting power > 0.
+    /// Each address may vote only once per proposal.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `proposal_id`: ID of the proposal to vote on.
+    /// - `voter`: Address casting the vote (must authorize).
+    /// - `vote_type`: [`GovernanceVoteType::For`], [`GovernanceVoteType::Against`], or [`GovernanceVoteType::Abstain`].
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] — contract not initialized.
+    /// - [`GovernanceError::ProposalNotFound`] — proposal_id does not exist.
+    /// - [`GovernanceError::VotingNotStarted`] — voting period has not begun.
+    /// - [`GovernanceError::VotingEnded`] — voting period has closed.
+    /// - [`GovernanceError::AlreadyVoted`] — voter has already cast a vote.
+    /// - [`GovernanceError::NoVotingPower`] — voter has no staked balance.
     pub fn cast_vote(
         env: Env,
         proposal_id: u64,

--- a/stellar-swipe/contracts/oracle/src/lib.rs
+++ b/stellar-swipe/contracts/oracle/src/lib.rs
@@ -39,7 +39,16 @@ pub struct OracleContract;
 
 #[contractimpl]
 impl OracleContract {
-    /// Initialize oracle with base currency
+    /// # Summary
+    /// One-time oracle initialization. Sets the admin and base currency.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `admin`: Address that will hold admin privileges.
+    /// - `base_currency`: The base asset all prices are quoted against.
+    ///
+    /// # Returns
+    /// Nothing. Panics if already initialized.
     pub fn initialize(env: Env, admin: Address, base_currency: Asset) {
         if env.storage().instance().has(&StorageKey::Admin) {
             panic!("already initialized");
@@ -68,7 +77,21 @@ impl OracleContract {
         }
     }
 
-    /// Set price for an asset pair
+    /// # Summary
+    /// Set price for an asset pair. Stores the price, updates history,
+    /// and triggers staleness metadata update.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `pair`: The asset pair to price.
+    /// - `price`: Price value (must be > 0).
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`OracleError::CircuitBreakerTripped`] — oracle is paused.
+    /// - [`OracleError::InvalidAsset`] — price <= 0.
     pub fn set_price(env: Env, pair: AssetPair, price: i128) -> Result<(), OracleError> {
         if admin::is_paused(&env, String::from_str(&env, CAT_ALL)) {
             return Err(OracleError::CircuitBreakerTripped);
@@ -493,7 +516,21 @@ impl OracleContract {
             .set(&StorageKey::Oracles, &new_oracles);
     }
 
-    /// returns aggregated price
+    /// # Summary
+    /// Get the aggregated price for an asset pair. Applies median aggregation
+    /// across all fresh price sources (staleness TTL: 300s).
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `pair`: The asset pair to query.
+    ///
+    /// # Returns
+    /// The median aggregated price.
+    ///
+    /// # Errors
+    /// - [`OracleError::PriceNotFound`] — no price data for this pair.
+    /// - [`OracleError::StalePrice`] — all price sources are stale (> 300s old).
+    /// - [`OracleError::UnreliablePrice`] — sources disagree by > 10%.
     pub fn get_price(env: Env, pair: AssetPair) -> Result<i128, OracleError> {
         let (price, _) = Self::get_price_with_confidence(env, pair)?;
         Ok(price)

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -115,7 +115,18 @@ impl SignalRegistry {
        INITIALIZATION
     ========================== */
 
-    /// Initialize contract with admin
+    /// # Summary
+    /// One-time contract initialization. Sets the admin address.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `admin`: Address that will hold admin privileges.
+    ///
+    /// # Returns
+    /// `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - [`AdminError::AlreadyInitialized`] if the contract has already been initialized.
     pub fn initialize(env: Env, admin: Address) -> Result<(), AdminError> {
         init_admin(&env, admin)
     }
@@ -530,6 +541,30 @@ impl SignalRegistry {
        PUBLIC API
     ========================== */
 
+    /// # Summary
+    /// Create a new trading signal. The provider must authorize the call.
+    /// Signals are rate-limited and subject to pause state checks.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `provider`: Address of the signal provider (must authorize).
+    /// - `asset_pair`: Asset pair string (e.g. `"XLM/USDC"`).
+    /// - `action`: [`SignalAction::Buy`] or [`SignalAction::Sell`].
+    /// - `price`: Target price for the signal (must be > 0).
+    /// - `rationale`: Human-readable rationale for the signal.
+    /// - `expiry`: Unix timestamp when the signal expires (must be in the future, max 30 days).
+    /// - `category`: Signal category (e.g. SWING, SCALP, PREMIUM).
+    /// - `tags`: Up to 10 tags for discoverability.
+    /// - `risk_level`: Risk classification (Low, Medium, High).
+    ///
+    /// # Returns
+    /// The new signal ID.
+    ///
+    /// # Errors
+    /// - [`AdminError::TradingPaused`] — signals category is paused.
+    /// - [`AdminError::RateLimitExceeded`] — provider has exceeded submission rate limit.
+    /// - [`AdminError::InvalidAssetPair`] — asset_pair format is invalid.
+    /// - Panics if expiry is in the past or exceeds 30 days.
     pub fn create_signal(
         env: Env,
         provider: Address,

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -51,7 +51,15 @@ fn effective_estimated_fee(env: &Env) -> i128 {
 #[contractimpl]
 impl TradeExecutorContract {
 
-    /// One-time init; stores admin who may configure the contract.
+    /// # Summary
+    /// One-time contract initialization. Stores the admin address.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `admin`: Address that will hold admin privileges.
+    ///
+    /// # Returns
+    /// Nothing. Panics if already initialized.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&StorageKey::Admin) {
             panic!("already initialized");
@@ -59,7 +67,16 @@ impl TradeExecutorContract {
         env.storage().instance().set(&StorageKey::Admin, &admin);
     }
 
-    /// Configure the portfolio contract used for position validation and copy-trade recording.
+    /// # Summary
+    /// Configure the portfolio contract used for position validation and
+    /// copy-trade recording. Admin auth required.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `portfolio`: Address of the UserPortfolio contract.
+    ///
+    /// # Returns
+    /// Nothing. Panics if not initialized.
     pub fn set_user_portfolio(env: Env, portfolio: Address) {
         let admin: Address = env
             .storage()
@@ -298,6 +315,29 @@ impl TradeExecutorContract {
         env.storage().instance().get(&StorageKey::SdexRouter)
     }
 
+    /// # Summary
+    /// Execute a swap via the configured SDEX router with an explicit minimum
+    /// received amount. Enforces slippage at the balance-delta level.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `from_token`: SEP-41 token to sell.
+    /// - `to_token`: SEP-41 token to buy.
+    /// - `amount`: Amount of `from_token` to sell (must be > 0).
+    /// - `min_received`: Minimum acceptable amount of `to_token` (must be >= 0).
+    ///
+    /// # Returns
+    /// Actual amount of `to_token` received.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — SDEX router not configured.
+    /// - [`ContractError::InvalidAmount`] — amount <= 0 or min_received < 0.
+    /// - [`ContractError::SlippageExceeded`] — actual received < min_received.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// client.swap(&xlm_token, &usdc_token, &1_000_0000000i128, &990_0000000i128);
+    /// ```
     pub fn swap(
         env: Env,
         from_token: Address,
@@ -313,6 +353,25 @@ impl TradeExecutorContract {
         execute_sdex_swap(&env, &router, &from_token, &to_token, amount, min_received)
     }
 
+    /// # Summary
+    /// Execute a swap with automatic slippage protection. Computes
+    /// `min_received = amount * (10_000 - max_slippage_bps) / 10_000`
+    /// and delegates to [`Self::swap`].
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `from_token`: SEP-41 token to sell.
+    /// - `to_token`: SEP-41 token to buy.
+    /// - `amount`: Amount of `from_token` to sell.
+    /// - `max_slippage_bps`: Maximum acceptable slippage in basis points (e.g. `100` = 1%).
+    ///
+    /// # Returns
+    /// Actual amount of `to_token` received.
+    ///
+    /// # Errors
+    /// - [`ContractError::InvalidAmount`] — amount <= 0 or slippage calculation overflows.
+    /// - [`ContractError::NotInitialized`] — SDEX router not configured.
+    /// - [`ContractError::SlippageExceeded`] — actual received < computed min_received.
     pub fn swap_with_slippage(
         env: Env,
         from_token: Address,


### PR DESCRIPTION
Each documented function includes:
- # Summary: what the function does
- # Parameters: all parameters with types and descriptions
- # Returns: return value description
- # Errors: all error variants that can be produced
- # Example: where applicable (execute_trade, swap)

Contracts documented:
- fee_collector: initialize, set_oracle_contract, fee_rate_for_user, monthly_trade_volume, treasury_balance, queue_withdrawal, withdraw_treasury_fees, collect_fee, claim_fees
- trade_executor: initialize, set_user_portfolio, swap, swap_with_slippage
- auto_trade: initialize, execute_trade
- oracle: initialize, set_price, get_price
- governance: initialize, create_proposal, cast_vote
- signal_registry: initialize, create_signal  closes #277