### PR TITLE
Blocked: oracle whitelist for trade executor

### DIFF
--- a/docs/issue-253-blocker.md
+++ b/docs/issue-253-blocker.md
@@ -1,0 +1,18 @@
+# Issue #253 Blocker
+
+Issue #253 requests an oracle whitelist in `contracts/trade_executor/src/oracle.rs`.
+
+This branch cannot safely implement that change on the current `main` base because:
+
+- `contracts/trade_executor/src/oracle.rs` does not exist.
+- `contracts/trade_executor/src/lib.rs` contains unresolved branch-marker text and duplicate/incomplete functions, so the contract does not parse.
+- `contracts/trade_executor/src/errors.rs` also contains unresolved branch-marker text and conflicting error-code mappings.
+- Workspace formatting is blocked by additional unrelated parse failures in `auto_trade` and `bridge`.
+
+Required prerequisite:
+
+1. Repair `trade_executor` so it has a valid module layout and compiles.
+2. Decide whether #253 belongs in `trade_executor` or in the existing `auto_trade` oracle module, which already has whitelist-style code.
+3. Reapply #253 against the repaired contract with tests for whitelisted update, unauthorized update, add oracle, remove oracle, and cannot remove last oracle.
+
+This PR intentionally does not include `closes #253` because it does not implement the requested behavior.


### PR DESCRIPTION
Refs #253

## Status
This is a blocker PR, not an implementation PR. It intentionally does not include closes #253 because the requested oracle whitelist is not implemented.

## Why blocked
- The requested file contracts/trade_executor/src/oracle.rs does not exist on main.
- contracts/trade_executor/src/lib.rs contains unresolved branch-marker text and duplicate/incomplete functions, so trade_executor does not parse.
- contracts/trade_executor/src/errors.rs contains unresolved branch-marker text and conflicting error-code mappings.
- Workspace cargo fmt is also blocked by unrelated malformed/conflicted files on main.

## Included change
- Adds docs/issue-253-blocker.md with the exact prerequisites needed before #253 can be implemented safely.

## Validation
- cargo fmt attempted and failed before formatting because contracts/fee_collector/Cargo.toml contains stray branch-marker text on main.

## Next step
Repair trade_executor module layout and error definitions first, then implement #253 against the repaired contract with whitelist storage, admin add/remove, update authorization, events, and tests.