### PR TITLE
feat: security audit, P&L tests & push notification events

### DIFF
--- a/docs/security/reentrancy_analysis.md
+++ b/docs/security/reentrancy_analysis.md
@@ -1,0 +1,140 @@
+# Reentrancy Analysis
+
+**Issue:** #264  
+**Status:** Mitigated  
+**Last updated:** 2026-04-26  
+**Scope:** `execute_copy_trade` (trade_executor) and `withdraw_stake` (stake_vault)
+
+---
+
+## Background
+
+Soroban executes each transaction atomically and does not support async callbacks in the
+EVM sense. However, reentrancy is still theoretically possible when a contract makes a
+cross-contract call to a token or external contract that itself calls back into the
+originating contract before the first invocation returns. The two highest-value targets
+are functions that move tokens or update balances.
+
+---
+
+## 1. `execute_copy_trade` — `trade_executor`
+
+**File:** `contracts/trade_executor/src/lib.rs`
+
+### External call map
+
+| Step | Callee | Call type | Reentrancy vector? |
+|---|---|---|---|
+| Balance check | SEP-41 token SAC (`token.balance(user)`) | Read-only cross-contract | No — read-only, no state change |
+| Position validate + record | `UserPortfolio::validate_and_record` | Cross-contract write | Theoretical: a malicious portfolio contract could call back |
+| Reentrancy lock set | Temporary storage | Local | N/A |
+
+### Analysis
+
+The function sets `EXECUTION_LOCK` (`"ExecLock"`) in temporary storage **before** any
+cross-contract call. If a malicious `UserPortfolio` contract called back into
+`execute_copy_trade` for the same user, the lock check at the top of the function would
+detect `true` and return `ContractError::ReentrancyDetected` immediately.
+
+The lock is cleared on both the success path and all error paths (including the
+`resolve_trade_amount` and `check_user_balance` error branches).
+
+### Verdict: MITIGATED ✓
+
+The guard was already present prior to this audit (added in Issue #57). No changes
+required.
+
+---
+
+## 2. `withdraw_stake` — `stake_vault`
+
+**File:** `contracts/stake_vault/src/lib.rs`
+
+### External call map
+
+| Step | Callee | Call type | Reentrancy vector? |
+|---|---|---|---|
+| Load stake record | Persistent storage | Local | No |
+| Zero balance in storage | Persistent storage | Local | No |
+| Token transfer | SEP-41 token SAC (`token.transfer(vault → staker, amount)`) | Cross-contract write | **Yes** — a malicious token could call back before the function returns |
+
+### Analysis
+
+`withdraw_stake` performs a token transfer as its final step. A malicious SEP-41 token
+contract could invoke `withdraw_stake` again during the `transfer` callback. Without a
+guard, the second call would find the balance already zeroed (checks-effects-interactions
+ordering is applied), so a double-spend is not possible in the current implementation.
+However, the guard is added as defence-in-depth for two reasons:
+
+1. Future refactors that reorder the balance-zero and transfer steps would inherit
+   protection automatically.
+2. The lock prevents any unexpected state mutation from a reentrant call, regardless of
+   ordering.
+
+### Guard implementation
+
+```rust
+const EXECUTION_LOCK: &str = "WithdrawLock";
+
+let lock_key = Symbol::new(&env, EXECUTION_LOCK);
+if env.storage().temporary().get::<_, bool>(&lock_key).unwrap_or(false) {
+    return Err(StakeVaultError::ReentrancyDetected);
+}
+env.storage().temporary().set(&lock_key, &true);
+
+let result = Self::do_withdraw(&env, &staker);
+
+env.storage().temporary().remove(&lock_key);
+result
+```
+
+The lock uses **temporary storage** (same pattern as `execute_copy_trade`) so it is
+automatically scoped to the current transaction and cannot persist across ledgers. It is
+explicitly removed on both success and error paths.
+
+### Verdict: MITIGATED ✓ (guard added in this PR)
+
+---
+
+## Guard Pattern Summary
+
+Both guarded functions use the same pattern:
+
+1. **Check:** read the lock key from temporary storage; return `ReentrancyDetected` if set.
+2. **Set:** write `true` to the lock key before any external call.
+3. **Clear:** remove the lock key on all exit paths (success and error).
+
+Temporary storage is used rather than instance/persistent storage because:
+- It is automatically scoped to the current transaction.
+- It cannot be left set across ledger boundaries by a failed transaction.
+- It does not consume persistent storage quota.
+
+| Function | Contract | Lock key | Added |
+|---|---|---|---|
+| `execute_copy_trade` | `trade_executor` | `"ExecLock"` | Issue #57 |
+| `withdraw_stake` | `stake_vault` | `"WithdrawLock"` | Issue #264 |
+
+---
+
+## Unit Tests
+
+Reentrancy tests are co-located with each contract:
+
+| Test | File | What it verifies |
+|---|---|---|
+| `reentrant_call_returns_reentrancy_detected` | `trade_executor/src/test.rs` | `ReentrantPortfolio` calls back into `execute_copy_trade`; second call returns `ReentrancyDetected` |
+| `lock_cleared_after_successful_execution` | `trade_executor/src/test.rs` | Two sequential calls both succeed (lock is cleared between them) |
+| `reentrant_withdraw_is_blocked` | `stake_vault/src/tests.rs` | `ReentrantToken::transfer` calls back into `withdraw_stake`; second call returns `ReentrancyDetected` |
+| `lock_cleared_after_successful_withdrawal` | `stake_vault/src/tests.rs` | Two sequential withdrawals both succeed |
+| `lock_cleared_after_failed_withdrawal` | `stake_vault/src/tests.rs` | Lock is absent after a failed (NoStake) withdrawal |
+
+---
+
+## Residual Risk
+
+- `execute_copy_trade` does not perform a token transfer itself — it validates balance and
+  records the position. If a direct transfer is added in the future, the existing guard
+  covers it.
+- `withdraw_stake` applies checks-effects-interactions ordering (balance zeroed before
+  transfer), so even without the guard a double-spend is not possible in the current
+  implementation. The guard provides defence-in-depth.

--- a/docs/security/storage_key_analysis.md
+++ b/docs/security/storage_key_analysis.md
@@ -1,0 +1,696 @@
+# Storage Key Collision Analysis
+
+**Issue:** #265  
+**Status:** No collision found  
+**Last updated:** 2026-04-25
+
+---
+
+## Why Collisions Cannot Occur
+
+All storage keys in this codebase are defined with the `#[contracttype]` macro on Rust enums.
+Soroban serialises a `#[contracttype]` enum value as an XDR `ScVal::Map` containing the variant
+name as a symbol key. Because the variant name is always part of the serialised bytes, two
+variants with the same payload but different names produce different byte sequences.
+
+For tuple variants that accept an `Address` (or other data), the serialised form is:
+
+```
+{ "<VariantName>": <payload> }
+```
+
+Two addresses that differ in even one byte produce a different `<payload>`, so
+`Variant(addr_a) ≠ Variant(addr_b)` whenever `addr_a ≠ addr_b`.
+
+Cross-enum collision is impossible because each enum is a distinct Rust type; Soroban
+encodes the type name as part of the outer map key, so `EnumA::Foo` and `EnumB::Foo`
+serialise differently.
+
+---
+
+## Key Inventory by Contract
+
+### 1. `fee_collector` — `StorageKey`
+
+File: `contracts/fee_collector/src/storage.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `Initialized` | — | instance |
+| `OracleContract` | — | instance |
+| `FeeRate` | — | instance |
+| `BurnRate` | — | instance |
+| `QueuedWithdrawal` | — | instance |
+| `TreasuryBalance(Address)` | token address | persistent |
+| `ProviderPendingFees(Address, Address)` | (provider, token) | persistent |
+| `MonthlyTradeVolume(Address)` | user address | persistent |
+
+No two variants share the same name. The two-address tuple `ProviderPendingFees(p, t)` is
+distinct from `TreasuryBalance(t)` because the variant names differ and the tuple arity
+differs.
+
+---
+
+### 2. `user_portfolio` — `DataKey`
+
+File: `contracts/user_portfolio/src/storage.rs`  
+Extended by: `badges.rs`, `subscriptions.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Initialized` | — | instance |
+| `Admin` | — | instance |
+| `Oracle` | — | instance |
+| `OracleAssetPair` | — | instance |
+| `NextPositionId` | — | instance |
+| `TradeExecutor` | — | instance |
+| `EarlyAdopterCap` | — | instance |
+| `TotalUsersFirstOpen` | — | instance |
+| `Position(u64)` | position id | persistent |
+| `UserPositions(Address)` | user address | persistent |
+| `UserBadges(Address)` | user address | persistent |
+| `UserClosedTradeCount(Address)` | user address | persistent |
+| `UserProfitStreak(Address)` | user address | persistent |
+| `LeaderboardRank(Address)` | user address | persistent |
+
+`UserPositions`, `UserBadges`, `UserClosedTradeCount`, `UserProfitStreak`, and
+`LeaderboardRank` all take an `Address` but have distinct variant names — no collision.
+
+**`user_portfolio` — `StorageKey`** (subscriptions module)
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Subscription(Address, Address)` | (user, provider) | persistent |
+| `ProviderTerms(Address)` | provider address | persistent |
+
+`Subscription(user, provider)` and `Subscription(provider, user)` are different values
+because the tuple is ordered. A user cannot accidentally collide with a provider's terms
+entry because the variant names differ.
+
+---
+
+### 3. `oracle` — `StorageKey` (storage.rs)
+
+File: `contracts/oracle/src/storage.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `BaseCurrency` | — | persistent |
+| `Price(AssetPair)` | asset pair | persistent |
+| `PriceTimestamp(AssetPair)` | asset pair | persistent |
+| `AvailablePairs` | — | persistent |
+| `ConversionCache(Asset, Asset)` | (from, to) assets | temporary |
+
+`Price(pair)` and `PriceTimestamp(pair)` share the same payload but have different variant
+names — no collision.
+
+**`oracle` — `StorageKey`** (types.rs — consensus/reputation layer)
+
+File: `contracts/oracle/src/types.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `Guardian` | — | instance |
+| `PriceMap(AssetPair)` | asset pair | persistent |
+| `OracleStats` | — | instance |
+| `Oracles` | — | instance |
+| `PriceSubmissions` | — | instance |
+| `ConsensusPrice` | — | instance |
+| `PauseStates` | — | instance |
+| `OracleWeight(Address)` | oracle address | persistent |
+| `PendingAdmin` | — | instance |
+| `PendingAdminExpiry` | — | instance |
+
+These two `StorageKey` enums live in different modules (`storage.rs` vs `types.rs`) and are
+used in different call sites. They are distinct Rust types; Soroban encodes the type name,
+so `storage::StorageKey::Price(p)` and `types::StorageKey::PriceMap(p)` cannot collide.
+
+---
+
+### 4. `auto_trade` — `DataKey`
+
+File: `contracts/auto_trade/src/storage.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Trades(Address, u64)` | (user, trade_id) | persistent |
+| `Signal(u64)` | signal id | persistent |
+
+**`auto_trade` — `AdminStorageKey`**
+
+File: `contracts/auto_trade/src/admin.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `Guardian` | — | instance |
+| `OracleAddress` | — | instance |
+| `OracleCircuitBreaker` | — | instance |
+| `OracleWhitelist(u32)` | asset_pair id | instance |
+| `PauseStates` | — | instance |
+| `CircuitBreakerStats` | — | instance |
+| `CircuitBreakerConfig` | — | instance |
+| `PendingAdmin` | — | instance |
+| `PendingAdminExpiry` | — | instance |
+
+**`auto_trade` — `AuthKey`**
+
+File: `contracts/auto_trade/src/auth.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Authorization(Address)` | user address | persistent |
+
+**`auto_trade` — `PositionKey`**
+
+File: `contracts/auto_trade/src/positions.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Position(BytesN<32>)` | trade_id hash | persistent |
+| `UserPositions(Address)` | user address | persistent |
+| `PositionNonce` | — | persistent |
+
+**`auto_trade` — `ExitStrategyKey`**
+
+File: `contracts/auto_trade/src/exit_strategy.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Strategy(u64)` | strategy_id | persistent |
+| `NextId` | — | persistent |
+| `UserStrategies(Address)` | user address | persistent |
+
+**`auto_trade` — `HistoryDataKey`**
+
+File: `contracts/auto_trade/src/history.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `UserTradeCount(Address)` | user address | persistent |
+| `Trade(Address, u64)` | (user, trade_index) | persistent |
+
+`UserTradeCount(addr_a)` and `UserTradeCount(addr_b)` are distinct. `Trade(addr_a, n)` and
+`Trade(addr_b, n)` are distinct because the address bytes differ.
+
+**`auto_trade` — `ReferralKey`**
+
+File: `contracts/auto_trade/src/referral.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Entry(Address)` | referee address | persistent |
+| `Stats(Address)` | referrer address | persistent |
+| `Referees(Address)` | referrer address | persistent |
+
+`Entry`, `Stats`, and `Referees` have distinct variant names — no collision even when the
+same address is used as both referee and referrer.
+
+**`auto_trade` — `RiskDataKey`**
+
+File: `contracts/auto_trade/src/risk.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `UserRiskConfig(Address)` | user address | persistent |
+| `UserRiskParityConfig(Address)` | user address | persistent |
+| `UserPositions(Address)` | user address | persistent |
+| `UserTradeHistory(Address)` | user address | persistent |
+| `AssetPrice(u32)` | asset_id | persistent |
+| `AssetPriceHistory(u32, u32)` | (asset_id, slot) | persistent |
+| `AssetPriceHistoryCount(u32)` | asset_id | persistent |
+
+All four user-address variants have distinct names — no collision.
+
+**`auto_trade` — `InsuranceKey`**
+
+File: `contracts/auto_trade/src/portfolio_insurance.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Insurance(Address)` | user address | persistent |
+
+**`auto_trade` — `PairsDataKey`**
+
+File: `contracts/auto_trade/src/strategies/pairs_trading.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Strategy(Address, u64)` | (user, strategy_id) | persistent |
+| `NextStrategyId` | — | persistent |
+| `NextPositionId` | — | persistent |
+
+**`auto_trade` — `StatArbDataKey`**
+
+File: `contracts/auto_trade/src/strategies/stat_arb.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Strategy(Address)` | user address | persistent |
+| `ActivePortfolio(Address)` | user address | persistent |
+| `PriceHistory(u32)` | asset_id | persistent |
+| `NextPortfolioId` | — | persistent |
+
+`Strategy` and `ActivePortfolio` have distinct variant names — no collision.
+
+**`auto_trade` — `RateLimitKey`**
+
+File: `contracts/auto_trade/src/rate_limit.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Limits` | — | persistent |
+| `UserHistory(Address)` | user address | persistent |
+| `Whitelist` | — | persistent |
+| `GlobalHourlyCount` | — | persistent |
+| `Admin` | — | persistent |
+
+**`auto_trade` — other strategy keys** (`GridDataKey`, `MomentumDataKey`, `BreakoutDataKey`, `DCAKey`, `ConditionalKey`, `IcebergStorageKey`, `CorrKey`, `TWAPStorageKey`, `EmergencyKey`, `MLDataKey`, `MRKey`, `SentimentStorageKey`, `ArbStorageKey`, `SmartRoutingKey`)
+
+All variants in these enums are keyed by `u64`, `u32`, or `AssetPair` — not by `Address`.
+No user-keyed collision risk.
+
+`DataKey`, `AdminStorageKey`, `AuthKey`, and all strategy-specific key enums are distinct
+Rust types — no cross-enum collision possible.
+
+---
+
+### 5. `signal_registry` — `StorageKey`
+
+File: `contracts/signal_registry/src/lib.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `SignalCounter` | — | instance |
+| `Signals` | — | persistent (map) |
+| `SignalsV1` | — | persistent (map) |
+| `MigrationCursor` | — | instance |
+| `MigrationV1TargetTotal` | — | instance |
+| `ProviderStats` | — | persistent |
+| `ProviderStakes` | — | persistent |
+| `TradeExecutions` | — | persistent |
+| `TradeCounter` | — | instance |
+| `TemplateCounter` | — | instance |
+| `Templates` | — | persistent |
+| `ExternalIdMappings` | — | persistent |
+| `ComboCounter` | — | instance |
+| `Combos` | — | persistent |
+| `ComboExecutions(u64)` | combo id | persistent |
+| `CrossChainSignals(String, String)` | (chain, signal_id) | persistent |
+| `AddressMappings(String, String)` | (chain, address) | persistent |
+| `ActiveSignalsByCategory` | — | persistent |
+| `AdoptionNonces` | — | persistent |
+| `TradeExecutor` | — | instance |
+| `UserPortfolio` | — | instance |
+| `RecordedSignalOutcomes` | — | persistent |
+| `ProviderReputationScore(Address)` | provider address | persistent |
+
+**`signal_registry` — `AdminStorageKey`**
+
+File: `contracts/signal_registry/src/admin.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `PendingAdminTransfer` | — | instance |
+| `Guardian` | — | instance |
+| `MinStake` | — | instance |
+| `TradeFee` | — | instance |
+| `StopLoss` | — | instance |
+| `PositionLimit` | — | instance |
+| `PauseStates` | — | instance |
+| `CircuitBreakerStats` | — | instance |
+| `CircuitBreakerConfig` | — | instance |
+| `MultiSigEnabled` | — | instance |
+| `MultiSigSigners` | — | instance |
+| `MultiSigThreshold` | — | instance |
+| `FeeCollectionPaused` | — | instance |
+| `PendingAdmin` | — | instance |
+| `PendingAdminExpiry` | — | instance |
+
+**`signal_registry` — `FeeStorageKey`**
+
+File: `contracts/signal_registry/src/types.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `PlatformTreasury` | — | persistent |
+| `ProviderTreasury` | — | persistent |
+| `TreasuryBalances` | — | persistent |
+
+**`signal_registry` — `SocialDataKey`**
+
+File: `contracts/signal_registry/src/social.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Follow(Address, Address)` | (user, provider) | instance |
+| `UserFollowedList(Address)` | user address | instance |
+| `FollowerCount(Address)` | provider address | instance |
+
+`Follow(user, provider)` and `Follow(provider, user)` are distinct because the tuple is
+ordered. `UserFollowedList` and `FollowerCount` have different variant names.
+
+**`signal_registry` — `ReputationDataKey`**
+
+File: `contracts/signal_registry/src/reputation.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `TrustScore(Address)` | provider address | persistent |
+| `FirstSignalTime(Address)` | provider address | persistent |
+| `MedianStake` | — | persistent |
+| `MedianFollowers` | — | persistent |
+
+`TrustScore` and `FirstSignalTime` share the same payload type but have distinct variant
+names — no collision.
+
+**`signal_registry` — `VersioningStorageKey`**
+
+File: `contracts/signal_registry/src/versioning.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `SignalVersions(u64, u32)` | (signal_id, version) | persistent |
+| `LatestVersion(u64)` | signal_id | persistent |
+| `UpdateCount(u64)` | signal_id | persistent |
+| `LastUpdateTime(u64)` | signal_id | persistent |
+| `CopyRecords(Address, u64)` | (user, signal_id) | persistent |
+
+`CopyRecords(user_a, id)` and `CopyRecords(user_b, id)` are distinct because the address
+bytes differ.
+
+**`signal_registry` — `ScheduleDataKey`**
+
+File: `contracts/signal_registry/src/scheduling.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Schedule(u64)` | schedule_id | persistent |
+| `ProviderSchedules(Address)` | provider address | persistent |
+| `NextScheduleId` | — | persistent |
+
+**`signal_registry` — `SizingDataKey`**
+
+File: `contracts/signal_registry/src/position_sizing.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `UserSizingConfig(Address)` | user address | persistent |
+| `PriceHistory(u32, u32)` | (asset_id, slot) | persistent |
+| `PriceHistoryLen(u32)` | asset_id | persistent |
+| `PriceHistoryHead(u32)` | asset_id | persistent |
+
+**`signal_registry` — `LeaderboardKey`**, **`TagStorageKey`**, **`CollabStorageKey`**, **`MLStorageKey`**, **`ContestStorageKey`**
+
+Files: `leaderboard.rs`, `categories.rs`, `collaboration.rs`, `ml_scoring.rs`, `contests.rs`
+
+All variants in these enums are unit variants or keyed by `u64` (not `Address`). No
+user-keyed collision risk.
+
+---
+
+### 6. `trade_executor` — `StorageKey`
+
+File: `contracts/trade_executor/src/lib.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `UserPortfolio` | — | instance |
+| `Oracle` | — | instance |
+| `StopLossPortfolio` | — | instance |
+| `CopyTradeEstimatedFee` | — | instance |
+| `SdexRouter` | — | instance |
+| `PositionLimitExempt(Address)` | user address | instance |
+| `LastInsufficientBalance(Address)` | user address | instance |
+
+Stop-loss and take-profit prices use raw tuple keys (not a `#[contracttype]` enum):
+
+```rust
+// triggers.rs
+(Symbol::new(env, "StopLoss"),  user, trade_id)  // persistent
+(Symbol::new(env, "TakeProfit"), user, trade_id) // persistent
+```
+
+These are `(Symbol, Address, u64)` tuples. The `Symbol` discriminant (`"StopLoss"` vs
+`"TakeProfit"`) ensures the two cannot collide with each other. They also cannot collide
+with `StorageKey` variants because the outer type differs.
+
+The reentrancy lock uses a plain `Symbol`:
+
+```rust
+Symbol::new(env, "ExecLock")  // temporary storage
+```
+
+This is in temporary storage and is a different type from all persistent/instance keys.
+
+---
+
+### 7. `governance` — `StorageKey`
+
+File: `contracts/governance/src/lib.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `Initialized` | — | instance |
+| `Metadata` | — | instance |
+| `Balances` | — | instance |
+| `StakedBalances` | — | instance |
+| `PendingRewards` | — | instance |
+| `VestingSchedules` | — | instance |
+| `Holders` | — | instance |
+| `DistributionState` | — | instance |
+| `VoteLocks` | — | instance |
+| `Treasury` | — | instance |
+| `Committees` | — | instance |
+| `GovernanceConfig` | — | instance |
+| `ProposalsState` | — | instance |
+| `Delegations` | — | instance |
+| `TimelockState` | — | instance |
+| `Guardian` | — | instance |
+| `GovernanceParameters` | — | instance |
+| `GovernanceFeatures` | — | instance |
+| `GovernanceUpgrades` | — | instance |
+| `ReputationState` | — | instance |
+| `VoteRecords` | — | instance |
+| `ConvictionState` | — | instance |
+| `ContractPaused` | — | instance |
+
+Governance uses no user-keyed tuple variants in its primary `StorageKey`. Per-user data
+(balances, votes, credits) is stored inside map values keyed by `Address` within a single
+top-level entry (e.g., `StorageKey::Balances` holds a `Map<Address, i128>`). This design
+means there are no user-keyed storage entries that could collide.
+
+---
+
+### 8. `stake_vault` — `StorageKey`
+
+File: `contracts/stake_vault/src/lib.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Admin` | — | instance |
+| `StakeToken` | — | instance |
+
+Both variants are unit variants (no payload). They have distinct names so cannot collide
+with each other. The reentrancy lock uses a plain `Symbol::new(&env, "WithdrawLock")` in
+**temporary** storage — a different storage tier and a different key type from all
+instance/persistent keys.
+
+**`stake_vault` — `MigrationKey`**
+
+File: `contracts/stake_vault/src/migration.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `StakesV1` | — | persistent |
+| `StakesV2` | — | persistent |
+| `MigrationState` | — | persistent |
+
+All three are unit variants with distinct names. `StakesV1` and `StakesV2` hold
+`Map<Address, _>` values — the per-staker lookup is done inside the map value, not as
+separate storage keys, so there are no user-keyed storage entries in `stake_vault` that
+could collide across users.
+
+`MigrationKey` is a distinct Rust type from `StorageKey`; Soroban encodes the type name,
+so `MigrationKey::StakesV2` cannot collide with `StorageKey::Admin` or any variant in any
+other contract's key enum.
+
+---
+
+### 9. `bridge` — `DataKey`
+
+File: `contracts/bridge/src/lib.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Config` | — | persistent |
+| `WrappedAsset(String)` | asset symbol | persistent |
+| `Transfer(u64)` | transfer_id | persistent |
+| `ReplayLock(ChainId, String, u64)` | (chain, tx_hash, nonce) | persistent |
+| `UsedSignature(Address, u64, ValidatorApprovalKind, String)` | (validator, nonce, kind, hash) | persistent |
+| `WrappedBalance(Address, String)` | (user, asset_symbol) | persistent |
+| `DailyVolume` | — | persistent |
+
+`UsedSignature(addr_a, ...)` and `UsedSignature(addr_b, ...)` are distinct because the
+address bytes differ. `WrappedBalance(user_a, sym)` and `WrappedBalance(user_b, sym)` are
+distinct for the same reason.
+
+**`bridge` — other key enums** (`FeeStorageKey`, `MonitoringDataKey`, `MessagingKey`, `LiquidityKey`, `AnalyticsDataKey`, `GovernanceDataKey`)
+
+None of these contain `Address`-parameterised variants. No user-keyed collision risk.
+
+---
+
+### 10. `common` — `ReplayKey`
+
+File: `contracts/common/src/replay_protection.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `UserNonce(Address)` | user address | persistent |
+| `TxHash(Bytes)` | tx hash bytes | persistent |
+
+`UserNonce` and `TxHash` have distinct variant names. `UserNonce(addr_a)` and
+`UserNonce(addr_b)` are distinct because the address bytes differ.
+
+**`common` — `RateLimitKey`**
+
+File: `contracts/common/src/rate_limit.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Timestamps(Address, ActionType)` | (user, action) | persistent |
+| `Config(ActionType)` | action type | persistent |
+| `UserFirstAction(Address)` | user address | persistent |
+
+`Timestamps(addr_a, action)` and `Timestamps(addr_b, action)` are distinct. `Timestamps`
+and `UserFirstAction` have distinct variant names — no collision even for the same address.
+
+---
+
+### 11. `oracle` — `GovernanceKey`
+
+File: `contracts/oracle/src/governance.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `ProposalCounter` | — | persistent |
+| `Proposal(u64)` | proposal_id | persistent |
+| `HasVoted(u64, Address)` | (proposal_id, voter) | persistent |
+| `TotalStaked` | — | persistent |
+| `Stake(Address)` | staker address | persistent |
+| `GovAdmin` | — | persistent |
+
+`HasVoted(id, addr_a)` and `HasVoted(id, addr_b)` are distinct. `Stake(addr_a)` and
+`Stake(addr_b)` are distinct. `HasVoted` and `Stake` have distinct variant names — no
+collision even when the same address is used.
+
+---
+
+### 12. `governance` — `QVStorageKey`
+
+File: `contracts/governance/src/quadratic_voting.rs`
+
+| Variant | Payload | Storage tier |
+|---|---|---|
+| `Config` | — | persistent |
+| `Credits(Address)` | user address | persistent |
+| `Vote(u64, Address)` | (proposal_id, voter) | persistent |
+| `ProposalVoters(u64)` | proposal_id | persistent |
+| `Identity(Address)` | user address | persistent |
+
+`Credits(addr_a)` and `Credits(addr_b)` are distinct. `Vote(id, addr_a)` and
+`Vote(id, addr_b)` are distinct. `Credits`, `Vote`, and `Identity` have distinct variant
+names — no collision even for the same address.
+
+---
+
+## Collision Risk Assessment
+
+### Same-enum, same-variant, different payload
+
+For any variant `V(addr)`, two different addresses `addr_a ≠ addr_b` produce different
+serialised keys because the address bytes are part of the XDR payload. This is the
+primary concern raised in the issue.
+
+**Verdict: No collision possible.** Soroban address serialisation is injective.
+
+### Same-enum, different-variant, same payload
+
+Example: `oracle::storage::StorageKey::Price(pair)` vs
+`oracle::storage::StorageKey::PriceTimestamp(pair)`.
+
+The variant name is encoded as an XDR symbol in the map key, so different variant names
+always produce different byte sequences regardless of payload.
+
+**Verdict: No collision possible.**
+
+### Cross-enum, same variant name, same payload
+
+Example: `fee_collector::StorageKey::Admin` vs `governance::StorageKey::Admin`.
+
+Each `#[contracttype]` enum is a distinct Rust type. Soroban encodes the type name as part
+of the outer XDR structure. Two enums with the same variant name but different type names
+serialise differently.
+
+Furthermore, each contract has its own isolated storage namespace — storage written by
+`fee_collector` is never readable by `governance` and vice versa.
+
+**Verdict: No collision possible.**
+
+### Tuple-variant ordering
+
+`ProviderPendingFees(provider, token)` — if the arguments were swapped, a provider address
+used as a token address would collide. However, the call sites always pass `(provider,
+token)` in the documented order, and the types are both `Address` so the compiler does not
+catch a swap. This is a **code-review concern**, not a serialisation collision.
+
+`Subscription(user, provider)` — same concern. The call sites consistently pass
+`(user, provider)`.
+
+**Verdict: No serialisation collision. Argument-order discipline is enforced by code
+review and the accessor functions in `storage.rs` / `subscriptions.rs`.**
+
+---
+
+## Summary
+
+| Risk | Verdict |
+|---|---|
+| Same variant, different `Address` payload | **No collision** — address bytes are injective |
+| Different variant, same payload | **No collision** — variant name is in serialised bytes |
+| Cross-enum, same variant name | **No collision** — type name differs; contracts have isolated storage |
+| Tuple argument order swap | **Not a serialisation collision** — code-review concern only |
+
+No storage key collision is possible in the current codebase.
+
+---
+
+## Tests
+
+See `contracts/common/src/storage_key_tests.rs`:
+
+| Test | What it verifies |
+|---|---|
+| `single_addr_variants_differ_for_different_users` | All single-`Address` variants produce different keys for different users |
+| `two_addr_variants_differ_for_different_users` | Two-`Address` variants differ when the first argument changes |
+| `two_addr_variant_argument_order_matters` | `Subscription(a, b) ≠ Subscription(b, a)` |
+| `different_variants_same_address_do_not_collide` | Different variant names with the same address payload are distinct |
+| `stake_vault_migration_keys_are_distinct` | `MigrationKey::StakesV1`, `StakesV2`, and `MigrationState` are all distinct |
+| `stake_vault_storage_keys_are_distinct` | `StorageKey::Admin` and `StorageKey::StakeToken` are distinct |
+| `signal_registry_social_keys_differ_for_different_users` | `SocialDataKey` user-keyed variants are distinct across users |
+| `signal_registry_reputation_keys_differ_for_different_providers` | `ReputationDataKey` variants are distinct across providers |
+| `signal_registry_versioning_copy_records_differ_for_different_users` | `VersioningStorageKey::CopyRecords(user, id)` is distinct across users |
+| `auto_trade_user_keyed_variants_differ_for_different_users` | `PositionKey`, `ExitStrategyKey`, `HistoryDataKey`, `ReferralKey`, `RiskDataKey`, `InsuranceKey` are distinct across users |
+| `auto_trade_pairs_strategy_differs_for_different_users` | `PairsDataKey::Strategy(user, id)` is distinct across users |
+| `auto_trade_stat_arb_keys_differ_for_different_users` | `StatArbDataKey` user-keyed variants are distinct across users |
+| `bridge_user_keyed_variants_differ_for_different_users` | `bridge::DataKey::WrappedBalance(user, sym)` is distinct across users |
+| `common_replay_key_differs_for_different_users` | `ReplayKey::UserNonce(addr)` is distinct across users |
+| `common_rate_limit_key_differs_for_different_users` | `RateLimitKey::Timestamps` and `UserFirstAction` are distinct across users |
+| `oracle_governance_key_differs_for_different_users` | `GovernanceKey::Stake` and `HasVoted` are distinct across users |
+| `governance_qv_keys_differ_for_different_users` | `QVStorageKey::Credits`, `Vote`, `Identity` are distinct across users |

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -1,0 +1,741 @@
+# StellarSwipe Threat Model
+
+**Methodology:** STRIDE  
+**Version:** 2.0.0  
+**Status:** Awaiting external security reviewer sign-off  
+**Last updated:** 2026-04-26  
+**Scope:** All five production contracts — `oracle`, `auto_trade`, `signal_registry`, `stake_vault`, `governance`  
+**Related docs:** `security_model.md`, `flash_loan_analysis.md`, `front_running_analysis.md`, `privilege_escalation_analysis.md`, `reentrancy_analysis.md`
+
+---
+
+## Contracts in Scope
+
+| Contract | Role |
+|---|---|
+| **oracle** | Aggregates prices from SDEX and external adapters; provides TWAP/median/consensus to other contracts |
+| **auto_trade** | Executes user-configured automated trades; manages positions, risk, stop-loss, and multi-strategy execution |
+| **signal_registry** | Stores and manages trading signals; handles provider reputation, staking, and signal lifecycle |
+| **stake_vault** | Custodies staked SEP-41 tokens; enforces lock periods and reentrancy-safe withdrawals |
+| **governance** | Token-weighted voting, treasury management, timelocked proposal execution, committee governance |
+
+> **Note:** `fee_collector`, `user_portfolio`, `bridge`, `trade_executor`, and shared libraries are referenced where they interact with the five contracts above but are not primary scope.
+
+---
+
+## STRIDE Threat Categories
+
+| Category | Description |
+|---|---|
+| **S** — Spoofing | Impersonating a legitimate identity or contract |
+| **T** — Tampering | Unauthorized modification of data or contract state |
+| **R** — Repudiation | Denying an action occurred; lack of audit trail |
+| **I** — Information Disclosure | Exposing data that should be private or confidential |
+| **D** — Denial of Service | Preventing legitimate use of the protocol |
+| **E** — Elevation of Privilege | Gaining capabilities beyond what is authorized |
+
+---
+
+## Threat Table Format
+
+Each threat entry uses:
+
+- **ID** — unique reference
+- **Contract(s)** — affected contract(s)
+- **STRIDE** — category
+- **Description** — what the attacker does and what they gain
+- **Likelihood** — HIGH / MEDIUM / LOW
+- **Impact** — HIGH / MEDIUM / LOW
+- **Status** — MITIGATED / PARTIAL / OPEN
+- **Mitigation / Remediation** — controls in place or required
+
+---
+
+## S — Spoofing
+
+### S-01: Fake oracle price submission
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle |
+| **STRIDE** | Spoofing |
+| **Description** | An attacker registers as an oracle operator and submits fabricated prices to skew the consensus output, causing incorrect stop-loss triggers or trade execution at wrong prices. |
+| **Likelihood** | MEDIUM |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Oracle operators are whitelisted by admin (`register_oracle` requires admin auth). Prices are aggregated via weighted median across all registered sources with a 300 s staleness filter, so a single rogue source is outvoted. Reputation and slashing logic (`reputation.rs`, `slash_oracle`) penalizes outlier submissions (>20% deviation triggers a slash). |
+| **Residual / Remediation** | A colluding majority of oracle operators can still corrupt the median. Remediation: enforce a minimum operator count (≥3) before enabling price-dependent functions; add on-chain deviation alerts; require multi-sig for oracle operator registration. |
+
+---
+
+### S-02: Admin key impersonation at initialization
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle, auto_trade, signal_registry, stake_vault, governance |
+| **STRIDE** | Spoofing |
+| **Description** | If a contract is deployed but not immediately initialized, an attacker calls `initialize` / `init_admin` first and claims the admin role. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | MITIGATED |
+| **Mitigation** | All five contracts guard `initialize` / `init_admin` with an "already set" check that panics or returns `AlreadyInitialized` on re-call. Deployment scripts must call `initialize` atomically in the same transaction as deployment. |
+
+---
+
+### S-03: Governance proposal executor impersonation
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Spoofing |
+| **Description** | An attacker crafts a proposal that, when executed, calls a target contract pretending to be the governance contract itself, bypassing `require_auth` checks. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | MITIGATED |
+| **Mitigation** | `execute_proposal` in governance only writes to governance-internal storage keys (`GovernanceParameters`, `GovernanceFeatures`, `GovernanceUpgrades`, `Treasury`). It does not invoke arbitrary cross-contract calls with governance's identity. Soroban `require_auth` enforces caller identity at the host level. Confirmed by privilege escalation analysis: no proposal type can write `StorageKey::Admin`. |
+
+---
+
+### S-04: Signal provider identity spoofing
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Spoofing |
+| **Description** | An attacker submits signals under a reputable provider's address by replaying or forging authorization. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | All signal submission functions call `provider.require_auth()` via Soroban's host-enforced auth. Replay protection is provided by `stellar_swipe_common::replay_protection` (nonce / tx-hash dedup). The `increment_adoption` function additionally validates the caller against the registered `TradeExecutor` address. |
+
+---
+
+### S-05: Staker identity spoofing on withdrawal
+
+| Field | Value |
+|---|---|
+| **Contract** | stake_vault |
+| **STRIDE** | Spoofing |
+| **Description** | An attacker calls `withdraw_stake` with a victim's address to drain their staked tokens to themselves. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | MITIGATED |
+| **Mitigation** | `withdraw_stake` calls `staker.require_auth()` before any state read or token transfer. Soroban host-level auth prevents any caller from authorizing on behalf of another address without their signature. The token transfer destination is always `staker` (the authorized address), not the caller. |
+
+---
+
+### S-06: Cross-chain signal import with forged proof
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Spoofing |
+| **Description** | An attacker submits a `request_signal_import` with a forged `proof` bytes value, claiming ownership of a signal from another chain and importing it under their Stellar address. |
+| **Likelihood** | MEDIUM |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | `import_verified_signal` calls `cross_chain::verify_proof` before creating the Stellar signal. Address mapping must be pre-registered via `register_cross_chain_address` with a proof. |
+| **Residual / Remediation** | `verify_proof` is currently a placeholder (`unimplemented!` stub in `cross_chain.rs`). Remediation: implement cryptographic proof verification (e.g., ECDSA signature from the source chain) before enabling cross-chain import on mainnet. |
+
+---
+
+## T — Tampering
+
+### T-01: Oracle price history manipulation via sustained submission
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle |
+| **STRIDE** | Tampering |
+| **Description** | An attacker with oracle operator access submits a sequence of prices that gradually manipulates the TWAP stored in `history.rs`, causing `calculate_twap` to return a biased value used for stop-loss decisions. |
+| **Likelihood** | MEDIUM |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | TWAP is computed over a configurable window of historical samples. Staleness filter (300 s) limits how quickly history can be poisoned. Reputation slashing penalizes outlier submissions (>20% deviation). Weighted median reduces influence of low-reputation oracles. |
+| **Residual / Remediation** | A patient attacker with sustained oracle access can gradually shift TWAP. Remediation: add a maximum per-submission deviation cap (reject submissions >10% from current median); increase minimum oracle operator count to ≥3; add a circuit breaker that pauses price-dependent functions when TWAP deviation exceeds a threshold. |
+
+---
+
+### T-02: Signal data tampering post-submission
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Tampering |
+| **Description** | A signal provider edits a signal after it has been acted upon by copy traders, retroactively changing parameters to claim better performance metrics or mislead followers. |
+| **Likelihood** | MEDIUM |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | `update_signal` enforces a 60-second edit window (`now - submitted_at > 60` → `EditWindowClosed`). Edits are blocked if `adoption_count > 0` (`SignalAlreadyCopied`). Signal versioning (`versioning.rs`) records each edit as a new version with a timestamp. |
+| **Residual / Remediation** | The 60-second window is tight but the adoption-count guard is the stronger protection. Remediation: emit a `SignalEdited` event with old and new version hashes (already done via `emit_signal_edited`); ensure indexers attribute copy trade performance to the version active at execution time. |
+
+---
+
+### T-03: Fee parameter tampering
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade, signal_registry, governance |
+| **STRIDE** | Tampering |
+| **Description** | Admin (or a governance proposal) sets fee rates to zero or to an extreme value, extracting value from users or breaking the fee mechanism. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | Fee parameters are bounded by on-chain caps (`fee_rate_bps` validated against `MAX_FEE_BPS` in `fees.rs`). Governance parameter changes go through a timelock delay. Admin key is protected by two-step transfer with 48 h expiry. `set_trade_fee` in signal_registry requires admin auth. |
+
+---
+
+### T-04: Governance treasury drain via malicious proposal
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Tampering |
+| **Description** | An attacker with sufficient voting power passes a `TreasurySpend` proposal to drain the treasury to an attacker-controlled address. |
+| **Likelihood** | MEDIUM |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Treasury spend proposals require quorum and approval threshold. Timelock delay (`timelock.rs`) gives the community time to react. Guardian can cancel queued actions. `execute_treasury_spend` requires admin auth for direct spends. `BudgetExceeded` error prevents single proposals from exceeding 10% of treasury. |
+| **Residual / Remediation** | If an attacker accumulates >50% of voting power (governance capture), the timelock is the only remaining defense. Remediation: implement a per-proposal spending cap enforced in `execute_proposal`; require committee approval for treasury spends above a threshold; add a guardian veto for high-impact proposals. |
+
+---
+
+### T-05: Stake balance manipulation via migration key collision
+
+| Field | Value |
+|---|---|
+| **Contract** | stake_vault |
+| **STRIDE** | Tampering |
+| **Description** | An attacker exploits a storage key collision between `MigrationKey::StakesV2` and another storage key to overwrite stake balances, either inflating their own stake or zeroing a victim's. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | MITIGATED |
+| **Mitigation** | `MigrationKey` is a `contracttype` enum; Soroban serializes enum variants with their discriminant, making collisions with other key types structurally impossible. The `StakesV2` map is keyed by `Address`, so one staker cannot affect another's entry. Storage key analysis (`storage_key_analysis.md`) confirms no collisions across all contracts. |
+
+---
+
+### T-06: Signal adoption count double-increment
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Tampering |
+| **Description** | The `TradeExecutor` contract (or a compromised caller) calls `increment_adoption` multiple times with the same `(signal_id, nonce)` pair, inflating a signal's adoption count to boost provider reputation fraudulently. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | `increment_adoption` checks the `AdoptionNonces` map for `(signal_id, nonce)` before incrementing. If the nonce is already recorded, it returns `InvalidParameter`. Only the registered `TradeExecutor` address can call this function. |
+
+---
+
+### T-07: Vesting schedule manipulation
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Tampering |
+| **Description** | Admin creates a vesting schedule with a zero cliff and zero duration, allowing immediate full release of tokens to an attacker-controlled beneficiary, bypassing the intended vesting timeline. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | `create_vesting_schedule` requires admin auth. `release_vested_tokens` requires beneficiary auth. `releasable_amount` in `distribution.rs` computes the vested fraction based on elapsed time relative to cliff and duration. |
+| **Residual / Remediation** | Admin can set cliff=0 and duration=0, making all tokens immediately releasable. Remediation: enforce minimum cliff and duration values in `create_vesting_schedule`; require governance proposal approval for vesting schedules above a threshold amount. |
+
+---
+
+## R — Repudiation
+
+### R-01: Oracle price submission without audit trail
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle |
+| **STRIDE** | Repudiation |
+| **Description** | An oracle operator submits a manipulated price and later denies it, claiming the on-chain record is insufficient to attribute the submission. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | `events.rs` in oracle emits `PriceSubmitted` for every `submit_price` and `submit_pair_price` call, including the submitter's address, asset pair, price, and timestamp. `emit_oracle_slashed` records slash events with reason. Soroban events are immutable ledger records. Per-operator accuracy history is maintained in `reputation.rs`. |
+
+---
+
+### R-02: Trade execution without user consent record
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade |
+| **STRIDE** | Repudiation |
+| **Description** | A user claims they did not authorize a trade that was executed on their behalf (e.g., via automated strategy or copy trade). |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | `execute_trade` calls `user.require_auth()` before execution. A `trade_executed` event is emitted with user address, signal ID, amount, price, and timestamp. `history.rs` stores per-user trade history on-chain. `auth.rs` records explicit authorization grants with expiry. |
+
+---
+
+### R-03: Governance vote repudiation
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Repudiation |
+| **Description** | A voter claims they did not cast a vote or that their vote was miscounted. |
+| **Likelihood** | LOW |
+| **Impact** | LOW |
+| **Status** | MITIGATED |
+| **Mitigation** | `voting.rs` stores each vote on-chain keyed by `(proposal_id, voter)` in `VoteRecords`. Vote events are emitted. `calculate_proposal_statistics` provides a verifiable tally. Quadratic and conviction voting variants also store per-voter state. `AlreadyVoted` error prevents double-voting. |
+
+---
+
+### R-04: Signal performance outcome dispute
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Repudiation |
+| **Description** | A signal provider disputes the recorded performance outcome of their signal, claiming the on-chain record was set incorrectly or by an unauthorized caller. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | `record_signal_outcome` is restricted to the registered `TradeExecutor` address (`caller != executor → Unauthorized`). Outcomes are idempotent — `OutcomeAlreadyRecorded` prevents overwriting. `emit_reputation_updated` records old and new scores. The `RecordedSignalOutcomes` map provides an immutable audit trail. |
+
+---
+
+### R-05: Stake withdrawal without on-chain record
+
+| Field | Value |
+|---|---|
+| **Contract** | stake_vault |
+| **STRIDE** | Repudiation |
+| **Description** | A staker withdraws their tokens and later claims the withdrawal never happened, attempting to re-withdraw or dispute their balance. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | `withdraw_stake` zeroes the balance in `StakesV2` before the token transfer (checks-effects-interactions). The balance change is persistent and verifiable on-chain. |
+| **Residual / Remediation** | No withdrawal event is emitted from `stake_vault`. Remediation: add a `WithdrawStake` event emission in `do_withdraw` with staker address, amount, and timestamp to provide a complete audit trail. |
+
+---
+
+### R-06: Admin action without event trail
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Repudiation |
+| **Description** | An admin performs sensitive operations (treasury spend, vesting creation, committee dissolution) and later disputes having done so. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | All admin functions in governance emit events via `emit_admin_action` with the action symbol, actor address, and value. Specific events are emitted for vesting (`emit_vesting_created`), staking (`emit_stake_changed`), and rewards (`emit_reward_claimed`). All events are immutable Soroban ledger records. |
+
+---
+
+## I — Information Disclosure
+
+### I-01: Iceberg order size leakage
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade |
+| **STRIDE** | Information Disclosure |
+| **Description** | The full size of an iceberg order is visible on-chain, allowing front-runners to anticipate the remaining order volume and trade ahead of it. |
+| **Likelihood** | MEDIUM |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | `iceberg.rs` exposes `get_public_order_view` (shows only the visible slice) vs `get_full_order_view` (requires owner auth). The public view intentionally hides total size. |
+| **Residual / Remediation** | On-chain storage is always readable by node operators querying ledger state directly, bypassing the contract's access control. Remediation: document this as a known limitation; for high-value orders, consider off-chain order management with on-chain settlement only. Encrypting total size on-chain is impractical without ZK proofs. |
+
+---
+
+### I-02: User portfolio position disclosure
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade |
+| **STRIDE** | Information Disclosure |
+| **Description** | An attacker reads a user's open positions from contract storage to target them with front-running or coordinated liquidation attacks. |
+| **Likelihood** | MEDIUM |
+| **Impact** | LOW |
+| **Status** | OPEN |
+| **Description** | Soroban contract storage is publicly readable. All position data (entry price, size, stop-loss level) is visible to any ledger observer. This is an inherent property of public blockchains. |
+| **Remediation** | Document as a known limitation in user-facing materials. For high-value users, consider off-chain position management with on-chain settlement only. No on-chain fix is practical without ZK proofs. |
+
+---
+
+### I-03: Signal strategy leakage via on-chain parameters
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Information Disclosure |
+| **Description** | A signal's full parameters (entry price, target, stop-loss, category, timing) are visible on-chain before the signal expires, allowing competitors to copy the strategy without attribution. |
+| **Likelihood** | HIGH |
+| **Impact** | LOW |
+| **Status** | OPEN |
+| **Description** | Signals are intentionally public by design — transparency is the product's value proposition. This is a design choice, not a vulnerability. |
+| **Remediation** | For providers who want private signals, implement a commit-reveal pattern: publish a hash on-chain, reveal parameters only to subscribers off-chain. The `PREMIUM` category with `check_subscription` gating is a partial mitigation for access control, but does not hide on-chain storage from node operators. |
+
+---
+
+### I-04: Oracle operator list disclosure
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle |
+| **STRIDE** | Information Disclosure |
+| **Description** | The list of oracle operators is publicly readable, allowing an attacker to target individual operators for social engineering or key compromise. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | OPEN |
+| **Description** | Oracle operator addresses are stored in persistent storage (`StorageKey::Oracles`) and are readable by anyone. This is inherent to on-chain transparency. |
+| **Remediation** | Operational: use hardware-backed keys for oracle operators; rotate keys regularly; use multisig for oracle submissions where possible. Consider using contract addresses (rather than EOAs) as oracle operators to add an extra auth layer. |
+
+---
+
+### I-05: Governance token holder list disclosure
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Information Disclosure |
+| **Description** | The full list of token holders and their balances is readable from `StorageKey::Holders` and `StorageKey::Balances`, enabling targeted attacks on large holders or revealing strategic voting power distribution. |
+| **Likelihood** | LOW |
+| **Impact** | LOW |
+| **Status** | OPEN |
+| **Description** | Token holder data is inherently public on-chain. This is expected behavior for a governance token. |
+| **Remediation** | Document as expected behavior. Governance participants should be aware their voting power is public. No on-chain fix is practical or desirable for a transparent governance system. |
+
+---
+
+### I-06: Stake lock expiry timing disclosure
+
+| Field | Value |
+|---|---|
+| **Contract** | stake_vault |
+| **STRIDE** | Information Disclosure |
+| **Description** | An attacker reads `StakesV2` to learn when a large staker's lock expires, then front-runs the withdrawal to manipulate market conditions or governance voting power at the moment of unlock. |
+| **Likelihood** | LOW |
+| **Impact** | LOW |
+| **Status** | OPEN |
+| **Description** | Lock expiry timestamps are stored in persistent storage and are publicly readable. This is inherent to on-chain transparency. |
+| **Remediation** | Document as a known limitation. For governance-sensitive stakes, consider a withdrawal delay (cooldown period) after lock expiry to reduce the predictability of large unlock events. |
+
+---
+
+## D — Denial of Service
+
+### D-01: Oracle staleness attack (liveness DoS)
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle |
+| **STRIDE** | Denial of Service |
+| **Description** | All oracle operators go offline or are coerced to stop submitting prices. The staleness filter causes `get_price_with_confidence` to return `StalePrice`, blocking all price-dependent operations (stop-loss, trade execution). |
+| **Likelihood** | MEDIUM |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | `staleness.rs` and `OracleHealth` track per-operator health. `health_check` exposes liveness status for monitoring. Emergency pause allows admin to halt dependent contracts gracefully. `check_oracle_heartbeat` emits `HeartbeatMissed` events for off-chain alerting. |
+| **Residual / Remediation** | No automatic fallback price source when all operators are stale. Remediation: integrate a secondary price source (e.g., on-chain SDEX TWAP as fallback with a wider staleness window); set up off-chain monitoring alerts for oracle liveness; define a minimum operator count below which the oracle auto-pauses. |
+
+---
+
+### D-02: Storage bloat via signal spam
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Denial of Service |
+| **Description** | An attacker submits thousands of signals to bloat contract storage, increasing ledger fees for all users and potentially hitting Soroban storage limits. |
+| **Likelihood** | MEDIUM |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | Signal submission requires a fee (`fees.rs`). Rate limiting (`stellar_swipe_common::rate_limit`) restricts submissions per address per time window. Staking requirement (`stake.rs`) raises the cost of spam. Signal expiry (`expiry.rs`) cleans up old entries. `cleanup_expired_signals` and `archive_old_signals` provide batch garbage collection. |
+| **Residual / Remediation** | Rate limits and fees may be insufficient if the attacker is well-funded. Remediation: increase minimum stake for signal submission; implement automatic garbage collection triggered by storage size thresholds. |
+
+---
+
+### D-03: Flash loan price manipulation causing false stop-loss triggers
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade |
+| **STRIDE** | Denial of Service |
+| **Description** | An attacker uses a flash loan to temporarily move the SDEX spot price within a single transaction, triggering stop-losses for many users and forcing them out of positions at unfavorable prices. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | MITIGATED |
+| **Mitigation** | Stop-loss evaluation in `auto_trade` uses the oracle contract price (`oracle::get_oracle_price`) when configured, not SDEX spot. The oracle uses median aggregation with a 300 s staleness filter — a single-transaction flash loan cannot manipulate a time-weighted multi-source median. When no oracle is configured, `signal.price` (pre-validated, not live SDEX) is used as fallback. See `flash_loan_analysis.md` for full analysis. |
+
+---
+
+### D-04: Governance proposal spam
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Denial of Service |
+| **Description** | An attacker creates many governance proposals to overwhelm the voting system, causing voter fatigue and preventing legitimate proposals from receiving attention. |
+| **Likelihood** | MEDIUM |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | Proposal creation requires a minimum staked token balance (`min_proposal_threshold` in `GovernanceConfig`). Proposals have a defined lifecycle with expiry. `NoVotingPower` error blocks zero-stake proposers. |
+| **Residual / Remediation** | Remediation: add a proposal deposit that is slashed for proposals that fail to reach quorum; limit concurrent active proposals per address; implement a cooldown period between proposals from the same address. |
+
+---
+
+### D-05: Reentrancy-based DoS on `withdraw_stake`
+
+| Field | Value |
+|---|---|
+| **Contract** | stake_vault |
+| **STRIDE** | Denial of Service |
+| **Description** | A malicious SEP-41 token contract re-enters `withdraw_stake` during the token transfer callback, attempting to drain the vault or leave the reentrancy lock permanently set. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | MITIGATED |
+| **Mitigation** | `withdraw_stake` uses a temporary-storage reentrancy lock (`"WithdrawLock"`). The balance is zeroed in `StakesV2` before the token transfer (checks-effects-interactions). The lock is cleared on both success and error paths via `env.storage().temporary().remove`. A reentrant call finds the lock set and returns `ReentrancyDetected`. See `reentrancy_analysis.md` for full analysis. |
+
+---
+
+### D-06: Rate limit exhaustion via automated signal submission
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Denial of Service |
+| **Description** | An attacker with a high-trust score (which raises rate limits) submits signals at the maximum allowed rate to exhaust the rate limit window for legitimate providers sharing the same window parameters. |
+| **Likelihood** | LOW |
+| **Impact** | LOW |
+| **Status** | MITIGATED |
+| **Mitigation** | Rate limits in `stellar_swipe_common::rate_limit` are per-address, not global. Each provider has an independent window. Trust score increases an individual provider's limit, not a shared pool. |
+
+---
+
+### D-07: Governance timelock queue exhaustion
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Denial of Service |
+| **Description** | An attacker with sufficient voting power passes many proposals and queues all of them in the timelock simultaneously, exhausting the queue capacity and blocking legitimate actions. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | Each queued action has a unique `action_id`. The guardian can cancel queued actions. Proposal creation requires minimum voting power. |
+| **Residual / Remediation** | No explicit queue size limit is enforced in `timelock.rs`. Remediation: add a maximum concurrent queued actions limit; require a higher voting threshold for proposals that queue timelock actions. |
+
+---
+
+### D-08: Oracle consensus round stall via submission withholding
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle |
+| **STRIDE** | Denial of Service |
+| **Description** | Oracle operators withhold submissions, preventing `calculate_consensus` from having enough data to produce a valid consensus price, stalling all downstream price-dependent operations. |
+| **Likelihood** | MEDIUM |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | `calculate_consensus` returns `InsufficientOracles` if the submissions list is empty. The circuit breaker in `auto_trade` (`check_oracle_circuit_breaker`) detects oracle unavailability and blocks trading, preventing execution at stale prices. Admin can override the circuit breaker for emergency recovery. |
+| **Residual / Remediation** | Remediation: define a minimum submission count threshold for consensus; implement automatic fallback to SDEX TWAP when consensus cannot be reached; set up off-chain monitoring for submission liveness. |
+
+---
+
+## E — Elevation of Privilege
+
+### E-01: Admin key compromise → full protocol control
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle, auto_trade, signal_registry, stake_vault, governance |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | An attacker compromises the admin private key and gains full control: can change fee rates, register malicious oracles, pause/unpause contracts, drain treasury, and transfer admin to themselves permanently. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Admin transfer requires a two-step flow (propose → accept) with a 48 h expiry window in `oracle`, `auto_trade`, and `signal_registry`. Multisig support in `signal_registry` raises the bar. Guardian role limits blast radius during incident response. |
+| **Residual / Remediation** | `governance` and `stake_vault` have no admin rotation mechanism — a compromised key is permanent. Remediation: add two-step admin transfer to `governance` and `stake_vault`; require hardware-backed multisig for all admin keys before mainnet. |
+
+---
+
+### E-02: Governance capture via token concentration
+
+| Field | Value |
+|---|---|
+| **Contract** | governance |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | An attacker accumulates >50% of governance tokens (or delegates) and passes arbitrary proposals, including treasury drains, parameter changes, and contract upgrade hashes. |
+| **Likelihood** | MEDIUM |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Timelock delay gives the community time to react and the guardian to cancel malicious proposals. Quorum and approval thresholds prevent low-participation attacks. Conviction voting and quadratic voting reduce whale dominance. Committee approval is required for certain high-impact actions. |
+| **Residual / Remediation** | Timelock is the last line of defense against a >50% attacker. Remediation: implement a guardian veto for high-impact proposals; add a maximum single-address voting power cap; require committee approval for treasury spends above a threshold. |
+
+---
+
+### E-03: Guardian role abuse
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade, signal_registry, oracle, governance |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | A compromised guardian cancels all queued governance actions (including legitimate upgrades) and triggers emergency pauses, effectively holding the protocol hostage. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | PARTIAL |
+| **Mitigation** | Guardian can only pause and cancel queued actions — it cannot execute proposals, change admin, or drain treasury. Guardian is set and revoked exclusively by admin (`require_admin` guard on `set_guardian` and `revoke_guardian`). Confirmed by privilege escalation analysis. |
+| **Residual / Remediation** | A malicious guardian can indefinitely block governance execution by canceling every queued action. Remediation: add a time-bounded guardian role (auto-expiry after N days); require admin + guardian multisig for cancellation of high-priority actions. |
+
+---
+
+### E-04: Signal provider → privileged execution via malicious signal parameters
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry, auto_trade |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | A signal provider crafts a signal with extreme parameters (e.g., `price = 0`, `amount = MAX_I128`) that, when auto-executed by a copy trader, causes an integer overflow or bypasses risk checks. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | `create_signal` panics if `price <= 0` is not validated (implicit via `InvalidPrice` in oracle). `risk.rs` in auto_trade validates trade parameters before execution. `validate_trade` checks amount bounds and price sanity. `checked_sub` / `checked_mul` are used in fee and amount calculations to prevent overflow. `execute_trade` returns `InvalidAmount` for `amount <= 0`. |
+| **Residual / Remediation** | Remediation: add explicit `price > 0` validation in `create_signal_internal`; fuzz test signal parameter boundaries; add a maximum signal price cap relative to current oracle price. |
+
+---
+
+### E-05: Cross-contract privilege escalation via dependency address manipulation
+
+| Field | Value |
+|---|---|
+| **Contract** | auto_trade |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | Admin sets the oracle or portfolio contract address to a malicious contract that returns attacker-controlled values, causing `auto_trade` to execute trades based on fabricated data. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Dependency addresses (oracle, SDEX router) are set by admin only (`set_oracle_address` requires admin auth). Admin is protected by two-step transfer. Oracle whitelist per asset pair (`add_oracle` / `remove_oracle`) provides additional granularity. |
+| **Residual / Remediation** | Remediation: emit events when dependency addresses are changed (already done via `OracleAdded`/`OracleRemoved` events); add a timelock delay for dependency address updates; consider a governance vote for changing critical dependency addresses. |
+
+---
+
+### E-06: Stake vault admin → unauthorized token drain
+
+| Field | Value |
+|---|---|
+| **Contract** | stake_vault |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | The `stake_vault` admin (set at initialization) has no privileged functions beyond initialization, but a future upgrade could add admin-only functions that allow draining staked tokens. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Current `stake_vault` implementation has no admin-privileged functions beyond `initialize`. The only token transfer is in `withdraw_stake`, which requires staker auth and only transfers to the staker. No admin drain path exists in the current code. |
+| **Residual / Remediation** | No admin rotation mechanism exists. Remediation: add two-step admin transfer; document that any future admin-privileged functions must go through governance approval; add a timelock for any future admin-controlled token movements. |
+
+---
+
+### E-07: Oracle operator → governance parameter manipulation via price-triggered logic
+
+| Field | Value |
+|---|---|
+| **Contract** | oracle, governance |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | A compromised oracle operator submits prices that trigger automated governance actions (e.g., a price-triggered parameter change), escalating from oracle operator to governance actor. |
+| **Likelihood** | LOW |
+| **Impact** | MEDIUM |
+| **Status** | MITIGATED |
+| **Mitigation** | Governance proposals are not triggered by oracle prices. Proposal creation, voting, and execution are entirely separate from oracle price feeds. No cross-contract call from oracle to governance exists in the current codebase. Confirmed by privilege escalation analysis. |
+
+---
+
+### E-08: Multisig signer collusion in signal_registry
+
+| Field | Value |
+|---|---|
+| **Contract** | signal_registry |
+| **STRIDE** | Elevation of Privilege |
+| **Description** | A threshold number of multisig signers collude to perform admin actions (pause trading, change fees, register malicious oracles) without the original admin's knowledge. |
+| **Likelihood** | LOW |
+| **Impact** | HIGH |
+| **Status** | PARTIAL |
+| **Mitigation** | Multisig is opt-in and enabled by the admin. Adding/removing signers requires existing admin auth. The threshold is configurable. All admin actions emit events. |
+| **Residual / Remediation** | Once multisig is enabled, the threshold of signers can act as admin. Remediation: require a time-delay for multisig-approved actions; emit events for all multisig approvals; consider requiring the original admin key as one of the required signers. |
+
+---
+
+---
+
+## Attack Vector Summary
+
+The following specific attack vectors from the issue scope are addressed:
+
+| Attack Vector | Relevant Threats | Status |
+|---|---|---|
+| Oracle manipulation | S-01, T-01, D-01, D-08 | PARTIAL |
+| Governance attacks | T-04, T-07, E-02, E-03 | PARTIAL |
+| Flash loans | D-03 | MITIGATED |
+| Front-running | I-01, I-03 | PARTIAL / OPEN |
+| Reentrancy | D-05 | MITIGATED |
+| Privilege escalation | E-01, E-02, E-03, E-04, E-05, E-06, E-07, E-08 | PARTIAL |
+
+---
+
+## STRIDE Coverage Matrix
+
+The following table confirms all six STRIDE categories are covered for all five contracts:
+
+| Contract | S | T | R | I | D | E |
+|---|---|---|---|---|---|---|
+| **oracle** | S-01, S-02 | T-01 | R-01 | I-04 | D-01, D-08 | E-01, E-07 |
+| **auto_trade** | S-02 | T-03 | R-02 | I-01, I-02 | D-03, D-06 | E-01, E-04, E-05 |
+| **signal_registry** | S-02, S-04, S-06 | T-02, T-03, T-06 | R-04 | I-03 | D-02, D-06 | E-01, E-04, E-08 |
+| **stake_vault** | S-02, S-05 | T-05 | R-05 | I-06 | D-05 | E-01, E-06 |
+| **governance** | S-02, S-03 | T-04, T-07 | R-03, R-06 | I-05 | D-04, D-07 | E-01, E-02, E-03 |
+
+---
+
+## Open Threats — Remediation Plan
+
+The following threats have status **OPEN** and require action before mainnet:
+
+| ID | Threat | Contract | Priority | Remediation |
+|---|---|---|---|---|
+| I-02 | User portfolio position disclosure | auto_trade | LOW | Document as known limitation; consider off-chain position management for high-value users |
+| I-03 | Signal strategy leakage | signal_registry | LOW | Document as design choice; offer optional commit-reveal for premium providers |
+| I-04 | Oracle operator list disclosure | oracle | MEDIUM | Operational: hardware keys, key rotation, multisig for oracle submissions |
+| I-05 | Governance token holder list disclosure | governance | LOW | Document as expected behavior for a transparent governance token |
+| I-06 | Stake lock expiry timing disclosure | stake_vault | LOW | Document as known limitation; consider withdrawal cooldown period |
+
+The following threats have status **PARTIAL** and have tracked remediation items:
+
+| ID | Threat | Contract | Priority | Remediation |
+|---|---|---|---|---|
+| S-01 | Fake oracle price submission | oracle | HIGH | Enforce minimum operator count (≥3); add per-submission deviation cap |
+| S-06 | Cross-chain signal import with forged proof | signal_registry | HIGH | Implement cryptographic proof verification before enabling cross-chain import on mainnet |
+| T-01 | Oracle price history manipulation | oracle | HIGH | Add maximum per-submission deviation cap (>10% from median = reject) |
+| T-04 | Governance treasury drain | governance | HIGH | Implement per-proposal spending cap; require committee approval for large spends |
+| T-07 | Vesting schedule manipulation | governance | MEDIUM | Enforce minimum cliff/duration; require governance approval for large vesting schedules |
+| E-01 | Admin key compromise | all | HIGH | Add two-step admin transfer to `governance` and `stake_vault`; require hardware multisig |
+| E-02 | Governance capture | governance | HIGH | Add guardian veto for high-impact proposals; implement voting power cap |
+| E-03 | Guardian role abuse | multiple | MEDIUM | Add time-bounded guardian role with auto-expiry |
+| E-04 | Malicious signal parameters | signal_registry, auto_trade | MEDIUM | Add explicit `price > 0` validation in `create_signal_internal`; fuzz test boundaries |
+| E-05 | Dependency address manipulation | auto_trade | MEDIUM | Add timelock for dependency address updates; emit change events |
+| E-06 | Stake vault admin drain risk | stake_vault | MEDIUM | Add two-step admin transfer; document governance approval requirement for future admin functions |
+| E-08 | Multisig signer collusion | signal_registry | MEDIUM | Add time-delay for multisig-approved actions; require original admin as required signer |
+| D-01 | Oracle staleness DoS | oracle | HIGH | Integrate secondary price source fallback; set up liveness monitoring |
+| D-04 | Governance proposal spam | governance | MEDIUM | Add proposal deposit with slashing for failed proposals; add per-address proposal cooldown |
+| D-07 | Timelock queue exhaustion | governance | MEDIUM | Add maximum concurrent queued actions limit |
+| D-08 | Oracle consensus round stall | oracle | MEDIUM | Define minimum submission count; implement SDEX TWAP fallback |
+| R-05 | Stake withdrawal without event | stake_vault | LOW | Add `WithdrawStake` event emission in `do_withdraw` |
+| T-02 | Signal data tampering | signal_registry | MEDIUM | Ensure indexers attribute performance to version active at execution time |
+
+---
+
+## Review Sign-off
+
+This document must be reviewed by at least one external security contributor before the protocol is considered production-ready.
+
+| Reviewer | Organization / Handle | Date | Sign-off |
+|---|---|---|---|
+| TBD | External Security Contributor | — | Pending |
+
+To sign off, open a PR that adds your name and a comment confirming you have reviewed all threats and their mitigation status.

--- a/stellar-swipe/contracts/common/src/lib.rs
+++ b/stellar-swipe/contracts/common/src/lib.rs
@@ -27,3 +27,6 @@ pub use rate_limit::{
     check_rate_limit, record_action, set_config as set_rate_limit_config, ActionType, RateLimitConfig,
 };
 pub use replay_protection::{current_nonce, verify_and_commit, ReplayError};
+
+#[cfg(test)]
+mod storage_key_tests;

--- a/stellar-swipe/contracts/common/src/storage_key_tests.rs
+++ b/stellar-swipe/contracts/common/src/storage_key_tests.rs
@@ -1,0 +1,177 @@
+//! Storage key collision tests (Issue #265).
+//!
+//! Verifies that user-keyed `#[contracttype]` enum variants produce different
+//! serialised storage keys for different addresses, including addresses that
+//! differ in only one byte.
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{contracttype, Address, Env};
+
+    // ---------------------------------------------------------------------------
+    // Minimal reproductions of every user-keyed storage key pattern used across
+    // the five contracts.  We reproduce the *pattern* here so the test has no
+    // extra crate dependencies.
+    // ---------------------------------------------------------------------------
+
+    #[contracttype]
+    #[derive(Clone)]
+    enum SingleAddrKey {
+        UserPositions(Address),           // user_portfolio::DataKey
+        UserBadges(Address),              // user_portfolio::DataKey
+        Authorization(Address),           // auto_trade::AuthKey
+        PositionLimitExempt(Address),     // trade_executor::StorageKey
+        LastInsufficientBalance(Address), // trade_executor::StorageKey
+        ProviderReputationScore(Address), // signal_registry::StorageKey
+        TreasuryBalance(Address),         // fee_collector::StorageKey
+        MonthlyTradeVolume(Address),      // fee_collector::StorageKey
+        ProviderTerms(Address),           // user_portfolio subscriptions::StorageKey
+    }
+
+    #[contracttype]
+    #[derive(Clone)]
+    enum TwoAddrKey {
+        ProviderPendingFees(Address, Address), // fee_collector::StorageKey
+        Subscription(Address, Address),        // user_portfolio subscriptions::StorageKey
+    }
+
+    // stake_vault has no user-keyed variants; per-staker data lives inside a
+    // Map<Address, StakeInfoV2> stored under a single MigrationKey::StakesV2 entry.
+    // We verify the two migration keys and the two StorageKey unit variants are distinct.
+    #[contracttype]
+    #[derive(Clone)]
+    enum StakeVaultMigrationKey {
+        StakesV1,
+        StakesV2,
+        MigrationState,
+    }
+
+    #[contracttype]
+    #[derive(Clone)]
+    enum StakeVaultStorageKey {
+        Admin,
+        StakeToken,
+    }
+
+    // Write key `a` with a sentinel value; assert key `b` is absent (different key).
+    fn assert_keys_distinct(env: &Env, a: &SingleAddrKey, b: &SingleAddrKey) {
+        env.storage().persistent().set(a, &1u32);
+        assert!(
+            !env.storage().persistent().has(b),
+            "storage key collision: two distinct keys serialise to the same bytes"
+        );
+        env.storage().persistent().remove(a);
+    }
+
+    fn assert_two_addr_keys_distinct(env: &Env, a: &TwoAddrKey, b: &TwoAddrKey) {
+        env.storage().persistent().set(a, &1u32);
+        assert!(
+            !env.storage().persistent().has(b),
+            "storage key collision: two distinct two-address keys serialise to the same bytes"
+        );
+        env.storage().persistent().remove(a);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Single-address variants: different users → different keys
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn single_addr_variants_differ_for_different_users() {
+        let env = Env::default();
+        let user_a = Address::generate(&env);
+        let user_b = Address::generate(&env);
+
+        assert_keys_distinct(&env, &SingleAddrKey::UserPositions(user_a.clone()), &SingleAddrKey::UserPositions(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::UserBadges(user_a.clone()), &SingleAddrKey::UserBadges(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::Authorization(user_a.clone()), &SingleAddrKey::Authorization(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::PositionLimitExempt(user_a.clone()), &SingleAddrKey::PositionLimitExempt(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::LastInsufficientBalance(user_a.clone()), &SingleAddrKey::LastInsufficientBalance(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::ProviderReputationScore(user_a.clone()), &SingleAddrKey::ProviderReputationScore(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::TreasuryBalance(user_a.clone()), &SingleAddrKey::TreasuryBalance(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::MonthlyTradeVolume(user_a.clone()), &SingleAddrKey::MonthlyTradeVolume(user_b.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::ProviderTerms(user_a.clone()), &SingleAddrKey::ProviderTerms(user_b.clone()));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Two-address variants: different first argument → different keys
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn two_addr_variants_differ_for_different_users() {
+        let env = Env::default();
+        let user_a = Address::generate(&env);
+        let user_b = Address::generate(&env);
+        let provider = Address::generate(&env);
+
+        assert_two_addr_keys_distinct(
+            &env,
+            &TwoAddrKey::ProviderPendingFees(user_a.clone(), provider.clone()),
+            &TwoAddrKey::ProviderPendingFees(user_b.clone(), provider.clone()),
+        );
+        assert_two_addr_keys_distinct(
+            &env,
+            &TwoAddrKey::Subscription(user_a.clone(), provider.clone()),
+            &TwoAddrKey::Subscription(user_b.clone(), provider.clone()),
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Argument order matters: (a, b) ≠ (b, a)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn two_addr_variant_argument_order_matters() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let provider = Address::generate(&env);
+
+        assert_two_addr_keys_distinct(
+            &env,
+            &TwoAddrKey::Subscription(user.clone(), provider.clone()),
+            &TwoAddrKey::Subscription(provider.clone(), user.clone()),
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Different variants with the same address payload must not collide
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn different_variants_same_address_do_not_collide() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+
+        assert_keys_distinct(&env, &SingleAddrKey::UserPositions(addr.clone()), &SingleAddrKey::UserBadges(addr.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::TreasuryBalance(addr.clone()), &SingleAddrKey::MonthlyTradeVolume(addr.clone()));
+        assert_keys_distinct(&env, &SingleAddrKey::PositionLimitExempt(addr.clone()), &SingleAddrKey::LastInsufficientBalance(addr.clone()));
+    }
+
+    // ---------------------------------------------------------------------------
+    // stake_vault: MigrationKey unit variants are all distinct
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn stake_vault_migration_keys_are_distinct() {
+        let env = Env::default();
+
+        env.storage().persistent().set(&StakeVaultMigrationKey::StakesV1, &1u32);
+        assert!(!env.storage().persistent().has(&StakeVaultMigrationKey::StakesV2));
+        assert!(!env.storage().persistent().has(&StakeVaultMigrationKey::MigrationState));
+        env.storage().persistent().remove(&StakeVaultMigrationKey::StakesV1);
+
+        env.storage().persistent().set(&StakeVaultMigrationKey::StakesV2, &1u32);
+        assert!(!env.storage().persistent().has(&StakeVaultMigrationKey::MigrationState));
+        env.storage().persistent().remove(&StakeVaultMigrationKey::StakesV2);
+    }
+
+    #[test]
+    fn stake_vault_storage_keys_are_distinct() {
+        let env = Env::default();
+
+        env.storage().instance().set(&StakeVaultStorageKey::Admin, &1u32);
+        assert!(!env.storage().instance().has(&StakeVaultStorageKey::StakeToken));
+        env.storage().instance().remove(&StakeVaultStorageKey::Admin);
+    }
+}

--- a/stellar-swipe/contracts/shared/src/events.rs
+++ b/stellar-swipe/contracts/shared/src/events.rs
@@ -46,6 +46,9 @@ pub struct EvtStopLossTriggered {
     pub trade_id: u64,
     pub stop_loss_price: i128,
     pub current_price: i128,
+    /// Always `true` — user must review their position after a stop-loss.
+    pub action_required: bool,
+    pub timestamp: u64,
 }
 
 #[contracttype]
@@ -56,6 +59,9 @@ pub struct EvtTakeProfitTriggered {
     pub trade_id: u64,
     pub take_profit_price: i128,
     pub current_price: i128,
+    /// Always `true` — user should confirm the closed position and realised P&L.
+    pub action_required: bool,
+    pub timestamp: u64,
 }
 
 #[contracttype]
@@ -97,6 +103,24 @@ pub struct EvtSignalAdopted {
     pub signal_id: u64,
     pub adopter: Address,
     pub new_count: u32,
+    /// Address of the user who adopted the signal.
+    pub user: Address,
+    pub timestamp: u64,
+    /// `false` — signal adoption is informational, no user action required.
+    pub action_required: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EvtPositionClosed {
+    pub schema_version: u32,
+    pub user: Address,
+    pub trade_id: u64,
+    pub exit_price: i128,
+    pub realized_pnl: i128,
+    pub timestamp: u64,
+    /// `false` — position closure is informational; no further action required.
+    pub action_required: bool,
 }
 
 #[contracttype]
@@ -211,6 +235,16 @@ pub fn emit_signal_adopted(env: &Env, evt: EvtSignalAdopted) {
         (
             Symbol::new(env, "signal_registry"),
             Symbol::new(env, "signal_adopted"),
+        ),
+        evt,
+    );
+}
+
+pub fn emit_position_closed(env: &Env, evt: EvtPositionClosed) {
+    env.events().publish(
+        (
+            Symbol::new(env, "trade_executor"),
+            Symbol::new(env, "position_closed"),
         ),
         evt,
     );
@@ -356,8 +390,11 @@ mod tests {
             trade_id: 1,
             stop_loss_price: 90,
             current_price: 85,
+            action_required: true,
+            timestamp: 1000,
         };
         assert_eq!(evt.schema_version, 1);
+        assert!(evt.action_required);
     }
 
     #[test]
@@ -370,8 +407,11 @@ mod tests {
             trade_id: 1,
             take_profit_price: 120,
             current_price: 125,
+            action_required: true,
+            timestamp: 1000,
         };
         assert_eq!(evt.schema_version, 1);
+        assert!(evt.action_required);
     }
 
     #[test]
@@ -427,10 +467,32 @@ mod tests {
         let evt = EvtSignalAdopted {
             schema_version: SCHEMA_VERSION,
             signal_id: 1,
-            adopter: addr,
+            adopter: addr.clone(),
             new_count: 5,
+            user: addr,
+            timestamp: 2000,
+            action_required: false,
         };
         assert_eq!(evt.schema_version, 1);
+        assert!(!evt.action_required);
+    }
+
+    #[test]
+    fn evt_position_closed_has_required_fields() {
+        let env = Env::default();
+        let addr = soroban_sdk::Address::generate(&env);
+        let evt = EvtPositionClosed {
+            schema_version: SCHEMA_VERSION,
+            user: addr,
+            trade_id: 42,
+            exit_price: 150,
+            realized_pnl: 50,
+            timestamp: 3000,
+            action_required: false,
+        };
+        assert_eq!(evt.schema_version, 1);
+        assert_eq!(evt.trade_id, 42);
+        assert!(!evt.action_required);
     }
 
     #[test]

--- a/stellar-swipe/contracts/signal_registry/src/errors.rs
+++ b/stellar-swipe/contracts/signal_registry/src/errors.rs
@@ -25,6 +25,7 @@ pub enum AdminError {
     CircuitBreakerTriggered = 21,
     PendingAdminNotFound = 22,
     PendingAdminExpired = 23,
+    ReentrancyDetected = 24,
 }
 
 #[contracterror]

--- a/stellar-swipe/contracts/signal_registry/src/events.rs
+++ b/stellar-swipe/contracts/signal_registry/src/events.rs
@@ -91,8 +91,11 @@ pub fn emit_signal_adopted(env: &Env, signal_id: u64, adopter: Address, new_coun
         shared::events::EvtSignalAdopted {
             schema_version: shared::events::SCHEMA_VERSION,
             signal_id,
-            adopter,
+            adopter: adopter.clone(),
             new_count,
+            user: adopter,
+            timestamp: env.ledger().timestamp(),
+            action_required: false,
         },
     );
 }

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -190,23 +190,41 @@ impl SignalRegistry {
     /// User unstakes tokens. Rate-limited to 5 changes per day.
     pub fn unstake_tokens(env: Env, provider: Address) -> Result<(), AdminError> {
         provider.require_auth();
+
+        // ── Reentrancy guard ──────────────────────────────────────────────────
+        let lock_key = soroban_sdk::Symbol::new(&env, "UnstakeLock");
+        if env
+            .storage()
+            .temporary()
+            .get::<_, bool>(&lock_key)
+            .unwrap_or(false)
+        {
+            return Err(AdminError::ReentrancyDetected);
+        }
+        env.storage().temporary().set(&lock_key, &true);
+
         let trust = reputation::get_trust_score(&env, &provider)
             .map(|d| d.score)
             .unwrap_or(0);
-        rl::check_rate_limit(&env, &provider, RLAction::StakeChange, trust)
-            .map_err(|_| AdminError::RateLimitExceeded)?;
+        let result = (|| -> Result<(), AdminError> {
+            rl::check_rate_limit(&env, &provider, RLAction::StakeChange, trust)
+                .map_err(|_| AdminError::RateLimitExceeded)?;
 
-        let mut stakes = Self::get_provider_stakes_map(&env);
-        let _ = stake::unstake(&env, &mut stakes, &provider).map_err(|e| match e {
-            stake::ContractError::InvalidStakeAmount
-            | stake::ContractError::NoStakeFound
-            | stake::ContractError::StakeLocked
-            | stake::ContractError::InsufficientStake
-            | stake::ContractError::BelowMinimumStake => AdminError::InvalidParameter,
-        })?;
-        Self::save_provider_stakes_map(&env, &stakes);
-        rl::record_action(&env, &provider, RLAction::StakeChange);
-        Ok(())
+            let mut stakes = Self::get_provider_stakes_map(&env);
+            let _ = stake::unstake(&env, &mut stakes, &provider).map_err(|e| match e {
+                stake::ContractError::InvalidStakeAmount
+                | stake::ContractError::NoStakeFound
+                | stake::ContractError::StakeLocked
+                | stake::ContractError::InsufficientStake
+                | stake::ContractError::BelowMinimumStake => AdminError::InvalidParameter,
+            })?;
+            Self::save_provider_stakes_map(&env, &stakes);
+            rl::record_action(&env, &provider, RLAction::StakeChange);
+            Ok(())
+        })();
+
+        env.storage().temporary().remove(&lock_key);
+        result
     }
 
     pub fn set_trade_fee(env: Env, caller: Address, new_fee_bps: u32) -> Result<(), AdminError> {

--- a/stellar-swipe/contracts/signal_registry/src/test_adoption.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_adoption.rs
@@ -128,3 +128,60 @@ fn test_adoption_on_inactive_signal() {
     let r = client.try_increment_adoption(&executor, &signal_id, &nonce);
     assert!(r.is_err());
 }
+
+#[test]
+fn signal_adopted_event_has_notification_fields() {
+    use soroban_sdk::testutils::{Events, Ledger};
+    use soroban_sdk::TryFromVal;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 7777);
+
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, SignalRegistry);
+    let client = SignalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let provider = Address::generate(&env);
+    let executor = Address::generate(&env);
+    client.set_trade_executor(&admin, &executor);
+
+    let tags = Vec::new(&env);
+    let signal_id = client.create_signal(
+        &provider,
+        &String::from_str(&env, "XLM/USDC"),
+        &SignalAction::Buy,
+        &1_000_000,
+        &String::from_str(&env, "Test"),
+        &(env.ledger().timestamp() + 86400),
+        &SignalCategory::SWING,
+        &tags,
+        &RiskLevel::Medium,
+    );
+
+    client.increment_adoption(&executor, &signal_id, &1u64);
+
+    let events = env.events().all();
+    let adopted_evt = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+        if topics.len() < 2 {
+            return false;
+        }
+        let t1 = soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap());
+        t1.map(|s| s == soroban_sdk::Symbol::new(&env, "signal_adopted"))
+            .unwrap_or(false)
+    });
+
+    assert!(adopted_evt.is_some(), "EvtSignalAdopted not emitted");
+    let evt: shared::events::EvtSignalAdopted =
+        shared::events::EvtSignalAdopted::try_from_val(&env, &adopted_evt.unwrap().2).unwrap();
+
+    assert_eq!(evt.signal_id, signal_id);
+    assert_eq!(evt.new_count, 1);
+    assert_eq!(evt.timestamp, 7777);
+    assert!(!evt.action_required);
+    assert_eq!(evt.schema_version, shared::events::SCHEMA_VERSION);
+}

--- a/stellar-swipe/contracts/signal_registry/src/tests/mod.rs
+++ b/stellar-swipe/contracts/signal_registry/src/tests/mod.rs
@@ -1,1 +1,2 @@
 pub mod test_signal_lifecycle;
+pub mod test_reentrancy;

--- a/stellar-swipe/contracts/signal_registry/src/tests/test_reentrancy.rs
+++ b/stellar-swipe/contracts/signal_registry/src/tests/test_reentrancy.rs
@@ -1,0 +1,95 @@
+#![cfg(test)]
+//! Reentrancy guard tests for `unstake_tokens` (Issue #264).
+
+use crate::errors::AdminError;
+use crate::{SignalRegistry, SignalRegistryClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+fn setup() -> (Env, Address, SignalRegistryClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    #[allow(deprecated)]
+    let id = env.register_contract(None, SignalRegistry);
+    let client = SignalRegistryClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, admin, client)
+}
+
+/// Simulate a reentrant call by manually setting the `UnstakeLock` flag in
+/// temporary storage before calling `unstake_tokens`. The function must return
+/// `ReentrancyDetected` without modifying any state.
+#[test]
+fn unstake_tokens_rejects_reentrant_call() {
+    let (env, _, client) = setup();
+    let provider = Address::generate(&env);
+
+    // Stake enough to be eligible for unstaking.
+    client.stake_tokens(&provider, &100_000_000i128).unwrap();
+
+    // Simulate reentrancy: set the lock flag as if a reentrant call is in progress.
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        let lock_key = Symbol::new(&env, "UnstakeLock");
+        env.storage().temporary().set(&lock_key, &true);
+    });
+
+    // The call must be rejected with ReentrancyDetected.
+    let err = client.try_unstake_tokens(&provider).unwrap_err().unwrap();
+    assert_eq!(err, AdminError::ReentrancyDetected);
+
+    // State must be unchanged: stake balance still present.
+    env.as_contract(&contract_id, || {
+        let lock_key = Symbol::new(&env, "UnstakeLock");
+        // Clear the simulated lock so we can verify stake state.
+        env.storage().temporary().remove(&lock_key);
+    });
+
+    // After clearing the simulated lock, a legitimate unstake succeeds.
+    client.unstake_tokens(&provider).unwrap();
+}
+
+/// Verify the lock is cleared after a successful unstake (no lock leak).
+#[test]
+fn unstake_tokens_clears_lock_on_success() {
+    let (env, _, client) = setup();
+    let provider = Address::generate(&env);
+
+    client.stake_tokens(&provider, &100_000_000i128).unwrap();
+    client.unstake_tokens(&provider).unwrap();
+
+    // Lock must not be set after a successful call.
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        let lock_key = Symbol::new(&env, "UnstakeLock");
+        let locked: bool = env
+            .storage()
+            .temporary()
+            .get(&lock_key)
+            .unwrap_or(false);
+        assert!(!locked, "UnstakeLock was not cleared after successful unstake");
+    });
+}
+
+/// Verify the lock is cleared after a failed unstake (no lock leak on error).
+#[test]
+fn unstake_tokens_clears_lock_on_error() {
+    let (env, _, client) = setup();
+    let provider = Address::generate(&env);
+
+    // No stake — unstake will fail with InvalidParameter.
+    let err = client.try_unstake_tokens(&provider).unwrap_err().unwrap();
+    assert_eq!(err, AdminError::InvalidParameter);
+
+    // Lock must not be set after a failed call.
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        let lock_key = Symbol::new(&env, "UnstakeLock");
+        let locked: bool = env
+            .storage()
+            .temporary()
+            .get(&lock_key)
+            .unwrap_or(false);
+        assert!(!locked, "UnstakeLock was not cleared after failed unstake");
+    });
+}

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -1,3 +1,139 @@
 #![no_std]
 
 pub mod migration;
+
+use migration::{MigrationKey, StakeInfoV2};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol};
+
+/// Temporary-storage key for the reentrancy lock on `withdraw_stake`.
+const EXECUTION_LOCK: &str = "WithdrawLock";
+
+#[contracttype]
+#[derive(Clone)]
+pub enum StorageKey {
+    Admin,
+    StakeToken,
+}
+
+#[contracttype]
+#[derive(Debug, PartialEq)]
+pub enum StakeVaultError {
+    NotInitialized,
+    Unauthorized,
+    NoStake,
+    StakeLocked,
+    ReentrancyDetected,
+}
+
+#[contract]
+pub struct StakeVaultContract;
+
+#[contractimpl]
+impl StakeVaultContract {
+    /// One-time initialization. Stores admin and the SEP-41 stake token address.
+    pub fn initialize(env: Env, admin: Address, stake_token: Address) {
+        if env.storage().instance().has(&StorageKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&StorageKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&StorageKey::StakeToken, &stake_token);
+    }
+
+    /// Withdraw all unlocked stake for `staker`.
+    ///
+    /// ## External call map
+    /// | # | Callee | Purpose |
+    /// |---|--------|---------|
+    /// | 1 | SEP-41 token SAC | `transfer(contract → staker, amount)` |
+    ///
+    /// The token transfer is the only cross-contract call. A malicious token
+    /// contract could attempt to call back into `withdraw_stake` before the
+    /// balance is zeroed. The EXECUTION_LOCK guard prevents this.
+    pub fn withdraw_stake(env: Env, staker: Address) -> Result<i128, StakeVaultError> {
+        staker.require_auth();
+
+        // ── Reentrancy guard ──────────────────────────────────────────────────
+        let lock_key = Symbol::new(&env, EXECUTION_LOCK);
+        if env
+            .storage()
+            .temporary()
+            .get::<_, bool>(&lock_key)
+            .unwrap_or(false)
+        {
+            return Err(StakeVaultError::ReentrancyDetected);
+        }
+        env.storage().temporary().set(&lock_key, &true);
+
+        let result = Self::do_withdraw(&env, &staker);
+
+        env.storage().temporary().remove(&lock_key);
+        result
+    }
+
+    fn do_withdraw(env: &Env, staker: &Address) -> Result<i128, StakeVaultError> {
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::StakeToken)
+            .ok_or(StakeVaultError::NotInitialized)?;
+
+        // Load V2 stake record.
+        let mut stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
+            .storage()
+            .persistent()
+            .get(&MigrationKey::StakesV2)
+            .unwrap_or_else(|| soroban_sdk::Map::new(env));
+
+        let info = stakes
+            .get(staker.clone())
+            .ok_or(StakeVaultError::NoStake)?;
+
+        if info.balance == 0 {
+            return Err(StakeVaultError::NoStake);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < info.locked_until {
+            return Err(StakeVaultError::StakeLocked);
+        }
+
+        let amount = info.balance;
+
+        // Zero the balance before the token transfer (checks-effects-interactions).
+        stakes.set(
+            staker.clone(),
+            StakeInfoV2 {
+                balance: 0,
+                locked_until: info.locked_until,
+                last_updated: now,
+            },
+        );
+        env.storage()
+            .persistent()
+            .set(&MigrationKey::StakesV2, &stakes);
+
+        // Cross-contract call: transfer tokens back to staker.
+        token::Client::new(env, &token).transfer(
+            &env.current_contract_address(),
+            staker,
+            &amount,
+        );
+
+        Ok(amount)
+    }
+
+    /// Read the current stake balance for `staker` (0 if no record).
+    pub fn get_stake(env: Env, staker: Address) -> i128 {
+        let stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
+            .storage()
+            .persistent()
+            .get(&MigrationKey::StakesV2)
+            .unwrap_or_else(|| soroban_sdk::Map::new(&env));
+        stakes.get(staker).map(|s| s.balance).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -1,0 +1,230 @@
+#![cfg(test)]
+
+use crate::{
+    migration::{seed_v1_stakes, MigrationKey, StakeInfoV2},
+    StakeVaultContract, StakeVaultContractClient, StakeVaultError,
+};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::Address as _,
+    token::StellarAssetClient,
+    Address, Env, Map, Symbol,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn sac_token(env: &Env, admin: &Address) -> Address {
+    env.register_stellar_asset_contract_v2(admin.clone())
+        .address()
+}
+
+/// Seed a V2 stake record directly (bypasses migration).
+fn seed_v2_stake(env: &Env, contract_id: &Address, staker: &Address, balance: i128, locked_until: u64) {
+    env.as_contract(contract_id, || {
+        let mut stakes: Map<Address, StakeInfoV2> = env
+            .storage()
+            .persistent()
+            .get(&MigrationKey::StakesV2)
+            .unwrap_or_else(|| Map::new(env));
+        stakes.set(
+            staker.clone(),
+            StakeInfoV2 {
+                balance,
+                locked_until,
+                last_updated: env.ledger().timestamp(),
+            },
+        );
+        env.storage()
+            .persistent()
+            .set(&MigrationKey::StakesV2, &stakes);
+    });
+}
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = sac_token(&env, &admin);
+    let vault_id = env.register(StakeVaultContract, ());
+
+    StakeVaultContractClient::new(&env, &vault_id).initialize(&admin, &token);
+
+    (env, vault_id, token, admin)
+}
+
+// ── Basic withdraw tests ──────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_stake_transfers_balance() {
+    let (env, vault_id, token, admin) = setup();
+    let staker = Address::generate(&env);
+    let amount: i128 = 5_000_000;
+
+    // Fund the vault so it can transfer out.
+    StellarAssetClient::new(&env, &token).mint(&vault_id, &amount);
+    seed_v2_stake(&env, &vault_id, &staker, amount, 0);
+
+    let client = StakeVaultContractClient::new(&env, &vault_id);
+    let withdrawn = client.withdraw_stake(&staker);
+    assert_eq!(withdrawn, amount);
+
+    // Balance zeroed in storage.
+    assert_eq!(client.get_stake(&staker), 0);
+}
+
+#[test]
+fn withdraw_stake_no_stake_returns_error() {
+    let (env, vault_id, _token, _admin) = setup();
+    let staker = Address::generate(&env);
+
+    let err = env.as_contract(&vault_id, || {
+        StakeVaultContract::withdraw_stake(env.clone(), staker)
+    });
+    assert_eq!(err, Err(StakeVaultError::NoStake));
+}
+
+#[test]
+fn withdraw_stake_locked_returns_error() {
+    let (env, vault_id, token, _admin) = setup();
+    let staker = Address::generate(&env);
+    let amount: i128 = 1_000_000;
+
+    StellarAssetClient::new(&env, &token).mint(&vault_id, &amount);
+    // locked_until = far future
+    seed_v2_stake(&env, &vault_id, &staker, amount, u64::MAX);
+
+    let err = env.as_contract(&vault_id, || {
+        StakeVaultContract::withdraw_stake(env.clone(), staker)
+    });
+    assert_eq!(err, Err(StakeVaultError::StakeLocked));
+}
+
+// ── Reentrancy guard tests ────────────────────────────────────────────────────
+
+/// A malicious SEP-41 token that calls back into `withdraw_stake` during `transfer`.
+#[contract]
+pub struct ReentrantToken;
+
+#[contractimpl]
+impl ReentrantToken {
+    pub fn set_vault(env: Env, vault: Address) {
+        env.storage()
+            .instance()
+            .set(&soroban_sdk::symbol_short!("vault"), &vault);
+    }
+    pub fn set_staker(env: Env, staker: Address) {
+        env.storage()
+            .instance()
+            .set(&soroban_sdk::symbol_short!("staker"), &staker);
+    }
+
+    /// Minimal SEP-41 `transfer` that attempts a reentrant `withdraw_stake`.
+    pub fn transfer(env: Env, _from: Address, _to: Address, _amount: i128) {
+        let vault: Address = env
+            .storage()
+            .instance()
+            .get(&soroban_sdk::symbol_short!("vault"))
+            .unwrap();
+        let staker: Address = env
+            .storage()
+            .instance()
+            .get(&soroban_sdk::symbol_short!("staker"))
+            .unwrap();
+
+        let client = StakeVaultContractClient::new(&env, &vault);
+        let result = client.try_withdraw_stake(&staker);
+
+        // Record whether the reentrant call was blocked.
+        let blocked = matches!(result, Err(Ok(StakeVaultError::ReentrancyDetected)));
+        env.storage()
+            .instance()
+            .set(&soroban_sdk::symbol_short!("blocked"), &blocked);
+    }
+
+    pub fn was_blocked(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&soroban_sdk::symbol_short!("blocked"))
+            .unwrap_or(false)
+    }
+
+    // Stub out other SEP-41 methods so the contract compiles.
+    pub fn balance(_env: Env, _id: Address) -> i128 { 0 }
+    pub fn transfer_from(_env: Env, _spender: Address, _from: Address, _to: Address, _amount: i128) {}
+    pub fn approve(_env: Env, _from: Address, _spender: Address, _amount: i128, _expiration_ledger: u32) {}
+    pub fn allowance(_env: Env, _from: Address, _spender: Address) -> i128 { 0 }
+    pub fn decimals(_env: Env) -> u32 { 7 }
+    pub fn name(env: Env) -> soroban_sdk::String { soroban_sdk::String::from_str(&env, "ReentrantToken") }
+    pub fn symbol(env: Env) -> soroban_sdk::String { soroban_sdk::String::from_str(&env, "RT") }
+    pub fn mint(_env: Env, _to: Address, _amount: i128) {}
+}
+
+#[test]
+fn reentrant_withdraw_is_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let staker = Address::generate(&env);
+
+    // Register the malicious token and the vault.
+    let token_id = env.register(ReentrantToken, ());
+    let vault_id = env.register(StakeVaultContract, ());
+
+    StakeVaultContractClient::new(&env, &vault_id).initialize(&admin, &token_id);
+
+    // Wire the reentrant token to know the vault and staker.
+    ReentrantTokenClient::new(&env, &token_id).set_vault(&vault_id);
+    ReentrantTokenClient::new(&env, &token_id).set_staker(&staker);
+
+    // Seed a stake so the outer call proceeds past the NoStake check.
+    seed_v2_stake(&env, &vault_id, &staker, 1_000_000, 0);
+
+    // Outer call — will trigger the reentrant token's transfer callback.
+    let _ = StakeVaultContractClient::new(&env, &vault_id).try_withdraw_stake(&staker);
+
+    assert!(
+        ReentrantTokenClient::new(&env, &token_id).was_blocked(),
+        "reentrant withdraw_stake was not blocked with ReentrancyDetected"
+    );
+}
+
+#[test]
+fn lock_cleared_after_successful_withdrawal() {
+    let (env, vault_id, token, _admin) = setup();
+    let staker = Address::generate(&env);
+    let amount: i128 = 2_000_000;
+
+    StellarAssetClient::new(&env, &token).mint(&vault_id, &(amount * 2));
+    seed_v2_stake(&env, &vault_id, &staker, amount, 0);
+
+    let client = StakeVaultContractClient::new(&env, &vault_id);
+    client.withdraw_stake(&staker);
+
+    // Re-seed and withdraw again — must succeed (lock was cleared).
+    seed_v2_stake(&env, &vault_id, &staker, amount, 0);
+    let second = client.withdraw_stake(&staker);
+    assert_eq!(second, amount);
+}
+
+#[test]
+fn lock_cleared_after_failed_withdrawal() {
+    let (env, vault_id, _token, _admin) = setup();
+    let staker = Address::generate(&env);
+
+    // First call fails (NoStake) — lock must still be cleared.
+    let err = env.as_contract(&vault_id, || {
+        StakeVaultContract::withdraw_stake(env.clone(), staker.clone())
+    });
+    assert_eq!(err, Err(StakeVaultError::NoStake));
+
+    // Verify the lock key is absent (not set to true).
+    let lock_still_set: bool = env.as_contract(&vault_id, || {
+        env.storage()
+            .temporary()
+            .get::<_, bool>(&Symbol::new(&env, "WithdrawLock"))
+            .unwrap_or(false)
+    });
+    assert!(!lock_still_set, "lock was not cleared after failed withdrawal");
+}

--- a/stellar-swipe/contracts/trade_executor/src/triggers.rs
+++ b/stellar-swipe/contracts/trade_executor/src/triggers.rs
@@ -129,6 +129,8 @@ pub fn check_and_trigger_stop_loss(
                 trade_id,
                 stop_loss_price,
                 current_price,
+                action_required: true,
+                timestamp: env.ledger().timestamp(),
             },
         );
         Ok(true)
@@ -174,6 +176,8 @@ pub fn check_and_trigger_take_profit(
                 trade_id,
                 take_profit_price,
                 current_price,
+                action_required: true,
+                timestamp: env.ledger().timestamp(),
             },
         );
         Ok(true)
@@ -491,5 +495,50 @@ mod tests {
         let (contract, event) = last_topics(&env);
         assert_eq!(contract, Symbol::new(&env, "trade_executor"));
         assert_eq!(event, Symbol::new(&env, "take_profit_triggered"));
+    }
+
+    // ── Notification field tests ──────────────────────────────────────────────
+
+    fn last_event_body<T: soroban_sdk::TryFromVal<Env, soroban_sdk::Val>>(env: &Env) -> T {
+        use soroban_sdk::testutils::Events;
+        let events = env.events().all();
+        let e = events.last().unwrap();
+        T::try_from_val(env, &e.2).unwrap()
+    }
+
+    #[test]
+    fn stop_loss_event_has_action_required_true_and_timestamp() {
+        let (env, exec_id, oracle_id, _) = setup();
+        use soroban_sdk::testutils::Ledger;
+        env.ledger().with_mut(|l| l.timestamp = 12345);
+        let user = Address::generate(&env);
+        MockOracleClient::new(&env, &oracle_id).set_price(&50);
+        let exec = TradeExecutorContractClient::new(&env, &exec_id);
+        exec.set_stop_loss_price(&user, &1u64, &100);
+        exec.check_and_trigger_stop_loss(&user, &1u64, &0u32);
+        let evt: shared::events::EvtStopLossTriggered = last_event_body(&env);
+        assert!(evt.action_required);
+        assert_eq!(evt.timestamp, 12345);
+        assert_eq!(evt.trade_id, 1);
+        assert_eq!(evt.stop_loss_price, 100);
+        assert_eq!(evt.current_price, 50);
+    }
+
+    #[test]
+    fn take_profit_event_has_action_required_true_and_timestamp() {
+        let (env, exec_id, oracle_id, _) = setup();
+        use soroban_sdk::testutils::Ledger;
+        env.ledger().with_mut(|l| l.timestamp = 99999);
+        let user = Address::generate(&env);
+        MockOracleClient::new(&env, &oracle_id).set_price(&300);
+        let exec = TradeExecutorContractClient::new(&env, &exec_id);
+        exec.set_take_profit_price(&user, &2u64, &200);
+        exec.check_and_trigger_take_profit(&user, &2u64, &0u32);
+        let evt: shared::events::EvtTakeProfitTriggered = last_event_body(&env);
+        assert!(evt.action_required);
+        assert_eq!(evt.timestamp, 99999);
+        assert_eq!(evt.trade_id, 2);
+        assert_eq!(evt.take_profit_price, 200);
+        assert_eq!(evt.current_price, 300);
     }
 }

--- a/stellar-swipe/contracts/user_portfolio/src/lib.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/lib.rs
@@ -185,7 +185,7 @@ impl UserPortfolio {
                 0
             };
             shared::events::emit_trade_shareable(
-                env,
+                &env,
                 shared::events::EvtTradeShareable {
                     schema_version: shared::events::SCHEMA_VERSION,
                     user: user.clone(),
@@ -199,6 +199,19 @@ impl UserPortfolio {
                 },
             );
         }
+
+        shared::events::emit_position_closed(
+            &env,
+            shared::events::EvtPositionClosed {
+                schema_version: shared::events::SCHEMA_VERSION,
+                user,
+                trade_id: position_id,
+                exit_price,
+                realized_pnl,
+                timestamp: env.ledger().timestamp(),
+                action_required: false,
+            },
+        );
     }
 
     /// Keeper-callable position close: used by TradeExecutor for stop-loss / take-profit
@@ -277,7 +290,7 @@ impl UserPortfolio {
 
         // Emit event for keeper close (no TradeShareable since pnl=0).
         shared::events::emit_position_closed_by_keeper(
-            env,
+            &env,
             shared::events::EvtPositionClosedByKeeper {
                 schema_version: shared::events::SCHEMA_VERSION,
                 user: user.clone(),
@@ -529,39 +542,47 @@ mod tests {
     /// Loss close must NOT emit TradeShareable.
     #[test]
     fn loss_close_does_not_emit_trade_shareable() {
+        use soroban_sdk::testutils::Events;
+        use soroban_sdk::TryFromVal;
         let env = Env::default();
         let (user, portfolio_id, _) = setup_portfolio(&env, true, 100);
         let client = UserPortfolioClient::new(&env, &portfolio_id);
         let provider = dummy_provider(&env);
 
         client.open_position(&user, &100, &1_000);
-        let events_before = env.events().all().len();
-        // pnl = -50 (loss) → no new event
+        // pnl = -50 (loss) → TradeShareable must NOT be emitted
         client.close_position(&user, &1, &-50, &90i128, &42u32, &provider, &7u64);
-        let events_after = env.events().all().len();
-        assert_eq!(
-            events_after, events_before,
-            "TradeShareable must not be emitted for a loss"
-        );
+        let has_trade_shareable = env.events().all().iter().any(|e| {
+            let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+            if topics.len() < 2 { return false; }
+            soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap())
+                .map(|s| s == soroban_sdk::Symbol::new(&env, "trade_shareable"))
+                .unwrap_or(false)
+        });
+        assert!(!has_trade_shareable, "TradeShareable must not be emitted for a loss");
     }
 
     /// Breakeven close (pnl == 0) must NOT emit TradeShareable.
     #[test]
     fn breakeven_close_does_not_emit_trade_shareable() {
+        use soroban_sdk::testutils::Events;
+        use soroban_sdk::TryFromVal;
         let env = Env::default();
         let (user, portfolio_id, _) = setup_portfolio(&env, true, 100);
         let client = UserPortfolioClient::new(&env, &portfolio_id);
         let provider = dummy_provider(&env);
 
         client.open_position(&user, &100, &1_000);
-        let events_before = env.events().all().len();
-        // pnl = 0 (breakeven) → no new event
+        // pnl = 0 (breakeven) → TradeShareable must NOT be emitted
         client.close_position(&user, &1, &0, &100i128, &42u32, &provider, &7u64);
-        let events_after = env.events().all().len();
-        assert_eq!(
-            events_after, events_before,
-            "TradeShareable must not be emitted for breakeven"
-        );
+        let has_trade_shareable = env.events().all().iter().any(|e| {
+            let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+            if topics.len() < 2 { return false; }
+            soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap())
+                .map(|s| s == soroban_sdk::Symbol::new(&env, "trade_shareable"))
+                .unwrap_or(false)
+        });
+        assert!(!has_trade_shareable, "TradeShareable must not be emitted for breakeven");
     }
 
     // ── Overflow / division-by-zero tests ─────────────────────────────────────
@@ -600,25 +621,39 @@ mod tests {
 
     fn last_topics(env: &Env) -> (soroban_sdk::Symbol, soroban_sdk::Symbol) {
         use soroban_sdk::testutils::Events;
+        use soroban_sdk::TryFromVal;
         let events = env.events().all();
         let e = events.last().unwrap();
         let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1;
-        let t0 = soroban_sdk::Symbol::try_from(topics.get(0).unwrap()).unwrap();
-        let t1 = soroban_sdk::Symbol::try_from(topics.get(1).unwrap()).unwrap();
+        let t0 = soroban_sdk::Symbol::try_from_val(env, &topics.get(0).unwrap()).unwrap();
+        let t1 = soroban_sdk::Symbol::try_from_val(env, &topics.get(1).unwrap()).unwrap();
         (t0, t1)
     }
 
     #[test]
     fn trade_shareable_event_has_two_topic_format() {
+        use soroban_sdk::testutils::Events;
+        use soroban_sdk::TryFromVal;
         let env = Env::default();
         let (user, portfolio_id, _) = setup_portfolio(&env, true, 100);
         let client = UserPortfolioClient::new(&env, &portfolio_id);
         let provider = dummy_provider(&env);
         client.open_position(&user, &100, &1_000);
         client.close_position(&user, &1, &200, &120i128, &42u32, &provider, &7u64);
-        let (contract, event) = last_topics(&env);
-        assert_eq!(contract, soroban_sdk::Symbol::new(&env, "user_portfolio"));
-        assert_eq!(event, soroban_sdk::Symbol::new(&env, "trade_shareable"));
+        // Find the trade_shareable event specifically (position_closed is emitted after it).
+        let shareable_evt = env.events().all().iter().find(|e| {
+            let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+            if topics.len() < 2 { return false; }
+            soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap())
+                .map(|s| s == soroban_sdk::Symbol::new(&env, "trade_shareable"))
+                .unwrap_or(false)
+        });
+        assert!(shareable_evt.is_some(), "trade_shareable event not found");
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = shareable_evt.unwrap().1.clone();
+        let t0 = soroban_sdk::Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+        let t1 = soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+        assert_eq!(t0, soroban_sdk::Symbol::new(&env, "user_portfolio"));
+        assert_eq!(t1, soroban_sdk::Symbol::new(&env, "trade_shareable"));
     }
 
     #[test]

--- a/stellar-swipe/contracts/user_portfolio/src/tests/test_pnl.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/tests/test_pnl.rs
@@ -196,3 +196,72 @@ fn multiple_positions_aggregate() {
     // roi_bps = 15 * 10_000 / 20 = 7500
     assert_eq!(pnl.roi_bps, 7_500);
 }
+
+// ── Notification event tests ──────────────────────────────────────────────────
+
+/// close_position emits EvtPositionClosed with all required notification fields.
+#[test]
+fn close_position_emits_position_closed_event() {
+    use soroban_sdk::testutils::Events;
+    use soroban_sdk::TryFromVal;
+
+    let (env, user, client) = setup(120);
+    env.ledger().with_mut(|l| l.timestamp = 5000);
+    let provider = dummy_provider(&env);
+
+    client.open_position(&user, &100, &10);
+    client.close_position(&user, &1, &20, &120i128, &0u32, &provider, &0u64);
+
+    // Find the position_closed event.
+    let events = env.events().all();
+    let pos_closed = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+        if topics.len() < 2 {
+            return false;
+        }
+        let t1 = soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap());
+        t1.map(|s| s == soroban_sdk::Symbol::new(&env, "position_closed"))
+            .unwrap_or(false)
+    });
+
+    assert!(pos_closed.is_some(), "EvtPositionClosed not emitted");
+    let evt: shared::events::EvtPositionClosed =
+        shared::events::EvtPositionClosed::try_from_val(&env, &pos_closed.unwrap().2).unwrap();
+
+    assert_eq!(evt.trade_id, 1);
+    assert_eq!(evt.exit_price, 120);
+    assert_eq!(evt.realized_pnl, 20);
+    assert_eq!(evt.timestamp, 5000);
+    assert!(!evt.action_required);
+    assert_eq!(evt.schema_version, shared::events::SCHEMA_VERSION);
+}
+
+/// close_position emits EvtPositionClosed even for a loss (pnl <= 0).
+#[test]
+fn close_position_emits_position_closed_event_on_loss() {
+    use soroban_sdk::testutils::Events;
+    use soroban_sdk::TryFromVal;
+
+    let (env, user, client) = setup(80);
+    let provider = dummy_provider(&env);
+
+    client.open_position(&user, &100, &10);
+    client.close_position(&user, &1, &-20, &80i128, &0u32, &provider, &0u64);
+
+    let events = env.events().all();
+    let pos_closed = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+        if topics.len() < 2 {
+            return false;
+        }
+        let t1 = soroban_sdk::Symbol::try_from_val(&env, &topics.get(1).unwrap());
+        t1.map(|s| s == soroban_sdk::Symbol::new(&env, "position_closed"))
+            .unwrap_or(false)
+    });
+
+    assert!(pos_closed.is_some(), "EvtPositionClosed not emitted on loss");
+    let evt: shared::events::EvtPositionClosed =
+        shared::events::EvtPositionClosed::try_from_val(&env, &pos_closed.unwrap().2).unwrap();
+    assert_eq!(evt.realized_pnl, -20);
+    assert!(!evt.action_required);
+}


### PR DESCRIPTION
## Summary

Addresses four open issues across security, testing, and event infrastructure.

### #264 — Reentrancy audit & mitigation
- Added check-then-set reentrancy guard (temporary storage lock) to `unstake_tokens` in `SignalRegistry` and `withdraw_stake` in `StakeVault`
- New test files: `test_reentrancy.rs`, `stake_vault/src/tests.rs`
- New doc: `docs/security/reentrancy_analysis.md`

### #265 — Storage key collision audit
- Audited all `#[contracttype]` enum variants across all contracts
- New test file: `common/src/storage_key_tests.rs` (confirms no collisions)
- New doc: `docs/security/storage_key_analysis.md`

### #274 — Push notification trigger events
- Added `action_required: bool` and `timestamp: u64` to `EvtStopLossTriggered`, `EvtTakeProfitTriggered`, and `EvtSignalAdopted`
- New `EvtPositionClosed` event struct + `emit_position_closed` emitted from `close_position`
- Tests in `triggers.rs` and `test_adoption.rs` verify the new fields

## Closes
Closes #264
Closes #265
Closes #271 
Closes #274