### PR TITLE
feat: handle orphaned signals when provider account is deleted

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/events.rs
+++ b/stellar-swipe/contracts/signal_registry/src/events.rs
@@ -333,3 +333,8 @@ pub fn emit_reputation_updated(env: &Env, provider: Address, old_score: u32, new
         },
     );
 }
+
+pub fn emit_signal_orphaned(env: &Env, signal_id: u64, reason: String) {
+    let topics = (Symbol::new(env, "signal_orphaned"),);
+    env.events().publish(topics, (signal_id, reason));
+}

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -556,6 +556,26 @@ impl SignalRegistry {
         })
     }
 
+    /// Returns `true` if the Stellar account for `provider` still exists on-chain.
+    /// A merged (deleted) account returns `false`.
+    fn check_provider_exists(env: &Env, provider: &Address) -> bool {
+        env.accounts().get(provider).is_some()
+    }
+
+    /// Mark a signal as orphaned (provider account deleted), emit the event, and persist.
+    fn orphan_signal(env: &Env, signals: &mut Map<u64, Signal>, signal_id: u64) {
+        if let Some(mut signal) = signals.get(signal_id) {
+            signal.status = SignalStatus::ProviderDeleted;
+            signals.set(signal_id, signal);
+            Self::save_signals_map(env, signals);
+            events::emit_signal_orphaned(
+                env,
+                signal_id,
+                String::from_str(env, "provider_account_deleted"),
+            );
+        }
+    }
+
     /* =========================
        PUBLIC API
     ========================== */
@@ -619,6 +639,11 @@ impl SignalRegistry {
     ) -> Result<u64, AdminError> {
         // Check if signals are paused
         admin::require_not_paused(env, String::from_str(env, CAT_SIGNALS))?;
+
+        // Verify provider account still exists on Stellar
+        if !Self::check_provider_exists(env, &provider) {
+            return Err(AdminError::Unauthorized);
+        }
 
         // Rate limit: signal submission
         let trust = reputation::get_trust_score(env, &provider)
@@ -709,8 +734,19 @@ impl SignalRegistry {
     }
 
     pub fn get_signal(env: Env, signal_id: u64) -> Option<Signal> {
-        let signals = Self::get_signals_map(&env);
-        signals.get(signal_id)
+        let mut signals = Self::get_signals_map(&env);
+        let signal = signals.get(signal_id)?;
+
+        // If signal is still active, check whether the provider account still exists.
+        // If the provider has merged/deleted their account, orphan the signal in-place.
+        if signal.status == SignalStatus::Active
+            && !Self::check_provider_exists(&env, &signal.provider)
+        {
+            Self::orphan_signal(&env, &mut signals, signal_id);
+            return signals.get(signal_id);
+        }
+
+        Some(signal)
     }
 
     /// Return the signal if `viewer` is allowed to see it. Non-[`SignalCategory::PREMIUM`]
@@ -1264,6 +1300,12 @@ impl SignalRegistry {
         let mut signal = signals.get(signal_id).ok_or(AdminError::InvalidParameter)?;
 
         if signal.status != SignalStatus::Active {
+            return Err(AdminError::InvalidParameter);
+        }
+
+        // Block new copies of orphaned signals (provider account deleted)
+        if !Self::check_provider_exists(&env, &signal.provider) {
+            Self::orphan_signal(&env, &mut signals, signal_id);
             return Err(AdminError::InvalidParameter);
         }
 

--- a/stellar-swipe/contracts/signal_registry/src/types.rs
+++ b/stellar-swipe/contracts/signal_registry/src/types.rs
@@ -31,6 +31,9 @@ pub enum SignalStatus {
     Expired,
     Successful,
     Failed,
+    /// Provider's Stellar account was deleted (merged). Signal is orphaned.
+    /// Existing copiers may still close open positions; new copies are blocked.
+    ProviderDeleted,
 }
 
 #[contracttype]


### PR DESCRIPTION
- Add ProviderDeleted variant to SignalStatus enum
- Add check_provider_exists helper using env.accounts().get()
- Add orphan_signal helper that marks status and emits SignalOrphaned event
- Verify provider account exists in create_signal_internal (blocks submission)
- Lazily orphan active signals in get_signal when provider is gone
- Block new copies in increment_adoption when provider account is deleted
- Existing copiers can still close open positions on orphaned signals

closes #385 