### PR TITLE
feat: add network congestion error handling to trade_executor

### DIFF
--- a/stellar-swipe/contracts/trade_executor/src/errors.rs
+++ b/stellar-swipe/contracts/trade_executor/src/errors.rs
@@ -9,6 +9,19 @@ pub struct InsufficientBalanceDetail {
     pub available: i128,
 }
 
+/// Populated when [`ContractError::NetworkCongestion`] is returned.
+/// `retry_after_ledger` is the earliest ledger at which the caller should retry.
+/// A value of `0` means the contract has no estimate — retry at caller's discretion.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NetworkErrorDetail {
+    /// Earliest ledger sequence the caller should retry at.
+    pub retry_after_ledger: u32,
+    /// Whether this error is transient (true) or permanent (false).
+    /// Frontend should only offer a retry option when `is_transient == true`.
+    pub is_transient: bool,
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -31,4 +44,8 @@ pub enum ContractError {
     DCAPlanAlreadyExists = 16,
     SignalExpired = 17,
     IntervalNotDue = 18,
+    /// Transient: the network is congested. Caller should read `NetworkErrorDetail`
+    /// via [`crate::TradeExecutorContract::get_network_error_detail`] and retry
+    /// after `retry_after_ledger`.
+    NetworkCongestion = 19,
 }

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -8,7 +8,7 @@ pub mod risk_gates;
 pub mod sdex;
 pub mod triggers;
 
-use errors::{ContractError, InsufficientBalanceDetail};
+use errors::{ContractError, InsufficientBalanceDetail, NetworkErrorDetail};
 use risk_gates::{
     check_user_balance, resolve_trade_amount, validate_and_record_position,
     DEFAULT_ESTIMATED_COPY_TRADE_FEE, MAX_BATCH_SIZE,
@@ -47,6 +47,8 @@ pub enum StorageKey {
     OracleWhitelistCount,
     /// DCA plan for (user, signal_id). Stores a `DCAPlan`.
     DCAPlan(Address, u64),
+    /// Last network congestion detail for a user (cleared on successful execute_copy_trade).
+    LastNetworkError(Address),
 }
 
 /// Temporary-storage key for the reentrancy lock on `execute_copy_trade`.
@@ -267,6 +269,25 @@ impl TradeExecutorContract {
         env.storage().instance().get(&key)
     }
 
+    /// Detail for the last `NetworkCongestion` error from [`Self::execute_copy_trade`].
+    /// Returns `None` if the last call succeeded or no congestion has occurred.
+    /// Frontend should check `is_transient` before offering a retry option.
+    pub fn get_network_error_detail(env: Env, user: Address) -> Option<NetworkErrorDetail> {
+        let key = StorageKey::LastNetworkError(user);
+        env.storage().instance().get(&key)
+    }
+
+    /// Returns `true` for errors that are transient (network/infrastructure) and
+    /// `false` for permanent logic errors. Used internally and exposed for testing.
+    pub fn is_transient_error(error: ContractError) -> bool {
+        matches!(
+            error,
+            ContractError::NetworkCongestion
+                | ContractError::OracleUnavailable
+                | ContractError::OraclePriceStale
+        )
+    }
+
     /// Execute a copy trade.
     ///
     /// ## Cross-contract call budget (Issue #306 optimization)
@@ -358,6 +379,7 @@ impl TradeExecutorContract {
         // ── Cross-contract call #1: SEP-41 balance check ──────────────────────
         let fee = effective_estimated_fee(&env);
         let bal_key = StorageKey::LastInsufficientBalance(user.clone());
+        let net_key = StorageKey::LastNetworkError(user.clone());
         match check_user_balance(&env, &user, &token, effective_amount, fee) {
             Ok(()) => {
                 env.storage().instance().remove(&bal_key);
@@ -370,7 +392,26 @@ impl TradeExecutorContract {
         }
 
         // ── Cross-contract call #2: batched position-limit check + record ─────
-        validate_and_record_position(&env, &portfolio, &user, exempt)?;
+        let record_result = validate_and_record_position(&env, &portfolio, &user, exempt);
+        match record_result {
+            Ok(()) => {
+                env.storage().instance().remove(&net_key);
+            }
+            Err(ContractError::OracleUnavailable) | Err(ContractError::OraclePriceStale) => {
+                // Transient: infrastructure unavailable — surface as NetworkCongestion
+                let detail = NetworkErrorDetail {
+                    retry_after_ledger: env.ledger().sequence().saturating_add(5),
+                    is_transient: true,
+                };
+                env.storage().instance().set(&net_key, &detail);
+                env.storage().temporary().remove(&lock_key);
+                return Err(ContractError::NetworkCongestion);
+            }
+            Err(e) => {
+                env.storage().temporary().remove(&lock_key);
+                return Err(e);
+            }
+        }
 
         env.storage().temporary().remove(&lock_key);
         Ok(())

--- a/stellar-swipe/contracts/trade_executor/src/test.rs
+++ b/stellar-swipe/contracts/trade_executor/src/test.rs
@@ -854,3 +854,125 @@ fn volume_resets_on_new_day() {
     // Day 1: limit resets — trade should succeed again.
     exec.execute_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
 }
+
+// ── Network Congestion Tests ──────────────────────────────────────────────────
+
+/// Mock portfolio that simulates a transient oracle failure (network congestion).
+#[contract]
+pub struct MockCongestedPortfolio;
+
+#[contractimpl]
+impl MockCongestedPortfolio {
+    pub fn validate_and_record(_env: Env, _user: Address, _max_positions: u32) -> u32 {
+        // Simulate oracle unavailable (transient network failure)
+        panic!("oracle unavailable");
+    }
+    pub fn has_position(_env: Env, _user: Address, _trade_id: u64) -> bool {
+        false
+    }
+    pub fn close_position(_env: Env, _user: Address, _trade_id: u64, _pnl: i128) {}
+}
+
+fn setup_with_congested_portfolio(
+    user_balance: i128,
+) -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token = sac_token(&env);
+    let portfolio_id = env.register(MockCongestedPortfolio, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+
+    StellarAssetClient::new(&env, &token).mint(&user, &user_balance);
+
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.initialize(&admin);
+    exec.set_user_portfolio(&portfolio_id);
+
+    (env, exec_id, user, admin, token)
+}
+
+/// A transient oracle failure during execute_copy_trade returns NetworkCongestion,
+/// not a permanent logic error.
+#[test]
+fn network_congestion_returns_network_congestion_error() {
+    let (env, exec_id, user, _admin, token) = setup_with_congested_portfolio(TRADE_AMOUNT * 10);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    let result = exec.try_execute_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
+    assert_eq!(result, Err(Ok(ContractError::NetworkCongestion)));
+}
+
+/// After a NetworkCongestion error, get_network_error_detail returns a transient detail
+/// with retry_after_ledger set in the future.
+#[test]
+fn network_congestion_persists_retry_detail() {
+    let (env, exec_id, user, _admin, token) = setup_with_congested_portfolio(TRADE_AMOUNT * 10);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    let _ = exec.try_execute_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
+
+    let detail = exec.get_network_error_detail(&user).expect("detail must be set");
+    assert!(detail.is_transient, "network congestion must be transient");
+    assert!(
+        detail.retry_after_ledger > 0,
+        "retry_after_ledger must be non-zero"
+    );
+}
+
+/// A permanent logic error (InsufficientBalance) is NOT classified as transient.
+#[test]
+fn insufficient_balance_is_not_transient() {
+    use crate::errors::ContractError as CE;
+    assert!(
+        !TradeExecutorContract::is_transient_error(CE::InsufficientBalance),
+        "InsufficientBalance must be permanent"
+    );
+    assert!(
+        !TradeExecutorContract::is_transient_error(CE::PositionLimitReached),
+        "PositionLimitReached must be permanent"
+    );
+    assert!(
+        !TradeExecutorContract::is_transient_error(CE::Unauthorized),
+        "Unauthorized must be permanent"
+    );
+}
+
+/// NetworkCongestion and oracle errors are classified as transient.
+#[test]
+fn network_and_oracle_errors_are_transient() {
+    use crate::errors::ContractError as CE;
+    assert!(
+        TradeExecutorContract::is_transient_error(CE::NetworkCongestion),
+        "NetworkCongestion must be transient"
+    );
+    assert!(
+        TradeExecutorContract::is_transient_error(CE::OracleUnavailable),
+        "OracleUnavailable must be transient"
+    );
+    assert!(
+        TradeExecutorContract::is_transient_error(CE::OraclePriceStale),
+        "OraclePriceStale must be transient"
+    );
+}
+
+/// A successful execute_copy_trade clears any previously stored network error detail.
+#[test]
+fn successful_trade_clears_network_error_detail() {
+    // First, trigger a congestion error to populate the detail.
+    let (env, exec_id, user, _admin, token) = setup_with_congested_portfolio(TRADE_AMOUNT * 10);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    let _ = exec.try_execute_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
+    assert!(exec.get_network_error_detail(&user).is_some());
+
+    // Now swap in a healthy portfolio and re-run — detail should be cleared.
+    let healthy_portfolio = env.register(MockUserPortfolio, ());
+    exec.set_user_portfolio(&healthy_portfolio);
+    exec.execute_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
+    assert!(
+        exec.get_network_error_detail(&user).is_none(),
+        "detail must be cleared after success"
+    );
+}


### PR DESCRIPTION
- Add NetworkErrorDetail { retry_after_ledger, is_transient } type
- Add ContractError::NetworkCongestion = 19 (transient)
- Add LastNetworkError storage key persisted per-user
- Add get_network_error_detail() getter for frontend retry guidance
- Add is_transient_error() to distinguish transient vs permanent errors
- Map OracleUnavailable/OraclePriceStale to NetworkCongestion in execute_copy_trade
- Clear network error detail on successful trade
- Add 5 unit tests covering both error types

closes #386 