### PR TITLE
Generate Soroban contract TypeScript bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,19 @@ jobs:
       - name: Build optimized Soroban WASM
         run: cd stellar-swipe && chmod +x scripts/build.sh && ./scripts/build.sh
 
+      - name: Generate contract TypeScript bindings
+        run: cd stellar-swipe && chmod +x scripts/generate_abi.sh && ./scripts/generate_abi.sh
+
       - name: Upload optimized WASM artifacts
         uses: actions/upload-artifact@v4
         with:
           name: soroban-wasm-optimized
           path: stellar-swipe/target/wasm-optimized/*.wasm
+          if-no-files-found: error
+
+      - name: Upload contract TypeScript bindings
+        uses: actions/upload-artifact@v4
+        with:
+          name: soroban-contract-bindings
+          path: stellar-swipe/bindings/**
           if-no-files-found: error

--- a/docs/contract_bindings.md
+++ b/docs/contract_bindings.md
@@ -1,0 +1,40 @@
+# Contract Bindings
+
+Frontend clients should use generated TypeScript bindings instead of hand-written
+contract call wrappers. The bindings are generated from the compiled Soroban WASM
+interface, so function names, parameter types, and return types stay aligned with
+the Rust contracts.
+
+## Generate Locally
+
+```bash
+cd stellar-swipe
+./scripts/build.sh
+./scripts/generate_abi.sh
+```
+
+By default, the generator reads optimized WASM artifacts from
+`target/wasm-optimized` and writes one package per contract under `bindings/`.
+Helper WASM files without a Soroban contract interface are skipped.
+Each package is created with:
+
+```bash
+stellar contract bindings typescript \
+  --wasm <contract.wasm> \
+  --output-dir bindings/<contract> \
+  --overwrite
+```
+
+The script also writes `abi.json` beside each generated package using
+`stellar contract info interface --output json-formatted`.
+
+## Options
+
+```bash
+./scripts/generate_abi.sh --wasm-dir target/wasm32-unknown-unknown/release
+./scripts/generate_abi.sh --output-dir ../frontend/src/contracts
+./scripts/generate_abi.sh --no-abi-json
+```
+
+CI runs the generator after the optimized WASM build and uploads the complete
+`bindings/` directory as a build artifact.

--- a/scripts/generate_abi.sh
+++ b/scripts/generate_abi.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Wrapper: Soroban workspace lives under stellar-swipe/.
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../stellar-swipe/scripts/generate_abi.sh" "$@"

--- a/stellar-swipe/scripts/generate_abi.sh
+++ b/stellar-swipe/scripts/generate_abi.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Generate frontend-ready TypeScript bindings and ABI JSON from compiled
+# Soroban contract WASM artifacts.
+#
+# Typical usage:
+#   cd stellar-swipe
+#   ./scripts/build.sh
+#   ./scripts/generate_abi.sh
+#
+# Environment overrides:
+#   WASM_DIR=target/wasm-optimized
+#   BINDINGS_DIR=bindings
+#   STELLAR_BIN=stellar
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+WASM_DIR="${WASM_DIR:-target/wasm-optimized}"
+BINDINGS_DIR="${BINDINGS_DIR:-bindings}"
+STELLAR_BIN="${STELLAR_BIN:-stellar}"
+WRITE_ABI_JSON=true
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/generate_abi.sh [options]
+
+Options:
+  --wasm-dir <dir>      Directory containing compiled .wasm files
+                        (default: target/wasm-optimized)
+  --output-dir <dir>    Directory for generated bindings
+                        (default: bindings)
+  --no-abi-json         Skip abi.json generation next to each binding package
+  -h, --help            Show this help
+
+The script runs:
+  stellar contract bindings typescript --wasm <wasm> --output-dir <dir> --overwrite
+
+It also writes abi.json using:
+  stellar contract info interface --wasm <wasm> --output json-formatted
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --wasm-dir)
+      WASM_DIR="${2:?missing value for --wasm-dir}"
+      shift 2
+      ;;
+    --output-dir)
+      BINDINGS_DIR="${2:?missing value for --output-dir}"
+      shift 2
+      ;;
+    --no-abi-json)
+      WRITE_ABI_JSON=false
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v "$STELLAR_BIN" >/dev/null 2>&1; then
+  echo "error: stellar CLI not found. Install e.g.: cargo install stellar-cli --locked --version 25.2.0" >&2
+  exit 1
+fi
+
+if [[ ! -d "$WASM_DIR" ]]; then
+  fallback="target/wasm32-unknown-unknown/release"
+  if [[ -d "$fallback" ]]; then
+    echo "warning: $WASM_DIR not found; falling back to $fallback" >&2
+    WASM_DIR="$fallback"
+  else
+    echo "error: wasm directory not found: $WASM_DIR" >&2
+    echo "hint: run ./scripts/build.sh first, or pass --wasm-dir" >&2
+    exit 1
+  fi
+fi
+
+mapfile -t wasm_files < <(find "$WASM_DIR" -maxdepth 1 -type f -name '*.wasm' | sort)
+if [[ ${#wasm_files[@]} -eq 0 ]]; then
+  echo "error: no .wasm artifacts found in $WASM_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$BINDINGS_DIR"
+
+echo "==> Generating TypeScript bindings from $WASM_DIR"
+for wasm in "${wasm_files[@]}"; do
+  base="$(basename "$wasm")"
+  contract="${base%.wasm}"
+  contract="${contract%.optimized}"
+  out_dir="$BINDINGS_DIR/$contract"
+  abi_tmp="$(mktemp)"
+
+  "$STELLAR_BIN" contract info interface \
+    --wasm "$wasm" \
+    --output json-formatted > "$abi_tmp"
+
+  if [[ ! -s "$abi_tmp" ]]; then
+    echo "    $contract -> skipped (no Soroban contract interface)"
+    rm -f "$abi_tmp"
+    continue
+  fi
+
+  echo "    $contract -> $out_dir"
+  "$STELLAR_BIN" contract bindings typescript \
+    --wasm "$wasm" \
+    --output-dir "$out_dir" \
+    --overwrite
+
+  if [[ "$WRITE_ABI_JSON" == true ]]; then
+    cp "$abi_tmp" "$out_dir/abi.json"
+  fi
+  rm -f "$abi_tmp"
+done
+
+echo "Done. Contract bindings: $BINDINGS_DIR/"


### PR DESCRIPTION
Closes #443

## Summary
- Add `stellar-swipe/scripts/generate_abi.sh` to generate TypeScript bindings from compiled Soroban WASM artifacts.
- Export `abi.json` beside each generated binding package using `stellar contract info interface`.
- Skip helper WASM artifacts that do not expose a Soroban contract interface, so shared/helper crates do not break generation.
- Wire CI to generate and upload `stellar-swipe/bindings/**` after the optimized WASM build.
- Document the local generation workflow and wrapper script.

## Validation
- `bash -n stellar-swipe/scripts/generate_abi.sh; bash -n scripts/generate_abi.sh`
- Smoke-tested `generate_abi.sh` with a fake `stellar` executable to verify TypeScript binding generation, `abi.json` output, and non-contract WASM skipping.
- `git diff --cached --check`

## Note
- `cargo fmt --all -- --check` is currently blocked on the repository baseline by existing formatting drift plus parse errors in `contracts/auto_trade/src/test.rs` and `contracts/trade_executor/src/lib.rs`; this PR only changes shell/docs/workflow files.