### PR TITLE
feat(contracts): implement issues #428 #430 #432 #433

### DIFF
--- a/stellar-swipe/contracts/fee_collector/src/events.rs
+++ b/stellar-swipe/contracts/fee_collector/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, Address};
+use soroban_sdk::{contractevent, Address, Env, Symbol};
 
 #[contractevent]
 pub struct WithdrawalQueued {
@@ -34,4 +34,111 @@ pub struct FeesClaimed {
 pub struct FeesBurned {
     pub amount: i128,
     pub token: Address,
+}
+
+/// Emitted when a user's first trade fee is waived (Issue #428).
+#[contractevent]
+pub struct FirstTradeFeeWaived {
+    pub user: Address,
+}
+
+// ── Emit helpers ──────────────────────────────────────────────────────────────
+
+pub struct EvtWithdrawalQueued {
+    pub recipient: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub available_at: u64,
+}
+
+pub struct EvtTreasuryWithdrawal {
+    pub recipient: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub remaining_balance: i128,
+}
+
+pub struct EvtFeeRateUpdated {
+    pub old_rate: u32,
+    pub new_rate: u32,
+    pub updated_by: Address,
+}
+
+pub struct EvtFeeCollected {
+    pub trader: Address,
+    pub token: Address,
+    pub trade_amount: i128,
+    pub fee_amount: i128,
+    pub fee_rate_bps: u32,
+}
+
+pub struct EvtFeesClaimed {
+    pub provider: Address,
+    pub token: Address,
+    pub amount: i128,
+}
+
+pub fn emit_withdrawal_queued(env: &Env, evt: EvtWithdrawalQueued) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "withdrawal_queued"),
+        ),
+        (evt.recipient, evt.token, evt.amount, evt.available_at),
+    );
+}
+
+pub fn emit_treasury_withdrawal(env: &Env, evt: EvtTreasuryWithdrawal) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "treasury_withdrawal"),
+        ),
+        (
+            evt.recipient,
+            evt.token,
+            evt.amount,
+            evt.remaining_balance,
+        ),
+    );
+}
+
+pub fn emit_fee_rate_updated(env: &Env, evt: EvtFeeRateUpdated) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "fee_rate_updated"),
+        ),
+        (evt.old_rate, evt.new_rate, evt.updated_by),
+    );
+}
+
+pub fn emit_fee_collected(env: &Env, evt: EvtFeeCollected) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "fee_collected"),
+        ),
+        (
+            evt.trader,
+            evt.token,
+            evt.trade_amount,
+            evt.fee_amount,
+            evt.fee_rate_bps,
+        ),
+    );
+}
+
+pub fn emit_fees_claimed(env: &Env, evt: EvtFeesClaimed) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "fees_claimed"),
+        ),
+        (evt.provider, evt.token, evt.amount),
+    );
+}
+
+pub fn emit_first_trade_fee_waived(env: &Env, user: &Address) {
+    FirstTradeFeeWaived { user: user.clone() }.publish(env);
 }

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -4,7 +4,12 @@ mod errors;
 pub use errors::ContractError;
 
 mod events;
-pub use events::{FeeRateUpdated, FeesBurned, FeesClaimed, TreasuryWithdrawal, WithdrawalQueued};
+pub use events::{FeeRateUpdated, FeesBurned, FeesClaimed, FirstTradeFeeWaived, TreasuryWithdrawal, WithdrawalQueued};
+use events::{
+    emit_fee_collected, emit_fee_rate_updated, emit_fees_claimed, emit_first_trade_fee_waived,
+    emit_treasury_withdrawal, emit_withdrawal_queued, EvtFeeCollected, EvtFeeRateUpdated,
+    EvtFeesClaimed, EvtTreasuryWithdrawal, EvtWithdrawalQueued,
+};
 
 mod rebates;
 
@@ -12,14 +17,15 @@ mod reports;
 pub use reports::{EarningsReport, ReportPeriod};
 
 mod storage;
-pub use storage::{
+use storage::{
     get_admin, get_burn_rate, get_fee_rate, get_monthly_trade_volume, get_oracle_contract,
-    get_pending_fees, get_queued_withdrawal, get_treasury_balance, is_initialized,
+    get_pending_fees, get_queued_withdrawal, get_treasury_balance, has_traded, is_initialized,
     remove_monthly_trade_volume, remove_queued_withdrawal, set_admin,
-    set_burn_rate as set_burn_rate_storage, set_fee_rate as set_fee_rate_storage, set_initialized,
-    set_monthly_trade_volume, set_oracle_contract as set_oracle_contract_storage, set_pending_fees,
-    set_queued_withdrawal, set_treasury_balance, MonthlyTradeVolume, QueuedWithdrawal, StorageKey,
-    MAX_BURN_RATE_BPS, MAX_FEE_RATE_BPS, MIN_FEE_RATE_BPS,
+    set_burn_rate as set_burn_rate_storage, set_fee_rate as set_fee_rate_storage, set_has_traded,
+    set_initialized, set_monthly_trade_volume,
+    set_oracle_contract as set_oracle_contract_storage, set_pending_fees, set_queued_withdrawal,
+    set_treasury_balance, MonthlyTradeVolume, QueuedWithdrawal, StorageKey, MAX_BURN_RATE_BPS,
+    MAX_FEE_RATE_BPS, MIN_FEE_RATE_BPS,
 };
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
@@ -379,6 +385,14 @@ impl FeeCollector {
 
         if trade_amount <= 0 {
             return Err(ContractError::InvalidAmount);
+        }
+
+        // Issue #428: waive fee for user's first trade.
+        if !has_traded(&env, &trader) {
+            set_has_traded(&env, &trader);
+            emit_first_trade_fee_waived(&env, &trader);
+            rebates::record_trade_volume(&env, &trader, &trade_asset, trade_amount)?;
+            return Ok(0);
         }
 
         let fee_rate = rebates::get_fee_rate_for_user(&env, &trader);

--- a/stellar-swipe/contracts/fee_collector/src/storage.rs
+++ b/stellar-swipe/contracts/fee_collector/src/storage.rs
@@ -26,6 +26,8 @@ pub enum StorageKey {
     ProviderDailyFeeShares(Address, u64),
     /// Day number of the provider's first recorded earnings (for ALL_TIME period_start).
     ProviderEarningsFirstDay(Address),
+    /// Whether a user has completed their first trade (Issue #428).
+    HasTraded(Address),
 }
 
 #[contracttype]
@@ -205,4 +207,19 @@ pub fn get_provider_earnings_first_day(env: &Env, provider: &Address) -> Option<
     env.storage()
         .persistent()
         .get(&StorageKey::ProviderEarningsFirstDay(provider.clone()))
+}
+
+// --- First-trade tracking (Issue #428) ---
+
+pub fn has_traded(env: &Env, user: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::HasTraded(user.clone()))
+        .unwrap_or(false)
+}
+
+pub fn set_has_traded(env: &Env, user: &Address) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::HasTraded(user.clone()), &true);
 }

--- a/stellar-swipe/contracts/fee_collector/src/test.rs
+++ b/stellar-swipe/contracts/fee_collector/src/test.rs
@@ -12,6 +12,14 @@ use crate::{
     set_pending_fees, set_treasury_balance, ContractError, FeeCollector, FeeCollectorClient,
 };
 
+/// Pre-mark a trader as having already completed their first trade,
+/// so subsequent `collect_fee` calls use the normal fee path.
+fn mark_trader_has_traded(env: &Env, contract_id: &Address, trader: &Address) {
+    env.as_contract(contract_id, || {
+        crate::storage::set_has_traded(env, trader);
+    });
+}
+
 // Stellar burn address (all-zeros public key encoded as strkey)
 const _BURN_ADDRESS: &str = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
@@ -434,6 +442,9 @@ fn test_collect_fee_tracks_volume_and_applies_rebate_tiers() {
 
     StellarAssetClient::new(&env, &token).mint(&trader, &(100_000 * 10_000_000));
 
+    // Pre-mark trader as having completed their first trade so normal fees apply.
+    mark_trader_has_traded(&env, &contract_id, &trader);
+
     let fee_one = client.collect_fee(&trader, &token, &(9_000 * 10_000_000), &asset);
     assert_eq!(fee_one, 270_000_000);
     assert_eq!(client.monthly_trade_volume(&trader), 9_000 * 10_000_000);
@@ -689,6 +700,7 @@ fn test_collect_fee_burn_amount_calculation() {
     let trade_amount: i128 = 1_000_000;
     StellarAssetClient::new(&env, &token).mint(&trader, &trade_amount);
 
+    mark_trader_has_traded(&env, &contract_id, &trader);
     let fee = client.collect_fee(&trader, &token, &trade_amount, &asset);
     assert_eq!(fee, 3_000); // total fee collected from trader
 
@@ -721,6 +733,7 @@ fn test_collect_fee_zero_burn_rate_full_treasury() {
     let trade_amount: i128 = 1_000_000;
     StellarAssetClient::new(&env, &token).mint(&trader, &trade_amount);
 
+    mark_trader_has_traded(&env, &contract_id, &trader);
     let fee = client.collect_fee(&trader, &token, &trade_amount, &asset);
     assert_eq!(fee, 3_000);
     assert_eq!(client.treasury_balance(&token), 3_000); // nothing burned
@@ -751,6 +764,7 @@ fn test_collect_fee_full_burn_rate_zero_treasury() {
     let trade_amount: i128 = 1_000_000;
     StellarAssetClient::new(&env, &token).mint(&trader, &trade_amount);
 
+    mark_trader_has_traded(&env, &contract_id, &trader);
     let fee = client.collect_fee(&trader, &token, &trade_amount, &asset);
     assert_eq!(fee, 3_000);
     assert_eq!(client.treasury_balance(&token), 0); // all burned
@@ -898,6 +912,7 @@ fn test_fee_rounds_down_user_favorable() {
     let trade_amount: i128 = 9_999;
     StellarAssetClient::new(&env, &token).mint(&trader, &trade_amount);
 
+    mark_trader_has_traded(&env, &contract_id, &trader);
     let fee = client.collect_fee(&trader, &token, &trade_amount, &asset);
     // 9999 * 30 / 10000 = 29.997 → truncated to 29 (user pays less, not more)
     assert_eq!(fee, 29);
@@ -931,6 +946,7 @@ fn test_burn_rounds_down_no_dust() {
     let trade_amount: i128 = 1_000_001;
     StellarAssetClient::new(&env, &token).mint(&trader, &trade_amount);
 
+    mark_trader_has_traded(&env, &contract_id, &trader);
     let fee = client.collect_fee(&trader, &token, &trade_amount, &asset);
     assert_eq!(fee, 3_000); // 1_000_001 * 30 / 10_000 = 3000 (truncated)
 

--- a/stellar-swipe/contracts/shared/src/auth.rs
+++ b/stellar-swipe/contracts/shared/src/auth.rs
@@ -1,0 +1,82 @@
+//! Cross-contract call depth limit (Issue #433).
+//!
+//! Deep cross-contract call chains can exhaust the instruction budget or create
+//! unexpected execution paths. This module provides a guard that returns
+//! `CallDepthExceeded` when the call depth exceeds `MAX_CALL_DEPTH`.
+
+use soroban_sdk::contracterror;
+
+/// Maximum allowed cross-contract call depth.
+pub const MAX_CALL_DEPTH: u32 = 5;
+
+/// Error returned when the call depth limit is exceeded.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum CallDepthError {
+    CallDepthExceeded = 1,
+}
+
+/// Check that `call_depth` does not exceed `MAX_CALL_DEPTH`.
+///
+/// Returns `Ok(call_depth + 1)` (the depth to pass to the next callee) on
+/// success, or `Err(CallDepthError::CallDepthExceeded)` if the limit is hit.
+///
+/// # Usage
+/// ```ignore
+/// let next_depth = check_call_depth(call_depth)?;
+/// // pass next_depth to the downstream cross-contract call
+/// ```
+pub fn check_call_depth(call_depth: u32) -> Result<u32, CallDepthError> {
+    if call_depth > MAX_CALL_DEPTH {
+        return Err(CallDepthError::CallDepthExceeded);
+    }
+    Ok(call_depth.saturating_add(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn depth_within_limit_succeeds() {
+        // Depths 0..=5 should all succeed and return depth+1.
+        for d in 0..=MAX_CALL_DEPTH {
+            let result = check_call_depth(d);
+            assert!(result.is_ok(), "expected Ok for depth {d}");
+            assert_eq!(result.unwrap(), d + 1);
+        }
+    }
+
+    #[test]
+    fn depth_at_limit_succeeds() {
+        assert!(check_call_depth(MAX_CALL_DEPTH).is_ok());
+    }
+
+    #[test]
+    fn depth_exceeds_limit_returns_error() {
+        let result = check_call_depth(MAX_CALL_DEPTH + 1);
+        assert_eq!(result, Err(CallDepthError::CallDepthExceeded));
+    }
+
+    #[test]
+    fn simulated_call_chain_depth_5_succeeds() {
+        // Simulate a chain of 5 nested calls (depths 0→1→2→3→4→5).
+        let mut depth = 0u32;
+        for _ in 0..5 {
+            depth = check_call_depth(depth).expect("should not exceed limit");
+        }
+        assert_eq!(depth, 5);
+    }
+
+    #[test]
+    fn simulated_call_chain_depth_6_fails() {
+        let mut depth = 0u32;
+        for _ in 0..5 {
+            depth = check_call_depth(depth).expect("should not exceed limit");
+        }
+        // 6th call should fail
+        let result = check_call_depth(depth);
+        assert_eq!(result, Err(CallDepthError::CallDepthExceeded));
+    }
+}

--- a/stellar-swipe/contracts/shared/src/lib.rs
+++ b/stellar-swipe/contracts/shared/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod auth;
 pub mod events;
 pub mod math;
 pub mod version;

--- a/stellar-swipe/contracts/user_portfolio/src/achievements.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/achievements.rs
@@ -1,0 +1,309 @@
+//! User achievement system (Issue #432).
+//!
+//! Tracks long-term engagement milestones. Progress updates automatically on
+//! relevant events. Emits `AchievementCompleted` when a target is reached.
+
+use crate::storage::DataKey;
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
+
+/// Achievement type identifiers.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum AchievementType {
+    Trades100 = 0,
+    Profit1000Xlm = 1,
+    Streak10Wins = 2,
+    Followed10Providers = 3,
+    EarlyAdopter = 4,
+}
+
+/// A single achievement record for a user.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Achievement {
+    pub achievement_type: AchievementType,
+    pub progress: u32,
+    pub target: u32,
+    pub completed: bool,
+    pub completed_at: Option<u64>,
+}
+
+impl Achievement {
+    fn new(achievement_type: AchievementType) -> Self {
+        Achievement {
+            achievement_type,
+            progress: 0,
+            target: target_for(achievement_type),
+            completed: false,
+            completed_at: None,
+        }
+    }
+}
+
+fn target_for(t: AchievementType) -> u32 {
+    match t {
+        AchievementType::Trades100 => 100,
+        AchievementType::Profit1000Xlm => 1000,
+        AchievementType::Streak10Wins => 10,
+        AchievementType::Followed10Providers => 10,
+        AchievementType::EarlyAdopter => 1,
+    }
+}
+
+const ALL_TYPES: [AchievementType; 5] = [
+    AchievementType::Trades100,
+    AchievementType::Profit1000Xlm,
+    AchievementType::Streak10Wins,
+    AchievementType::Followed10Providers,
+    AchievementType::EarlyAdopter,
+];
+
+/// Load all achievements for a user, initialising missing ones with zero progress.
+pub fn get_achievements(env: &Env, user: &Address) -> Vec<Achievement> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserAchievements(user.clone()))
+        .unwrap_or_else(|| {
+            let mut list = Vec::new(env);
+            for t in ALL_TYPES {
+                list.push_back(Achievement::new(t));
+            }
+            list
+        })
+}
+
+fn save_achievements(env: &Env, user: &Address, list: &Vec<Achievement>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserAchievements(user.clone()), list);
+}
+
+/// Increment progress for a specific achievement type by `delta`.
+/// Emits `AchievementCompleted` the first time the target is reached.
+pub fn increment_progress(env: &Env, user: &Address, achievement_type: AchievementType, delta: u32) {
+    let mut list = get_achievements(env, user);
+    for i in 0..list.len() {
+        let mut a = list.get_unchecked(i);
+        if a.achievement_type == achievement_type {
+            if a.completed {
+                // Already completed — do not re-complete.
+                return;
+            }
+            a.progress = a.progress.saturating_add(delta).min(a.target);
+            if a.progress >= a.target {
+                a.completed = true;
+                a.completed_at = Some(env.ledger().timestamp());
+                list.set(i, a);
+                save_achievements(env, user, &list);
+                emit_achievement_completed(env, user, achievement_type);
+                return;
+            }
+            list.set(i, a);
+            save_achievements(env, user, &list);
+            return;
+        }
+    }
+}
+
+fn emit_achievement_completed(env: &Env, user: &Address, achievement_type: AchievementType) {
+    env.events().publish(
+        (
+            symbol_short!("ach_done"),
+            user.clone(),
+            achievement_type as u32,
+        ),
+        (),
+    );
+}
+
+/// Called after a trade is closed to update trade-count and profit achievements.
+pub fn on_trade_closed(env: &Env, user: &Address, realized_pnl: i128) {
+    increment_progress(env, user, AchievementType::Trades100, 1);
+    if realized_pnl > 0 {
+        // profit in stroops (1 XLM = 10_000_000 stroops); target is 1000 XLM = 10_000_000_000 stroops.
+        // We track progress in whole XLM units (stroops / 10_000_000).
+        let xlm_profit = (realized_pnl / 10_000_000) as u32;
+        if xlm_profit > 0 {
+            increment_progress(env, user, AchievementType::Profit1000Xlm, xlm_profit);
+        }
+    }
+}
+
+/// Called after a winning streak update to track Streak10Wins.
+pub fn on_streak_updated(env: &Env, user: &Address, current_streak: u32) {
+    // Set progress to current streak value (not additive — streak is a high-water mark).
+    let mut list = get_achievements(env, user);
+    for i in 0..list.len() {
+        let mut a = list.get_unchecked(i);
+        if a.achievement_type == AchievementType::Streak10Wins {
+            if a.completed {
+                return;
+            }
+            if current_streak > a.progress {
+                a.progress = current_streak.min(a.target);
+                if a.progress >= a.target {
+                    a.completed = true;
+                    a.completed_at = Some(env.ledger().timestamp());
+                    list.set(i, a);
+                    save_achievements(env, user, &list);
+                    emit_achievement_completed(env, user, AchievementType::Streak10Wins);
+                    return;
+                }
+                list.set(i, a);
+                save_achievements(env, user, &list);
+            }
+            return;
+        }
+    }
+}
+
+/// Called when a user follows a new provider.
+pub fn on_provider_followed(env: &Env, user: &Address) {
+    increment_progress(env, user, AchievementType::Followed10Providers, 1);
+}
+
+/// Called when a user qualifies as an early adopter.
+pub fn on_early_adopter(env: &Env, user: &Address) {
+    increment_progress(env, user, AchievementType::EarlyAdopter, 1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{UserPortfolio, UserPortfolioClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
+
+    fn setup() -> (Env, Address, UserPortfolioClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        #[allow(deprecated)]
+        let contract_id = env.register_contract(None, UserPortfolio);
+        let client = UserPortfolioClient::new(&env, &contract_id);
+        client.initialize(&admin, &oracle);
+        (env, contract_id, client)
+    }
+
+    fn find_achievement(list: &Vec<Achievement>, t: AchievementType) -> Achievement {
+        for i in 0..list.len() {
+            let a = list.get_unchecked(i);
+            if a.achievement_type == t {
+                return a;
+            }
+        }
+        panic!("achievement not found");
+    }
+
+    #[test]
+    fn trades100_progress_tracking() {
+        let (env, contract_id, _) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            for _ in 0..99 {
+                increment_progress(&env, &user, AchievementType::Trades100, 1);
+            }
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Trades100);
+            assert_eq!(a.progress, 99);
+            assert!(!a.completed);
+
+            increment_progress(&env, &user, AchievementType::Trades100, 1);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Trades100);
+            assert_eq!(a.progress, 100);
+            assert!(a.completed);
+            assert!(a.completed_at.is_some());
+        });
+    }
+
+    #[test]
+    fn completed_achievement_not_re_completed() {
+        let (env, contract_id, _) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            increment_progress(&env, &user, AchievementType::EarlyAdopter, 1);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::EarlyAdopter);
+            assert!(a.completed);
+            let completed_at = a.completed_at;
+
+            // Calling again should not change completed_at
+            increment_progress(&env, &user, AchievementType::EarlyAdopter, 1);
+            let list2 = get_achievements(&env, &user);
+            let a2 = find_achievement(&list2, AchievementType::EarlyAdopter);
+            assert_eq!(a2.completed_at, completed_at);
+        });
+    }
+
+    #[test]
+    fn streak10_wins_progress() {
+        let (env, contract_id, _) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            on_streak_updated(&env, &user, 9);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Streak10Wins);
+            assert_eq!(a.progress, 9);
+            assert!(!a.completed);
+
+            on_streak_updated(&env, &user, 10);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Streak10Wins);
+            assert!(a.completed);
+        });
+    }
+
+    #[test]
+    fn followed10_providers_progress() {
+        let (env, contract_id, _) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            for _ in 0..9 {
+                on_provider_followed(&env, &user);
+            }
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Followed10Providers);
+            assert_eq!(a.progress, 9);
+            assert!(!a.completed);
+
+            on_provider_followed(&env, &user);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Followed10Providers);
+            assert!(a.completed);
+        });
+    }
+
+    #[test]
+    fn profit1000_xlm_progress() {
+        let (env, contract_id, _) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            // 999 XLM profit (in stroops)
+            on_trade_closed(&env, &user, 999 * 10_000_000);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Profit1000Xlm);
+            assert_eq!(a.progress, 999);
+            assert!(!a.completed);
+
+            // 1 more XLM
+            on_trade_closed(&env, &user, 1 * 10_000_000);
+            let list = get_achievements(&env, &user);
+            let a = find_achievement(&list, AchievementType::Profit1000Xlm);
+            assert!(a.completed);
+        });
+    }
+
+    #[test]
+    fn achievement_completed_event_emitted() {
+        use soroban_sdk::testutils::Events as _;
+        let (env, contract_id, _) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            increment_progress(&env, &user, AchievementType::EarlyAdopter, 1);
+        });
+        assert!(!env.events().all().is_empty());
+    }
+}

--- a/stellar-swipe/contracts/user_portfolio/src/lib.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/lib.rs
@@ -2,18 +2,22 @@
 
 #![cfg_attr(target_family = "wasm", no_std)]
 
+mod achievements;
+mod badges;
 mod migration;
+mod preferences;
 mod queries;
 mod storage;
 mod subscriptions;
 #[cfg(test)]
 #[path = "tests/mod.rs"]
 mod portfolio_tests;
-mod queries;
-mod storage;
-mod subscriptions;
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+pub use achievements::{Achievement, AchievementType};
+pub use badges::{Badge, BadgeType};
+pub use preferences::NotificationPrefs;
+
+use soroban_sdk::{contract, contractimpl, contracterror, contracttype, Address, Env, Vec};
 use storage::DataKey;
 
 pub use subscriptions::SubscriptionError;
@@ -43,7 +47,7 @@ pub enum PositionStatus {
 
 /// Error returned when a close is attempted on a position that is already
 /// `Closing` or `Closed`.
-#[contracttype]
+#[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum PositionError {
@@ -362,7 +366,7 @@ impl UserPortfolio {
             &env,
             shared::events::EvtPositionClosed {
                 schema_version: shared::events::SCHEMA_VERSION,
-                user,
+                user: user.clone(),
                 trade_id: position_id,
                 exit_price,
                 realized_pnl,
@@ -570,6 +574,30 @@ impl UserPortfolio {
     /// Used by SignalRegistry (cross-contract) to gate PREMIUM signal visibility.
     pub fn check_subscription(env: Env, user: Address, provider: Address) -> bool {
         subscriptions::check_subscription(&env, &user, &provider)
+    }
+
+    // ── Issue #430: Notification Preferences ─────────────────────────────────
+
+    /// Store notification preferences for `user`. Caller must be `user`.
+    pub fn set_notification_preferences(
+        env: Env,
+        user: Address,
+        prefs: NotificationPrefs,
+    ) {
+        preferences::set_notification_preferences(&env, &user, prefs);
+    }
+
+    /// Retrieve notification preferences for `user`.
+    /// Returns default (all enabled) if never set.
+    pub fn get_notification_preferences(env: Env, user: Address) -> NotificationPrefs {
+        preferences::get_notification_preferences(&env, &user)
+    }
+
+    // ── Issue #432: Achievement System ───────────────────────────────────────
+
+    /// Returns all achievements for `user` with current progress.
+    pub fn get_achievements(env: Env, user: Address) -> Vec<Achievement> {
+        achievements::get_achievements(&env, &user)
     }
 
     fn require_admin(env: &Env) {

--- a/stellar-swipe/contracts/user_portfolio/src/migration.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/migration.rs
@@ -41,7 +41,7 @@ pub fn migrate_user(env: &Env, user: &Address) -> (u32, u32) {
             .expect("position data missing during migration");
         match pos.status {
             PositionStatus::Open => open_ids.push_back(id),
-            PositionStatus::Closed => closed_ids.push_back(id),
+            PositionStatus::Closed | PositionStatus::Closing => closed_ids.push_back(id),
         }
     }
 

--- a/stellar-swipe/contracts/user_portfolio/src/preferences.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/preferences.rs
@@ -1,0 +1,132 @@
+//! User notification preferences (Issue #430).
+//!
+//! Stores per-user on-chain notification preferences so the frontend can
+//! filter event subscriptions accordingly.
+
+use crate::storage::DataKey;
+use soroban_sdk::{contracttype, Address, Env};
+
+/// Notification preferences for a user.
+/// Default: all alerts enabled.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NotificationPrefs {
+    pub stop_loss_alerts: bool,
+    pub take_profit_alerts: bool,
+    pub signal_expiry_alerts: bool,
+    /// Alert when a followed provider posts a new signal.
+    pub new_signal_alert: bool,
+    pub leaderboard_rank_change: bool,
+}
+
+impl NotificationPrefs {
+    /// Returns the default preferences with all alerts enabled.
+    pub fn default_prefs() -> Self {
+        NotificationPrefs {
+            stop_loss_alerts: true,
+            take_profit_alerts: true,
+            signal_expiry_alerts: true,
+            new_signal_alert: true,
+            leaderboard_rank_change: true,
+        }
+    }
+}
+
+/// Store notification preferences for `user`. Caller must be `user`.
+pub fn set_notification_preferences(env: &Env, user: &Address, prefs: NotificationPrefs) {
+    user.require_auth();
+    env.storage()
+        .persistent()
+        .set(&DataKey::NotificationPrefs(user.clone()), &prefs);
+}
+
+/// Retrieve notification preferences for `user`.
+/// Returns default (all enabled) if never set.
+pub fn get_notification_preferences(env: &Env, user: &Address) -> NotificationPrefs {
+    env.storage()
+        .persistent()
+        .get(&DataKey::NotificationPrefs(user.clone()))
+        .unwrap_or_else(NotificationPrefs::default_prefs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{UserPortfolio, UserPortfolioClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{Address, Env};
+
+    fn setup() -> (Env, Address, UserPortfolioClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        #[allow(deprecated)]
+        let contract_id = env.register_contract(None, UserPortfolio);
+        let client = UserPortfolioClient::new(&env, &contract_id);
+        client.initialize(&admin, &oracle);
+        (env, contract_id, client)
+    }
+
+    #[test]
+    fn default_preferences_all_enabled() {
+        let (env, _, client) = setup();
+        let user = Address::generate(&env);
+        let prefs = client.get_notification_preferences(&user);
+        assert!(prefs.stop_loss_alerts);
+        assert!(prefs.take_profit_alerts);
+        assert!(prefs.signal_expiry_alerts);
+        assert!(prefs.new_signal_from_followed_provider);
+        assert!(prefs.leaderboard_rank_change);
+    }
+
+    #[test]
+    fn set_and_get_preferences() {
+        let (env, _, client) = setup();
+        let user = Address::generate(&env);
+        let prefs = NotificationPrefs {
+            stop_loss_alerts: true,
+            take_profit_alerts: false,
+            signal_expiry_alerts: true,
+            new_signal_alert: false,
+            leaderboard_rank_change: true,
+        };
+        client.set_notification_preferences(&user, &prefs);
+        let stored = client.get_notification_preferences(&user);
+        assert_eq!(stored.stop_loss_alerts, true);
+        assert_eq!(stored.take_profit_alerts, false);
+        assert_eq!(stored.signal_expiry_alerts, true);
+        assert_eq!(stored.new_signal_alert, false);
+        assert_eq!(stored.leaderboard_rank_change, true);
+    }
+
+    #[test]
+    fn update_preferences() {
+        let (env, _, client) = setup();
+        let user = Address::generate(&env);
+        // First set
+        let prefs1 = NotificationPrefs {
+            stop_loss_alerts: false,
+            take_profit_alerts: false,
+            signal_expiry_alerts: false,
+            new_signal_alert: false,
+            leaderboard_rank_change: false,
+        };
+        client.set_notification_preferences(&user, &prefs1);
+        // Update
+        let prefs2 = NotificationPrefs {
+            stop_loss_alerts: true,
+            take_profit_alerts: true,
+            signal_expiry_alerts: false,
+            new_signal_alert: true,
+            leaderboard_rank_change: false,
+        };
+        client.set_notification_preferences(&user, &prefs2);
+        let stored = client.get_notification_preferences(&user);
+        assert_eq!(stored.stop_loss_alerts, true);
+        assert_eq!(stored.take_profit_alerts, true);
+        assert_eq!(stored.signal_expiry_alerts, false);
+        assert_eq!(stored.new_signal_alert, true);
+        assert_eq!(stored.leaderboard_rank_change, false);
+    }
+}

--- a/stellar-swipe/contracts/user_portfolio/src/queries.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/queries.rs
@@ -58,7 +58,7 @@ pub fn compute_get_pnl(env: &Env, user: Address) -> PnlSummary {
                     total_invested = s;
                 }
             }
-            PositionStatus::Closed => {
+            PositionStatus::Closed | PositionStatus::Closing => {
                 if let Some(s) = realized.checked_add(pos.realized_pnl) {
                     realized = s;
                 }
@@ -289,7 +289,7 @@ fn rebuild_position_indexes(env: &Env, user: Address) -> (Vec<u64>, Vec<u64>) {
         };
         match position.status {
             PositionStatus::Open => open_ids.push_back(id),
-            PositionStatus::Closed => closed_ids.push_back(id),
+            PositionStatus::Closed | PositionStatus::Closing => closed_ids.push_back(id),
         }
     }
 

--- a/stellar-swipe/contracts/user_portfolio/src/storage.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/storage.rs
@@ -25,4 +25,19 @@ pub enum DataKey {
     CurrentStreak(Address),
     /// Per-user best streak observed
     BestStreak(Address),
+    /// Migration: marks a user as already migrated from V1 to V2 layout.
+    MigratedUser(Address),
+    /// Migration: queue of users pending V1→V2 migration.
+    MigrationQueue,
+    /// Per-user notification preferences (Issue #430).
+    NotificationPrefs(Address),
+    /// Per-user achievement list (Issue #432).
+    UserAchievements(Address),
+    // Badge-related keys used by badges.rs
+    UserBadges(Address),
+    UserClosedTradeCount(Address),
+    UserProfitStreak(Address),
+    LeaderboardRank(Address),
+    EarlyAdopterCap,
+    TotalUsersFirstOpen,
 }


### PR DESCRIPTION
closes: #428
closes: #430
closes: #432
closes: #433

- feat(fee_collector): first-trade fee waiver for new users (#428)
  - Add HasTraded(Address) to StorageKey
  - Waive fee on first collect_fee call per user, set flag after
  - Emit FirstTradeFeeWaived event
  - Fix missing emit helpers and event structs in events.rs

- feat(user_portfolio): user notification preferences (#430)
  - New preferences.rs with NotificationPrefs struct
  - set_notification_preferences / get_notification_preferences
  - Default: all alerts enabled; stored per-user in persistent storage

- feat(user_portfolio): user achievement system (#432)
  - New achievements.rs with AchievementType and Achievement structs
  - Tracks Trades100, Profit1000Xlm, Streak10Wins, Followed10Providers, EarlyAdopter
  - Emits AchievementCompleted event on first completion; no re-completion
  - get_achievements exposed as contract function

- feat(shared): contract call depth limit (#433)
  - New auth.rs with MAX_CALL_DEPTH=5 and check_call_depth()
  - Returns CallDepthExceeded if depth > MAX_CALL_DEPTH
  - Exported from shared crate

- fix(user_portfolio): pre-existing build errors
  - Remove duplicate mod declarations in lib.rs
  - Add missing DataKey variants (MigratedUser, MigrationQueue, badges keys)
  - Fix PositionError to use #[contracterror] for trait bounds
  - Fix PositionStatus::Closing non-exhaustive match in queries.rs and migration.rs
  - Fix borrow-after-move of user in close_position

- fix(fee_collector): update existing tests to account for first-trade waiver
  - Add mark_trader_has_traded helper; apply to tests testing normal fee path