### PR TITLE
feat: add on-chain balance reconciliation audit to fee collector

### DIFF
--- a/docs/fee_collector_reconciliation.md
+++ b/docs/fee_collector_reconciliation.md
@@ -1,0 +1,99 @@
+# Fee Collector Balance Reconciliation Audit
+
+## Overview
+
+The fee collector contract stores a per-token treasury balance in persistent state (`StorageKey::TreasuryBalance`). Under normal operation this accounting stays in sync with the contract's actual on-chain token holdings. The `audit_balances` method lets operators verify that invariant at any time.
+
+## Method signature
+
+```rust
+pub fn audit_balances(
+    env: Env,
+    tokens: Vec<Address>,
+) -> Result<Vec<BalanceMismatch>, ContractError>
+```
+
+### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| `tokens` | `Vec<Address>` | List of SEP-41 token addresses to audit |
+
+### Return value
+
+A `Vec<BalanceMismatch>` — one entry per token whose stored balance differs from the on-chain balance. Returns an empty vector when all balances reconcile.
+
+```rust
+pub struct BalanceMismatch {
+    pub token: Address, // The token that has a discrepancy
+    pub expected: i128, // Balance recorded in contract storage
+    pub actual: i128,   // Actual on-chain balance held by this contract
+    pub delta: i128,    // actual - expected (positive = surplus, negative = deficit)
+}
+```
+
+### Errors
+
+- `ContractError::NotInitialized` — contract has not been initialized yet.
+
+## When to run reconciliation checks
+
+| Trigger | Recommended action |
+|---------|-------------------|
+| After any treasury withdrawal | Confirm the stored balance decreased by the exact withdrawal amount |
+| After a large fee collection period | Verify accumulated fees match expectations |
+| Incident response / suspected exploit | Identify which tokens and amounts are affected |
+| Routine monitoring | Run as part of a weekly cron job via simulation |
+| Before a contract upgrade | Capture baseline balances to compare post-upgrade |
+
+## How to use
+
+### Off-chain simulation (no fees, no auth)
+
+Use `simulateTransaction` so the read-only call costs nothing and requires no auth:
+
+```typescript
+import { Contract, TransactionBuilder, Networks } from "@stellar/stellar-sdk";
+
+const contract = new Contract(FEE_COLLECTOR_ADDRESS);
+const tokens = [TOKEN_A_ADDRESS, TOKEN_B_ADDRESS];
+
+const tx = new TransactionBuilder(sourceAccount, { fee: "100", networkPassphrase: Networks.TESTNET })
+  .addOperation(contract.call("audit_balances", xdr.ScVal.scvVec(tokens.map(toAddress))))
+  .setTimeout(30)
+  .build();
+
+const result = await server.simulateTransaction(tx);
+// Decode result: Vec<BalanceMismatch>
+```
+
+### Monitoring script pattern
+
+```typescript
+const mismatches = await auditBalances(tokens);
+
+if (mismatches.length > 0) {
+  for (const m of mismatches) {
+    const direction = m.delta > 0 ? "SURPLUS" : "DEFICIT";
+    console.error(`[ALERT] ${direction} on ${m.token}: expected=${m.expected}, actual=${m.actual}, delta=${m.delta}`);
+    // Send alert to PagerDuty / Slack / etc.
+  }
+}
+```
+
+## Interpreting results
+
+| Scenario | `delta` sign | Likely cause |
+|----------|-------------|--------------|
+| Balanced | — (no entry) | Contract accounting is correct |
+| Surplus (`delta > 0`) | Positive | Tokens were sent directly to the contract address bypassing `collect_fee`, or a burn was undercounted |
+| Deficit (`delta < 0`) | Negative | Tokens left the contract without updating stored balance — indicates a potential accounting bug or exploit |
+
+A **surplus** is generally harmless but should be investigated. A **deficit** is a critical anomaly that may indicate loss of funds and should trigger immediate incident response.
+
+## Notes
+
+- `audit_balances` is read-only; it does not modify any state.
+- It can be called without admin auth and is safe to call in a `simulateTransaction` RPC call.
+- Pass only the tokens you expect the contract to hold to keep simulation costs low.
+- Revenue share pool balances (`StorageKey::RevenueSharePool`) are **not** included in `expected` — only `TreasuryBalance` is audited. If you need to audit revenue share pools, compare them separately.

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -29,12 +29,13 @@ use storage::{
     set_fee_optimization_config, set_failed_fee_collection, set_has_traded, set_initialized,
     set_monthly_trade_volume, set_network_condition_score,
     set_oracle_contract as set_oracle_contract_storage, set_pending_fees, set_queued_withdrawal,
-    set_treasury_balance, ErrorReport, FailedFeeCollection, FeeOptimizationConfig,
+    set_treasury_balance, BalanceMismatch, ErrorReport, FailedFeeCollection, FeeOptimizationConfig,
     MonthlyTradeVolume, QueuedWithdrawal, StorageKey, MAX_BURN_RATE_BPS, MAX_FEE_RATE_BPS,
     MIN_FEE_RATE_BPS,
 };
+pub use storage::BalanceMismatch;
 
-use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String, Vec};
 
 use shared::errors::{ErrorCategory, RecoveryStrategy};
 use stellar_swipe_common::Asset;
@@ -164,6 +165,46 @@ impl FeeCollector {
             return Err(ContractError::NotInitialized);
         }
         Ok(get_treasury_balance(&env, &token))
+    }
+
+    /// # Summary
+    /// Read-only audit that compares the stored treasury balance against the
+    /// contract's actual on-chain token balance for each supplied token.
+    ///
+    /// Call this off-chain (via `simulateTransaction`) or from monitoring
+    /// scripts after unusual activity to detect accounting discrepancies.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `tokens`: List of SEP-41 token addresses to audit.
+    ///
+    /// # Returns
+    /// A `Vec<BalanceMismatch>` containing one entry per token where
+    /// `actual != expected`. Returns an empty vec when all balances reconcile.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
+    pub fn audit_balances(
+        env: Env,
+        tokens: Vec<Address>,
+    ) -> Result<Vec<BalanceMismatch>, ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let mut mismatches = Vec::new(&env);
+        for token in tokens.iter() {
+            let expected = get_treasury_balance(&env, &token);
+            let actual = token::Client::new(&env, &token).balance(&env.current_contract_address());
+            if actual != expected {
+                mismatches.push_back(BalanceMismatch {
+                    token: token.clone(),
+                    expected,
+                    actual,
+                    delta: actual.saturating_sub(expected),
+                });
+            }
+        }
+        Ok(mismatches)
     }
 
     /// # Summary

--- a/stellar-swipe/contracts/fee_collector/src/storage.rs
+++ b/stellar-swipe/contracts/fee_collector/src/storage.rs
@@ -103,6 +103,21 @@ pub struct MonthlyTradeVolume {
     pub volume_usd: i128,
 }
 
+/// Describes a discrepancy between the contract's stored treasury balance
+/// and the actual on-chain token balance for a given token.
+#[contracttype]
+#[derive(Clone)]
+pub struct BalanceMismatch {
+    /// The token whose balances were compared.
+    pub token: Address,
+    /// Balance recorded in contract storage (`TreasuryBalance`).
+    pub expected: i128,
+    /// Actual token balance held by this contract on-chain.
+    pub actual: i128,
+    /// Difference: `actual - expected`. Positive means surplus, negative means deficit.
+    pub delta: i128,
+}
+
 // --- Admin ---
 
 pub fn get_admin(env: &Env) -> Address {

--- a/stellar-swipe/contracts/fee_collector/src/test.rs
+++ b/stellar-swipe/contracts/fee_collector/src/test.rs
@@ -1125,3 +1125,137 @@ fn test_withdraw_timelock_timestamp_overflow() {
     let result = client.try_withdraw_treasury_fees(&recipient, &token, &1000i128);
     assert_eq!(result, Err(Ok(ContractError::ArithmeticOverflow)));
 }
+
+// ---------------------------------------------------------------------------
+// audit_balances — reconciliation tests
+// ---------------------------------------------------------------------------
+
+/// Helper: set up contract with a token and matching on-chain + stored balances.
+fn setup_audit(env: &Env, amount: i128) -> (Address, Address, FeeCollectorClient<'_>) {
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(env, &contract_id);
+    client.initialize(&admin);
+    StellarAssetClient::new(env, &token).mint(&contract_id, &amount);
+    env.as_contract(&contract_id, || {
+        set_treasury_balance(env, &token, amount);
+    });
+    (token, contract_id, client)
+}
+
+#[test]
+fn test_audit_balances_no_mismatch() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, _contract_id, client) = setup_audit(&env, 1_000i128);
+
+    let tokens = soroban_sdk::vec![&env, token.clone()];
+    let mismatches = client.audit_balances(&tokens).unwrap();
+
+    // Stored balance equals on-chain balance: no mismatches
+    assert_eq!(mismatches.len(), 0);
+}
+
+#[test]
+fn test_audit_balances_detects_surplus() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, contract_id, client) = setup_audit(&env, 1_000i128);
+
+    // Mint extra tokens directly to the contract without updating stored balance
+    StellarAssetClient::new(&env, &token).mint(&contract_id, &500i128);
+
+    let tokens = soroban_sdk::vec![&env, token.clone()];
+    let mismatches = client.audit_balances(&tokens).unwrap();
+
+    assert_eq!(mismatches.len(), 1);
+    let m = mismatches.get(0).unwrap();
+    assert_eq!(m.token, token);
+    assert_eq!(m.expected, 1_000);
+    assert_eq!(m.actual, 1_500);
+    assert_eq!(m.delta, 500); // surplus
+}
+
+#[test]
+fn test_audit_balances_detects_deficit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (token, contract_id, client) = setup_audit(&env, 1_000i128);
+
+    // Artificially inflate the stored balance to simulate a deficit
+    env.as_contract(&contract_id, || {
+        set_treasury_balance(&env, &token, 2_000i128);
+    });
+
+    let tokens = soroban_sdk::vec![&env, token.clone()];
+    let mismatches = client.audit_balances(&tokens).unwrap();
+
+    assert_eq!(mismatches.len(), 1);
+    let m = mismatches.get(0).unwrap();
+    assert_eq!(m.expected, 2_000);
+    assert_eq!(m.actual, 1_000);
+    assert_eq!(m.delta, -1_000); // deficit
+}
+
+#[test]
+fn test_audit_balances_multiple_tokens() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // Token A: balanced
+    let token_a = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    StellarAssetClient::new(&env, &token_a).mint(&contract_id, &500i128);
+    env.as_contract(&contract_id, || {
+        set_treasury_balance(&env, &token_a, 500i128);
+    });
+
+    // Token B: stored says 300, actual is 400 (surplus)
+    let token_b = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    StellarAssetClient::new(&env, &token_b).mint(&contract_id, &400i128);
+    env.as_contract(&contract_id, || {
+        set_treasury_balance(&env, &token_b, 300i128);
+    });
+
+    let tokens = soroban_sdk::vec![&env, token_a.clone(), token_b.clone()];
+    let mismatches = client.audit_balances(&tokens).unwrap();
+
+    // Only token B should appear
+    assert_eq!(mismatches.len(), 1);
+    let m = mismatches.get(0).unwrap();
+    assert_eq!(m.token, token_b);
+    assert_eq!(m.expected, 300);
+    assert_eq!(m.actual, 400);
+    assert_eq!(m.delta, 100);
+}
+
+#[test]
+fn test_audit_balances_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(&env, &contract_id);
+
+    let tokens = soroban_sdk::vec![&env, token.clone()];
+    let result = client.try_audit_balances(&tokens);
+    assert_eq!(result, Err(Ok(ContractError::NotInitialized)));
+}


### PR DESCRIPTION
## Summary
Closes #548
Adds a read-only `audit_balances` method to the fee collector contract that compares stored treasury balances against actual on-chain token holdings to detect accounting discrepancies.

## Changes

- **`storage.rs`**: Add `BalanceMismatch` contracttype (`token`, `expected`, `actual`, `delta`)
- **`lib.rs`**: Add `audit_balances(tokens) -> Vec<BalanceMismatch>` — returns only tokens with discrepancies; empty vec means all balances reconcile
- **`test.rs`**: 5 new tests — no mismatch, surplus detection, deficit detection, multi-token, not-initialized error
- **`docs/fee_collector_reconciliation.md`**: Usage guide covering when/how to run reconciliation checks and how to interpret results

## Testing

- Matching state: `test_audit_balances_no_mismatch`
- Intentional mismatch (surplus): `test_audit_balances_detects_surplus`
- Intentional mismatch (deficit): `test_audit_balances_detects_deficit`
- Multi-token: `test_audit_balances_multiple_tokens`
- Guard: `test_audit_balances_not_initialized`