### PR TITLE
Fixed the broken cross-contract call

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/providers.rs
+++ b/stellar-swipe/contracts/signal_registry/src/providers.rs
@@ -380,12 +380,16 @@ fn slash_stake(env: &Env, provider: &Address, stake_vault: &Address) -> i128 {
         .unwrap_or(0);
 
     if stake > 0 {
-        // Call slash_stake on StakeVault (the contract will burn/transfer the slashed amount)
+        // Call slash_stake on StakeVault — pass this contract as caller (authorizes the slash),
+        // the provider, the full stake amount, and a reason tag for the audit event.
         let slash_sym = soroban_sdk::Symbol::new(env, "slash_stake");
         let mut slash_args = soroban_sdk::Vec::<soroban_sdk::Val>::new(env);
+        let caller = env.current_contract_address();
+        slash_args.push_back(caller.into_val(env));
         slash_args.push_back(provider.clone().into_val(env));
         slash_args.push_back(stake.into_val(env));
-        // We attempt to slash, but if it fails, we still return the stake amount for the event
+        let reason = soroban_sdk::Symbol::new(env, "ban");
+        slash_args.push_back(reason.into_val(env));
         let _ = env.try_invoke_contract::<()>(stake_vault, &slash_sym, slash_args);
     }
 

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -281,15 +281,23 @@ impl StakeVaultContract {
 
     /// Admin: slash (seize) a portion of a provider's stake.
     /// Called by SignalRegistry when banning a provider (Issue #424).
-    /// The slashed amount is burned (transferred to a zero-address sentinel).
+    /// The slashed amount is burned via the token's burn function and a
+    /// structured `stake_slashed` event is emitted for audit purposes.
     pub fn slash_stake(
         env: Env,
         caller: Address,
         provider: Address,
         amount: i128,
+        reason: Symbol,
     ) -> Result<(), StakeVaultError> {
         // Only the SignalRegistry (authorized caller) can slash stake.
         caller.require_auth();
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::StakeToken)
+            .ok_or(StakeVaultError::NotInitialized)?;
 
         let mut stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
             .storage()
@@ -303,7 +311,7 @@ impl StakeVaultContract {
             return Err(StakeVaultError::NoStake);
         }
 
-        // Reduce the staked balance by the slashed amount
+        // Reduce the staked balance before the burn (checks-effects-interactions).
         info.balance = info
             .balance
             .checked_sub(amount)
@@ -314,19 +322,17 @@ impl StakeVaultContract {
             .persistent()
             .set(&MigrationKey::StakesV2, &stakes);
 
-        // Transfer the slashed tokens to the contract itself (effectively burning them
-        // since they stay in the contract and are not withdrawable)
-        let token: Address = env
-            .storage()
-            .instance()
-            .get(&StorageKey::StakeToken)
-            .ok_or(StakeVaultError::NotInitialized)?;
-
-        token::Client::new(&env, &token).transfer(
-            &env.current_contract_address(),
-            &env.current_contract_address(),
-            &amount,
+        // Emit structured event for audit trail before the external call.
+        env.events().publish(
+            (
+                Symbol::new(&env, "stake_vault"),
+                Symbol::new(&env, "stake_slashed"),
+            ),
+            (provider.clone(), amount, reason),
         );
+
+        // Burn the slashed tokens from the contract's token balance.
+        token::Client::new(&env, &token).burn(&env.current_contract_address(), &amount);
 
         Ok(())
     }

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -229,6 +229,71 @@ fn lock_cleared_after_failed_withdrawal() {
     assert!(!lock_still_set, "lock was not cleared after failed withdrawal");
 }
 
+// ── slash_stake tests ────────────────────────────────────────────────────────
+
+#[test]
+fn slash_stake_emits_event() {
+    use soroban_sdk::testutils::Events;
+    let (env, vault_id, token, _admin) = setup();
+    let caller = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let amount: i128 = 500_000;
+
+    StellarAssetClient::new(&env, &token).mint(&vault_id, &amount);
+    seed_v2_stake(&env, &vault_id, &provider, amount, 0);
+
+    let events_before = env.events().all().len();
+    StakeVaultContractClient::new(&env, &vault_id)
+        .slash_stake(&caller, &provider, &amount, &Symbol::new(&env, "ban"));
+
+    assert!(
+        env.events().all().len() > events_before,
+        "stake_slashed event not emitted"
+    );
+}
+
+#[test]
+fn slash_stake_reduces_provider_balance() {
+    let (env, vault_id, token, _admin) = setup();
+    let caller = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let initial: i128 = 1_000_000;
+    let slash_amount: i128 = 300_000;
+
+    StellarAssetClient::new(&env, &token).mint(&vault_id, &initial);
+    seed_v2_stake(&env, &vault_id, &provider, initial, 0);
+
+    let client = StakeVaultContractClient::new(&env, &vault_id);
+    client.slash_stake(&caller, &provider, &slash_amount, &Symbol::new(&env, "fraud"));
+
+    assert_eq!(client.get_stake(&provider), initial - slash_amount);
+}
+
+#[test]
+fn slash_stake_burns_tokens_from_vault() {
+    use soroban_sdk::token;
+    let (env, vault_id, token_addr, _admin) = setup();
+    let caller = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let initial: i128 = 1_000_000;
+    let slash_amount: i128 = 400_000;
+
+    StellarAssetClient::new(&env, &token_addr).mint(&vault_id, &initial);
+    seed_v2_stake(&env, &vault_id, &provider, initial, 0);
+
+    let token_client = token::Client::new(&env, &token_addr);
+    let balance_before = token_client.balance(&vault_id);
+
+    StakeVaultContractClient::new(&env, &vault_id)
+        .slash_stake(&caller, &provider, &slash_amount, &Symbol::new(&env, "misconduct"));
+
+    assert_eq!(
+        token_client.balance(&vault_id),
+        balance_before - slash_amount,
+        "slashed tokens were not burned from vault"
+    );
+}
+
 // ── Issue #388: stake-below-minimum tests ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #537

## Changes Made

### `stake_vault/src/lib.rs` — `slash_stake` Function (3 Fixes)

| Fix | Description |
|-----|-------------|
| **New `reason` parameter** | Slash reason is now part of the function signature and flows into the event |
| **Real token burn** | Replaced no‑op `self-transfer` (`transfer(contract → contract, amount)`) with `token::Client::burn(&contract_address, &amount)` — now **actually destroys** tokens from the contract's on‑chain balance |
| **Structured event emission** | Emits `(stake_vault, stake_slashed)` topics with `(provider, amount, reason)` data **before** the burn call. Event is emitted **after** state is updated (CEI pattern), so ledger state remains consistent if the event is the last observable action |

---

### `signal_registry/src/providers.rs` — Cross‑Contract Call Fix

**Before:** Passed `[provider, amount]` — mismatch with `slash_stake` signature  
**After:** Passes `env.current_contract_address()` as `caller` (so `caller.require_auth()` succeeds in the vault) and `Symbol("ban")` as `reason`

✅ Now correctly passes: `[caller, provider, amount, reason]`

---

### `stake_vault/src/tests.rs` — 3 New Tests

| Test | Verifies |
|------|----------|
| `slash_stake_emits_event` | Event count increases after `slash_stake` |
| `slash_stake_reduces_provider_balance` | Provider's stored stake drops by exactly the slashed amount |
| `slash_stake_burns_tokens_from_vault` | Vault's token balance decreases by the slashed amount (tokens actually burned) |