### PR TITLE
Fix pending limit order sweep

### DIFF
--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -652,35 +652,6 @@ impl TradeExecutorContract {
                 continue;
             };
 
-        // ── Cross-contract call #1: SEP-41 balance check ──────────────────────
-        let fee = effective_estimated_fee(&env);
-        let bal_key = StorageKey::LastInsufficientBalance(user.clone());
-
-        // Primary: try to deduct fee upfront (user has amount + fee).
-        // Fallback: if primary fails but user has at least `amount`, proceed and
-        // deduct fee from received tokens after the trade.
-        let use_fee_fallback = match check_user_balance(&env, &user, &token, effective_amount, fee) {
-            Ok(()) => {
-                env.storage().instance().remove(&bal_key);
-                false
-            }
-            Err(detail) => {
-                // Primary failed. Check if user has enough for just the amount (no fee).
-                match check_user_balance(&env, &user, &token, effective_amount, 0) {
-                    Ok(()) => {
-                        // User has enough for the trade but not the fee — use fallback.
-                        env.storage().instance().remove(&bal_key);
-                        true
-                    }
-                    Err(_) => {
-                        // User doesn't even have enough for the trade amount.
-                        env.storage().instance().set(&bal_key, &detail);
-                        env.storage().temporary().remove(&lock_key);
-                        return Err(ContractError::InsufficientBalance);
-                    }
-                }
-            }
-        };
             if order.token != token {
                 next_ids.push_back(order_id);
                 continue;
@@ -712,32 +683,6 @@ impl TradeExecutorContract {
             }
         }
 
-        // If fallback was used, emit the FeeDeductedFromReceived event.
-        // The trade_id is the current position count (used as a proxy identifier).
-        if use_fee_fallback && fee > 0 {
-            // Use a monotonic counter stored per user as a trade_id proxy.
-            let trade_id_key = StorageKey::FeeDeductedFromReceived(user.clone(), 0);
-            let trade_id: u64 = env
-                .storage()
-                .instance()
-                .get(&trade_id_key)
-                .unwrap_or(0u64)
-                .saturating_add(1);
-            env.storage().instance().set(&trade_id_key, &trade_id);
-
-            shared::events::emit_fee_deducted_from_received(
-                &env,
-                shared::events::EvtFeeDeductedFromReceived {
-                    schema_version: shared::events::SCHEMA_VERSION,
-                    user: user.clone(),
-                    fee_amount: fee,
-                    trade_id,
-                },
-            );
-        }
-
-        env.storage().temporary().remove(&lock_key);
-        Ok(())
         set_pending_order_ids(&env, &next_ids);
         Ok(processed)
     }


### PR DESCRIPTION
## Summary

Fixes #623 by removing duplicated, out-of-scope market-trade balance logic from `check_pending_limit_orders`.

## Changes

- Removed copied fee/balance fallback code that referenced `user`, `effective_amount`, and `lock_key` outside their scope.
- Removed the copied fallback event path and early `Ok(())`.
- Restored the intended pending-order sweep tail so `next_ids` is persisted and `processed` is returned.

## Testing/Verification

- `docker run --rm -v <repo>\stellar-swipe:/work -w /work rust:latest sh -lc "/usr/local/cargo/bin/cargo check -p trade_executor --lib"`
  - Current result: blocked before this target can fully compile by unrelated upstream errors in `contracts/shared`:
    - missing `panic_with_error` macro import,
    - missing `env.deployer().get_contract_wasm_hash`,
    - `Ok(next_depth)` returning `u32` where `u64` is expected.
- I also ran a Docker temp-copy check with temporary shims only for those shared dependency blockers. That check reaches `trade_executor`, and the #623 undefined-variable/unreachable-path errors are gone. Remaining failures are unrelated existing `trade_executor` compile blockers:
  - duplicate `ContractError` discriminant value `15`,
  - missing circuit-breaker storage keys/helpers,
  - missing open-interest helpers.

Closes #623.
