### PR TITLE
auto_trade: fix build + add trade logging/metrics; trade_executor: market simulation & stress tests

### DIFF
--- a/stellar-swipe/Cargo.lock
+++ b/stellar-swipe/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
 name = "auto_trade"
 version = "0.0.0"
 dependencies = [
+ "shared",
  "soroban-sdk",
  "stellar_swipe_common",
 ]

--- a/stellar-swipe/contracts/auto_trade/Cargo.toml
+++ b/stellar-swipe/contracts/auto_trade/Cargo.toml
@@ -14,6 +14,7 @@ testutils = []
 [dependencies]
 soroban-sdk = { workspace = true }
 stellar_swipe_common = { path = "../common" }
+shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/stellar-swipe/contracts/auto_trade/src/admin.rs
+++ b/stellar-swipe/contracts/auto_trade/src/admin.rs
@@ -1,123 +1,18 @@
-use soroban_sdk::{contracttype, Address, Env, Symbol};
-
-use crate::errors::AutoTradeError;
-use crate::storage::{self, RateLimitInfo};
-
-// Constants
-/// Rate limit duration: 720 ledgers ≈ 1 hour (assuming 5-second block time)
-pub const RATE_LIMIT_DURATION_LEDGERS: u64 = 720;
-
-/// 1 hour in seconds (3600 seconds)
-pub const RATE_LIMIT_DURATION_SECONDS: u64 = 3600;
-
-#[contracttype]
-#[derive(Clone)]
-pub enum AdminStorageKey {
-    Admin,
-    Operator,
-}
-
-/// Initialize admin (called once at contract deployment)
-pub fn init_admin(env: &Env, admin: Address) -> Result<(), AutoTradeError> {
-    if has_admin(env) {
-        return Err(AutoTradeError::Unauthorized);
-    }
-
-    env.storage().instance().set(&AdminStorageKey::Admin, &admin);
-    Ok(())
-}
-
-/// Check if admin is initialized
-pub fn has_admin(env: &Env) -> bool {
-    env.storage().instance().has(&AdminStorageKey::Admin)
-}
-
-/// Get current admin
-pub fn get_admin(env: &Env) -> Result<Address, AutoTradeError> {
-    env.storage()
-        .instance()
-        .get(&AdminStorageKey::Admin)
-        .ok_or(AutoTradeError::Unauthorized)
-}
-
-/// Require caller is admin
-pub fn require_admin(env: &Env, caller: &Address) -> Result<(), AutoTradeError> {
-    let admin = get_admin(env)?;
-    if caller != &admin {
-        return Err(AutoTradeError::Unauthorized);
-    }
-    caller.require_auth();
-    Ok(())
-}
-
-/// Get current operator
-pub fn get_operator(env: &Env) -> Result<Address, AutoTradeError> {
-    env.storage()
-        .instance()
-        .get(&AdminStorageKey::Operator)
-        .ok_or(AutoTradeError::Unauthorized)
-}
-
-/// Set operator (admin only)
-pub fn set_operator(env: &Env, caller: &Address, operator: Address) -> Result<(), AutoTradeError> {
-    require_admin(env, caller)?;
-
-    env.storage()
-        .instance()
-        .set(&AdminStorageKey::Operator, &operator);
-
-    #[allow(deprecated)]
-    env.events().publish(
-        (Symbol::new(env, "operator_set"), caller.clone()),
-        operator.clone(),
-    );
-
-    Ok(())
-}
-
-/// Require caller is operator
-pub fn require_operator(env: &Env, caller: &Address) -> Result<(), AutoTradeError> {
-    let operator = get_operator(env)?;
-    if caller != &operator {
-        return Err(AutoTradeError::Unauthorized);
-    }
-    caller.require_auth();
-    Ok(())
-}
-
-/// Set rate limit flag for a user (operator only)
-/// Sets is_limited=true and expires_at = now + RATE_LIMIT_DURATION_SECONDS
-pub fn set_rate_limited(
-    env: &Env,
-    caller: &Address,
-    user: &Address,
-) -> Result<(), AutoTradeError> {
-    require_operator(env, caller)?;
-
-    let now = env.ledger().timestamp();
-    let expires_at = now + RATE_LIMIT_DURATION_SECONDS;
-
-    let info = RateLimitInfo {
-        user: user.clone(),
-        is_limited: true,
-        expires_at,
-    };
-
-    storage::set_rate_limit_info(env, user, &info);
-
-    #[allow(deprecated)]
-    env.events().publish(
-        (Symbol::new(env, "user_rate_limited"), user.clone()),
-use soroban_sdk::{contracttype, Address, Env, Map, String};
+use soroban_sdk::{contracttype, Address, Env, Map, String, Symbol};
 use stellar_swipe_common::emergency::{
     CircuitBreakerConfig, CircuitBreakerStats, PauseState, CAT_ALL, CAT_TRADING,
 };
 
 use crate::errors::AutoTradeError;
+use crate::storage::{self, RateLimitInfo};
+
+/// 1 hour in seconds (3600 seconds)
+pub const RATE_LIMIT_DURATION_SECONDS: u64 = 3600;
 
 #[contracttype]
 pub enum AdminStorageKey {
     Admin,
+    Operator,
     Guardian,
     OracleAddress,
     OracleCircuitBreaker,
@@ -171,6 +66,42 @@ pub fn require_admin(env: &Env, caller: &Address) -> Result<(), AutoTradeError> 
     if caller != &admin {
         return Err(AutoTradeError::Unauthorized);
     }
+    Ok(())
+}
+
+/// Get current operator
+pub fn get_operator(env: &Env) -> Result<Address, AutoTradeError> {
+    env.storage()
+        .instance()
+        .get(&AdminStorageKey::Operator)
+        .ok_or(AutoTradeError::Unauthorized)
+}
+
+/// Set operator (admin only)
+pub fn set_operator(env: &Env, caller: &Address, operator: Address) -> Result<(), AutoTradeError> {
+    require_admin(env, caller)?;
+    caller.require_auth();
+
+    env.storage()
+        .instance()
+        .set(&AdminStorageKey::Operator, &operator);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (Symbol::new(env, "operator_set"), caller.clone()),
+        operator.clone(),
+    );
+
+    Ok(())
+}
+
+/// Require caller is operator
+pub fn require_operator(env: &Env, caller: &Address) -> Result<(), AutoTradeError> {
+    let operator = get_operator(env)?;
+    if caller != &operator {
+        return Err(AutoTradeError::Unauthorized);
+    }
+    caller.require_auth();
     Ok(())
 }
 
@@ -403,25 +334,6 @@ pub fn propose_admin_transfer(
     Ok(())
 }
 
-/// Clear rate limit flag for a user (operator only)
-pub fn clear_rate_limited(
-    env: &Env,
-    caller: &Address,
-    user: &Address,
-) -> Result<(), AutoTradeError> {
-    require_operator(env, caller)?;
-
-    let info = RateLimitInfo {
-        user: user.clone(),
-        is_limited: false,
-        expires_at: 0,
-    };
-
-    storage::set_rate_limit_info(env, user, &info);
-
-    #[allow(deprecated)]
-    env.events().publish(
-        (Symbol::new(env, "user_rate_limit_cleared"), user.clone()),
 /// Accept admin transfer (called by new admin)
 pub fn accept_admin_transfer(env: &Env, caller: &Address) -> Result<(), AutoTradeError> {
     caller.require_auth();
@@ -478,17 +390,6 @@ pub fn accept_admin_transfer(env: &Env, caller: &Address) -> Result<(), AutoTrad
     Ok(())
 }
 
-/// Get rate limit info for a user
-pub fn get_rate_limit_info(
-    env: &Env,
-    user: &Address,
-) -> Option<RateLimitInfo> {
-    storage::get_rate_limit_info(env, user)
-}
-
-/// Check if user is rate limited (and auto-expire if necessary)
-pub fn is_rate_limited(env: &Env, user: &Address) -> bool {
-    storage::is_rate_limited(env, user)
 /// Cancel pending admin transfer (current admin only)
 pub fn cancel_admin_transfer(env: &Env, caller: &Address) -> Result<(), AutoTradeError> {
     require_admin(env, caller)?;
@@ -506,6 +407,73 @@ pub fn cancel_admin_transfer(env: &Env, caller: &Address) -> Result<(), AutoTrad
     env.storage().instance().remove(&AdminStorageKey::PendingAdminExpiry);
 
     Ok(())
+}
+
+/// Set rate limit flag for a user (operator only)
+/// Sets is_limited=true and expires_at = now + RATE_LIMIT_DURATION_SECONDS
+pub fn set_rate_limited(
+    env: &Env,
+    caller: &Address,
+    user: &Address,
+) -> Result<(), AutoTradeError> {
+    require_operator(env, caller)?;
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + RATE_LIMIT_DURATION_SECONDS;
+
+    let info = RateLimitInfo {
+        user: user.clone(),
+        is_limited: true,
+        expires_at,
+    };
+
+    storage::set_rate_limit_info(env, user, &info);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (Symbol::new(env, "user_rate_limited"), user.clone()),
+        expires_at,
+    );
+
+    Ok(())
+}
+
+/// Clear rate limit flag for a user (operator only)
+pub fn clear_rate_limited(
+    env: &Env,
+    caller: &Address,
+    user: &Address,
+) -> Result<(), AutoTradeError> {
+    require_operator(env, caller)?;
+
+    let info = RateLimitInfo {
+        user: user.clone(),
+        is_limited: false,
+        expires_at: 0,
+    };
+
+    storage::set_rate_limit_info(env, user, &info);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (Symbol::new(env, "user_rate_limit_cleared"), user.clone()),
+        (),
+    );
+
+    Ok(())
+}
+
+/// Get rate limit info for a user
+pub fn get_rate_limit_info(
+    env: &Env,
+    user: &Address,
+) -> Option<RateLimitInfo> {
+    storage::get_rate_limit_info(env, user)
+}
+
+/// Check if user is rate limited (and auto-expire if necessary)
+pub fn is_rate_limited(env: &Env, user: &Address) -> bool {
+    storage::is_rate_limited(env, user)
 }
 
 // ==================== Self-Destruct Protection ====================

--- a/stellar-swipe/contracts/auto_trade/src/errors.rs
+++ b/stellar-swipe/contracts/auto_trade/src/errors.rs
@@ -23,62 +23,58 @@ pub enum AutoTradeError {
     InsufficientPriceHistory = 12,
     RankingDisabled = 13,
     RateLimited = 14,
-    PrivacyModeEnabled = 10,
-    TradingPaused = 10,
-    StrategyNotFound = 11,
-    PositionAlreadyExists = 12,
+    PrivacyModeEnabled = 15,
+    TradingPaused = 16,
     // ── Portfolio / stat-arb ─────────────────────────────────────────────────
-    InvalidBasketSize = 13,
-    InsufficientPriceHistory = 14,
-    InvalidPriceData = 15,
-    NonCointegratedBasket = 16,
-    ActivePortfolioExists = 17,
-    NoActivePortfolio = 18,
-    NoTradeSignal = 19,
-    InvalidStatArbConfig = 20,
+    InvalidBasketSize = 17,
+    InvalidPriceData = 18,
+    NonCointegratedBasket = 19,
+    ActivePortfolioExists = 20,
+    NoActivePortfolio = 21,
+    NoTradeSignal = 22,
+    InvalidStatArbConfig = 23,
     // ── Exit / insurance ─────────────────────────────────────────────────────
-    ExitStrategyNotFound = 21,
-    InvalidExitConfig = 22,
-    InsuranceNotConfigured = 23,
-    InvalidInsuranceConfig = 24,
+    ExitStrategyNotFound = 24,
+    InvalidExitConfig = 25,
+    InsuranceNotConfigured = 26,
+    InvalidInsuranceConfig = 27,
     // ── Referral (SelfReferral / AlreadySet / Circular / LimitExceeded) ──────
-    ReferralError = 25,
+    ReferralError = 28,
     // ── TWAP (InvalidDuration / NotFound / NotOwner / NotActive) ─────────────
-    TWAPError = 26,
+    TWAPError = 29,
     // ── Correlation ──────────────────────────────────────────────────────────
-    CorrelationLimitExceeded = 27,
-    TooManyCorrelatedPositions = 28,
+    CorrelationLimitExceeded = 30,
+    TooManyCorrelatedPositions = 31,
     // ── Conditional orders (NotFound / NotPending / NotTriggered / Config) ───
-    ConditionalOrderError = 29,
-    InvalidConditionalConfig = 30,
+    ConditionalOrderError = 32,
+    InvalidConditionalConfig = 33,
     // ── Rate limits (all sub-types collapsed) ────────────────────────────────
-    RateLimitExceeded = 31,
+    RateLimitExceeded = 34,
     // ── Pairs trading ────────────────────────────────────────────────────────
-    PairsStrategyNotFound = 32,
-    PairsPositionError = 33,
-    InsufficientCorrelation = 34,
-    PairNotCointegrated = 35,
-    InvalidPairsConfig = 36,
+    PairsStrategyNotFound = 35,
+    PairsPositionError = 36,
+    InsufficientCorrelation = 37,
+    PairNotCointegrated = 38,
+    InvalidPairsConfig = 39,
     // ── Oracle ───────────────────────────────────────────────────────────────
-    OracleUnavailable = 37,
+    OracleUnavailable = 40,
     // ── DCA (NotFound / Inactive / EndTimeReached) ────────────────────────────
-    DcaError = 38,
+    DcaError = 41,
     // ── Mean-reversion (NotFound / InsufficientHistory / LowVolatility) ──────
-    MrStrategyError = 39,
+    MrStrategyError = 42,
     // ── Admin transfer ───────────────────────────────────────────────────────
-    AdminTransferError = 40,
+    AdminTransferError = 43,
     // ── Routing ──────────────────────────────────────────────────────────────
-    RoutingPlanNotFound = 41,
+    RoutingPlanNotFound = 44,
     // ── Arbitrage ────────────────────────────────────────────────────────────
-    ArbitrageError = 42,
-    FrontRunningRisk = 43,
+    ArbitrageError = 45,
+    FrontRunningRisk = 46,
     // ── System / bridge / recovery ───────────────────────────────────────────
-    SystemError = 44,
-    SlippageExceeded = 45,
+    SystemError = 47,
+    SlippageExceeded = 48,
     // ── Misc ─────────────────────────────────────────────────────────────────
-    RankingDisabled = 46,
-    LastOracleForPair = 47,
-    NotPaused = 48,
+    LastOracleForPair = 49,
+    NotPaused = 50,
 }
 
 // ── Backward-compatible aliases ───────────────────────────────────────────────

--- a/stellar-swipe/contracts/auto_trade/src/kyc.rs
+++ b/stellar-swipe/contracts/auto_trade/src/kyc.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{contracttype, Address, Env, String, Symbol};
 use crate::admin::require_admin;
 use crate::errors::AutoTradeError;
-use stellar_swipe_common::shared::events::{emit_kyc_status_updated, EvtKycStatusUpdated, SCHEMA_VERSION};
+use shared::events::{emit_kyc_status_updated, EvtKycStatusUpdated, SCHEMA_VERSION};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/stellar-swipe/contracts/auto_trade/src/lib.rs
+++ b/stellar-swipe/contracts/auto_trade/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol, Vec};
 
 mod admin;
@@ -143,30 +142,30 @@ impl AutoTradeContract {
         max_slippage_bps: u32,
     ) -> TradeSimulation {
         if amount <= 0 {
-            return failed_simulation(&env, "invalid_amount");
+            return Self::failed_simulation(&env, "invalid_amount");
         }
 
         let signal = match storage::get_signal(&env, signal_id) {
             Some(signal) => signal,
-            None => return failed_simulation(&env, "signal_not_found"),
+            None => return Self::failed_simulation(&env, "signal_not_found"),
         };
 
         if env.ledger().timestamp() > signal.expiry {
-            return failed_simulation(&env, "signal_expired");
+            return Self::failed_simulation(&env, "signal_expired");
         }
 
         if !auth::is_authorized(&env, &user, amount) {
-            return failed_simulation(&env, "unauthorized");
+            return Self::failed_simulation(&env, "unauthorized");
         }
 
         if !sdex::has_sufficient_balance(&env, &user, &signal.base_asset, amount) {
-            return failed_simulation(&env, "insufficient_balance");
+            return Self::failed_simulation(&env, "insufficient_balance");
         }
 
         let current_price = sdex::get_current_price(&env, &signal);
         let available_liquidity = sdex::get_available_liquidity(&env, &signal, amount);
         if available_liquidity <= 0 {
-            return failed_simulation(&env, "insufficient_liquidity");
+            return Self::failed_simulation(&env, "insufficient_liquidity");
         }
 
         let expected_output = core::cmp::min(amount, available_liquidity);
@@ -189,6 +188,16 @@ impl AutoTradeContract {
         } else {
             None
         };
+
+        if let Some(ref reason) = failure_reason {
+            logging::emit_log(
+                &env,
+                logging::LogLevel::Warn,
+                String::from_str(&env, "simulation"),
+                reason.clone(),
+                None,
+            );
+        }
 
         TradeSimulation {
             expected_output,
@@ -414,6 +423,17 @@ impl AutoTradeContract {
         logging::emit_log(&env, level, category, message, correlation_id);
     }
 
+    /// Get running trade-outcome counters (attempts / filled / partially
+    /// filled / failed) for a cheap on-chain success-rate signal.
+    pub fn get_trade_metrics(env: Env) -> logging::TradeMetrics {
+        logging::get_trade_metrics(&env)
+    }
+
+    /// Get the most recent structured log entries (oldest first, capped at 20).
+    pub fn get_recent_logs(env: Env) -> soroban_sdk::Vec<logging::LogEntry> {
+        logging::get_recent_logs(&env)
+    }
+
     /// Submit a KYC verification request for a user.
     pub fn submit_kyc_verification(
         env: Env,
@@ -497,6 +517,13 @@ impl AutoTradeContract {
         amount: i128,
     ) -> Result<TradeResult, AutoTradeError> {
         if admin::is_paused(&env, String::from_str(&env, CAT_TRADING)) {
+            logging::emit_log(
+                &env,
+                logging::LogLevel::Warn,
+                String::from_str(&env, "trade"),
+                String::from_str(&env, "execute_trade_blocked"),
+                None,
+            );
             return Err(AutoTradeError::TradingPaused);
         }
 
@@ -509,7 +536,16 @@ impl AutoTradeContract {
         );
 
         // Oracle circuit breaker: halt if oracle is unavailable (unless admin override)
-        oracle::check_oracle_circuit_breaker(&env, signal_id as u32)?;
+        if let Err(err) = oracle::check_oracle_circuit_breaker(&env, signal_id as u32) {
+            logging::emit_log(
+                &env,
+                logging::LogLevel::Warn,
+                String::from_str(&env, "trade"),
+                String::from_str(&env, "execute_trade_blocked"),
+                None,
+            );
+            return Err(err);
+        }
 
         if amount <= 0 {
             return Err(AutoTradeError::InvalidAmount);
@@ -591,6 +627,8 @@ impl AutoTradeContract {
         } else {
             TradeStatus::Filled
         };
+
+        logging::record_trade_outcome(&env, &status);
 
         admin::update_cb_stats(
             &env,
@@ -829,6 +867,8 @@ impl AutoTradeContract {
         user_b: Address,
     ) -> Result<portfolio::PortfolioComparison, AutoTradeError> {
         portfolio::compare_portfolios(&env, user_a, user_b)
+    }
+
     /// Set risk parity configuration
     pub fn set_risk_parity_config(
         env: Env,
@@ -1007,6 +1047,13 @@ impl AutoTradeContract {
     }
 
 fn failed_simulation(env: &Env, reason: &str) -> TradeSimulation {
+    logging::emit_log(
+        env,
+        logging::LogLevel::Warn,
+        String::from_str(env, "simulation"),
+        String::from_str(env, reason),
+        None,
+    );
     TradeSimulation {
         expected_output: 0,
         fee_amount: 0,
@@ -1017,7 +1064,6 @@ fn failed_simulation(env: &Env, reason: &str) -> TradeSimulation {
     }
 }
 
-mod test;
     /// Returns estimated storage usage metrics.
     ///
     /// # Estimation methodology

--- a/stellar-swipe/contracts/auto_trade/src/logging.rs
+++ b/stellar-swipe/contracts/auto_trade/src/logging.rs
@@ -1,5 +1,23 @@
 #![allow(dead_code)]
 
+//! Structured logging and trade-outcome metrics (issue #636).
+//!
+//! Emitted events (topic `log_entry`, payload [`LogEntry`]):
+//! - category `"trade"`, message `"execute_trade_started"` — Info, on entry
+//!   to `execute_trade`, before any validation.
+//! - category `"trade"`, message `"execute_trade_blocked"` — Warn, when
+//!   trading is paused or the oracle circuit breaker is tripped.
+//! - category `"trade"`, message one of `"trade_filled"` /
+//!   `"trade_partially_filled"` / `"trade_failed"` — Info/Warn/Critical,
+//!   once the trade's final [`crate::TradeStatus`] is known.
+//! - category `"simulation"`, message = the simulation's failure reason
+//!   (e.g. `"slippage_exceeded"`, `"insufficient_liquidity"`) — Warn, any
+//!   time `simulate_copy_trade` predicts a trade would not succeed.
+//!
+//! [`TradeMetrics`] is a running counter (attempts / filled / partially
+//! filled / failed) updated on every `execute_trade` outcome, queryable via
+//! `get_trade_metrics` for a cheap on-chain success-rate signal.
+
 use soroban_sdk::{contracttype, Address, Env, String, Symbol, Vec};
 use crate::admin::{require_admin};
 use crate::errors::AutoTradeError;
@@ -10,7 +28,10 @@ pub enum LogLevel {
     Debug,
     Info,
     Warn,
-    Error,
+    // Named `Critical` rather than `Error`: a variant literally named `Error`
+    // collides with the associated type `Error` that soroban's #[contracttype]
+    // macro generates for value conversion, which rustc rejects as ambiguous.
+    Critical,
 }
 
 #[contracttype]
@@ -28,6 +49,60 @@ pub struct LogEntry {
 pub enum LoggingStorageKey {
     Config,
     RecentLogs,
+    Metrics,
+}
+
+/// Running trade-outcome counters, updated once per `execute_trade` call.
+#[contracttype]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TradeMetrics {
+    pub total_attempts: u64,
+    pub total_filled: u64,
+    pub total_partially_filled: u64,
+    pub total_failed: u64,
+}
+
+pub fn get_trade_metrics(env: &Env) -> TradeMetrics {
+    env.storage()
+        .instance()
+        .get(&LoggingStorageKey::Metrics)
+        .unwrap_or_default()
+}
+
+/// Record the outcome of a completed `execute_trade` call and emit a
+/// matching structured log entry (Info for a full fill, Warn for a partial
+/// fill, Critical for a failure).
+pub fn record_trade_outcome(env: &Env, status: &crate::TradeStatus) {
+    let mut metrics = get_trade_metrics(env);
+    metrics.total_attempts += 1;
+
+    let (level, message) = match status {
+        crate::TradeStatus::Filled => {
+            metrics.total_filled += 1;
+            (LogLevel::Info, "trade_filled")
+        }
+        crate::TradeStatus::PartiallyFilled => {
+            metrics.total_partially_filled += 1;
+            (LogLevel::Warn, "trade_partially_filled")
+        }
+        crate::TradeStatus::Failed => {
+            metrics.total_failed += 1;
+            (LogLevel::Critical, "trade_failed")
+        }
+        crate::TradeStatus::Pending => return,
+    };
+
+    env.storage()
+        .instance()
+        .set(&LoggingStorageKey::Metrics, &metrics);
+
+    emit_log(
+        env,
+        level,
+        String::from_str(env, "trade"),
+        String::from_str(env, message),
+        None,
+    );
 }
 
 pub fn set_log_level(env: &Env, caller: &Address, level: LogLevel) -> Result<(), AutoTradeError> {
@@ -80,15 +155,23 @@ pub fn emit_log(
     env.storage().instance().set(&LoggingStorageKey::RecentLogs, &logs);
 }
 
+/// Returns the most recent log entries (oldest first), capped at 20.
+pub fn get_recent_logs(env: &Env) -> Vec<LogEntry> {
+    env.storage()
+        .instance()
+        .get(&LoggingStorageKey::RecentLogs)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
 fn should_log(configured: &LogLevel, event_level: &LogLevel) -> bool {
     matches!(
         (configured, event_level),
         (LogLevel::Debug, _)
             | (LogLevel::Info, LogLevel::Info)
             | (LogLevel::Info, LogLevel::Warn)
-            | (LogLevel::Info, LogLevel::Error)
+            | (LogLevel::Info, LogLevel::Critical)
             | (LogLevel::Warn, LogLevel::Warn)
-            | (LogLevel::Warn, LogLevel::Error)
-            | (LogLevel::Error, LogLevel::Error)
+            | (LogLevel::Warn, LogLevel::Critical)
+            | (LogLevel::Critical, LogLevel::Critical)
     )
 }

--- a/stellar-swipe/contracts/auto_trade/src/oracle.rs
+++ b/stellar-swipe/contracts/auto_trade/src/oracle.rs
@@ -165,6 +165,8 @@ pub fn get_aggregated_price(
                 OracleError::PriceNotFound => String::from_str(env, "price_not_found"),
                 OracleError::PriceStale    => String::from_str(env, "price_stale"),
                 OracleError::CallFailed    => String::from_str(env, "call_failed"),
+                OracleError::PriceBelowMin => String::from_str(env, "price_below_min"),
+                OracleError::PriceAboveMax => String::from_str(env, "price_above_max"),
             };
             env.events().publish(
                 (Symbol::new(env, "oracle_cb_triggered"),),

--- a/stellar-swipe/contracts/auto_trade/src/storage.rs
+++ b/stellar-swipe/contracts/auto_trade/src/storage.rs
@@ -45,20 +45,6 @@ pub fn authorize_user(env: &Env, user: &Address) {
         .set(&(user.clone(), symbol_short!("balance")), &i128::MAX);
 }
 
-/// Authorize a user with default limits (test helper).
-#[cfg(test)]
-pub fn authorize_user(env: &Env, user: &Address) {
-    let config = AuthConfig {
-        authorized: true,
-        max_trade_amount: 1_000_000_000_000,
-        expires_at: env.ledger().timestamp() + (30 * 86400),
-        granted_at: env.ledger().timestamp(),
-    };
-    env.storage()
-        .persistent()
-        .set(&AuthKey::Authorization(user.clone()), &config);
-}
-
 /// Authorize a user with explicit limits.
 pub fn authorize_user_with_limits(
     env: &Env,
@@ -86,7 +72,24 @@ pub fn revoke_user_authorization(env: &Env, user: &Address) {
         .remove(&AuthKey::Authorization(user.clone()));
 }
 
-#[cfg(test)]
-pub fn authorize_user(env: &Env, user: &Address) {
-    authorize_user_with_limits(env, user, 1_000_000_000_000, 30);
+/// Get the stored rate-limit info for a user, if any.
+pub fn get_rate_limit_info(env: &Env, user: &Address) -> Option<RateLimitInfo> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RateLimitInfo(user.clone()))
+}
+
+/// Persist rate-limit info for a user.
+pub fn set_rate_limit_info(env: &Env, user: &Address, info: &RateLimitInfo) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::RateLimitInfo(user.clone()), info);
+}
+
+/// Whether a user is currently rate limited (flag set and not yet expired).
+pub fn is_rate_limited(env: &Env, user: &Address) -> bool {
+    match get_rate_limit_info(env, user) {
+        Some(info) => info.is_limited && env.ledger().timestamp() < info.expires_at,
+        None => false,
+    }
 }

--- a/stellar-swipe/contracts/auto_trade/src/strategies/momentum.rs
+++ b/stellar-swipe/contracts/auto_trade/src/strategies/momentum.rs
@@ -599,7 +599,7 @@ pub fn get_historical_prices(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::Env;
 
     fn setup_test_prices(env: &Env) -> Vec<i128> {

--- a/stellar-swipe/contracts/auto_trade/src/test.rs
+++ b/stellar-swipe/contracts/auto_trade/src/test.rs
@@ -7,7 +7,7 @@ use crate::storage;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, IntoVal, Symbol, Val,
+    Address, Env, IntoVal, Symbol, TryFromVal, Val,
 };
 
 fn setup_env() -> Env {
@@ -615,11 +615,11 @@ fn test_stop_loss_check() {
         let config = risk::RiskConfig::default(); // 15% stop loss
 
         // Price at 90 (10% drop) - should NOT trigger
-        let triggered = risk::check_stop_loss(&env, &user, 1, 90, &config);
+        let triggered = risk::check_stop_loss(&env, &user, 1, 90, None, &config);
         assert!(!triggered);
 
         // Price at 80 (20% drop) - should trigger
-        let triggered = risk::check_stop_loss(&env, &user, 1, 80, &config);
+        let triggered = risk::check_stop_loss(&env, &user, 1, 80, None, &config);
         assert!(triggered);
     });
 }
@@ -702,10 +702,10 @@ fn test_trailing_stop_triggers_auto_sell_and_event() {
             1u32,
         )
             .into_val(&env);
-        let expected_data: Val = result.into_val(&env);
         let events = env.events().all();
         assert!(events.iter().any(|event| {
-            event.1 == expected_topics && event.2 == expected_data
+            event.1 == expected_topics
+                && advanced_risk::AutoSellResult::try_from_val(&env, &event.2) == Ok(result.clone())
         }));
     });
 }
@@ -1236,13 +1236,162 @@ fn test_authorization_at_exact_limit() {
         assert!(res.is_ok());
     });
 }
-feat/batch-copy-trade
 
+// ── Logging / metrics tests (issue #636) ─────────────────────────────────────
+
+#[test]
+fn test_trade_metrics_start_at_zero() {
+    let env = setup_env();
+    let contract_id = env.register(AutoTradeContract, ());
+
+    env.as_contract(&contract_id, || {
+        let metrics = AutoTradeContract::get_trade_metrics(env.clone());
+        assert_eq!(metrics.total_attempts, 0);
+        assert_eq!(metrics.total_filled, 0);
+        assert_eq!(metrics.total_partially_filled, 0);
+        assert_eq!(metrics.total_failed, 0);
+    });
+}
+
+#[test]
+fn test_successful_trade_records_metrics_and_emits_filled_log() {
+    let env = setup_env();
+    let contract_id = env.register(AutoTradeContract, ());
+    let user = Address::generate(&env);
+    let signal_id = 1;
+    let signal = setup_signal(&env, signal_id, env.ledger().timestamp() + 1000);
+
+    grant_auth(&env, &contract_id, &user, 500_0000000, 30);
+
+    env.as_contract(&contract_id, || {
+        storage::set_signal(&env, signal_id, &signal);
+        storage::authorize_user_with_limits(&env, &user, 500_0000000, 30);
+        env.storage()
+            .temporary()
+            .set(&(user.clone(), symbol_short!("balance")), &1000_0000000i128);
+        env.storage()
+            .temporary()
+            .set(&(symbol_short!("liquidity"), signal_id), &1000_0000000i128);
+
+        let res = AutoTradeContract::execute_trade(
+            env.clone(),
+            user.clone(),
+            signal_id,
+            OrderType::Market,
+            500_0000000,
+        )
+        .unwrap();
+        assert_eq!(res.trade.status, TradeStatus::Filled);
+
+        let metrics = AutoTradeContract::get_trade_metrics(env.clone());
+        assert_eq!(metrics.total_attempts, 1);
+        assert_eq!(metrics.total_filled, 1);
+        assert_eq!(metrics.total_partially_filled, 0);
+        assert_eq!(metrics.total_failed, 0);
+
+        let expected_topics = (Symbol::new(&env, "log_entry"),).into_val(&env);
+        let events = env.events().all();
+        assert!(events.iter().any(|event| {
+            event.1 == expected_topics
+                && logging::LogEntry::try_from_val(&env, &event.2)
+                    .map(|entry| {
+                        entry.level == logging::LogLevel::Info
+                            && entry.message == String::from_str(&env, "trade_filled")
+                    })
+                    .unwrap_or(false)
+        }));
+    });
+}
+
+#[test]
+fn test_trade_blocked_while_paused_logs_warning_and_skips_metrics() {
+    let env = setup_env();
+    let contract_id = env.register(AutoTradeContract, ());
+    let user = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let signal_id = 1;
+    let signal = setup_signal(&env, signal_id, env.ledger().timestamp() + 1000);
+
+    env.as_contract(&contract_id, || {
+        admin::init_admin(&env, admin.clone());
+        storage::set_signal(&env, signal_id, &signal);
+        admin::pause_category(
+            &env,
+            &admin,
+            String::from_str(&env, CAT_TRADING),
+            None,
+            String::from_str(&env, "maintenance"),
+        )
+        .unwrap();
+
+        let res = AutoTradeContract::execute_trade(
+            env.clone(),
+            user.clone(),
+            signal_id,
+            OrderType::Market,
+            500_0000000,
+        );
+        assert_eq!(res, Err(AutoTradeError::TradingPaused));
+
+        // A blocked trade must not be counted as an attempt.
+        let metrics = AutoTradeContract::get_trade_metrics(env.clone());
+        assert_eq!(metrics.total_attempts, 0);
+
+        let expected_topics = (Symbol::new(&env, "log_entry"),).into_val(&env);
+        let events = env.events().all();
+        assert!(events.iter().any(|event| {
+            event.1 == expected_topics
+                && logging::LogEntry::try_from_val(&env, &event.2)
+                    .map(|entry| {
+                        entry.level == logging::LogLevel::Warn
+                            && entry.message == String::from_str(&env, "execute_trade_blocked")
+                    })
+                    .unwrap_or(false)
+        }));
+    });
+}
+
+#[test]
+fn test_simulation_failure_emits_simulation_log() {
+    let env = setup_env();
+    let contract_id = env.register(AutoTradeContract, ());
+    let user = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        // No signal stored for id 999 → simulation must fail with "signal_not_found".
+        let sim = AutoTradeContract::simulate_copy_trade(env.clone(), user.clone(), 999, 100, 100);
+        assert!(!sim.would_succeed);
+
+        let expected_topics = (Symbol::new(&env, "log_entry"),).into_val(&env);
+        let events = env.events().all();
+        assert!(events.iter().any(|event| {
+            event.1 == expected_topics
+                && logging::LogEntry::try_from_val(&env, &event.2)
+                    .map(|entry| {
+                        entry.level == logging::LogLevel::Warn
+                            && entry.category == String::from_str(&env, "simulation")
+                            && entry.message == String::from_str(&env, "signal_not_found")
+                    })
+                    .unwrap_or(false)
+        }));
+    });
+}
 
 // ========================================
 // DCA Strategy Tests
 // ========================================
-
+//
+// QUARANTINED: the dca_tests / exit_strategy_tests / insurance_tests modules
+// below (through end of file) are corrupted by historical bad merges across
+// several independent PRs — test bodies from unrelated modules (DCA,
+// exit-strategy, insurance, stat-arb) are interleaved with each other and
+// contain dangling/unclosed braces (e.g. an unclosed `use soroban_sdk::{...}`
+// at the top of dca_tests followed directly by an unrelated stat-arb test).
+// Untangling this requires reconstructing intent across multiple authors'
+// commits and was judged too risky to guess at; left disabled so the crate
+// compiles and the rest of the suite runs. See git blame on this region for
+// the original (still-broken) commits if someone wants to repair it properly.
+/*
 #[cfg(test)]
 mod dca_tests {
     use crate::strategies::dca::*;
@@ -2255,5 +2404,4 @@ feat/smart-order-routing-84
         });
     }
 }
-
- main
+*/

--- a/stellar-swipe/contracts/auto_trade/src/test_admin_transfer.rs
+++ b/stellar-swipe/contracts/auto_trade/src/test_admin_transfer.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+extern crate std;
+
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -180,11 +182,11 @@ fn test_reinitialize_blocked() {
     client.initialize(&admin);
 
     // Second initialize must panic (already initialized guard)
-    let result = std::panic::catch_unwind(|| {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let env2 = env.clone();
         let client2 = AutoTradeContractClient::new(&env2, &contract_id);
         client2.initialize(&attacker);
-    });
+    }));
     assert!(result.is_err(), "Re-initialization must be blocked");
 }
 

--- a/stellar-swipe/contracts/auto_trade/src/twap.rs
+++ b/stellar-swipe/contracts/auto_trade/src/twap.rs
@@ -181,13 +181,6 @@ fn volatility_from_history(env: &Env, history: &Vec<i128>) -> u32 {
     }
 }
 
-fn get_baseline_volatility(env: &Env, pair: &AssetPair) -> Result<u32, AutoTradeError> {
-    let window = 30u32;
-    let history = get_price_history(env, pair, window);
-    let vol = volatility_from_history(env, &history);
-    Ok(vol.max(1000))
-}
-
 fn get_twap_price_window(env: &Env, pair: &AssetPair, window_minutes: u32) -> Vec<i128> {
     get_price_history(env, pair, window_minutes)
 }
@@ -327,7 +320,7 @@ fn execute_twap_segment(env: &Env, twap: &mut TWAPOrder) -> Result<u64, AutoTrad
 fn get_market_price(env: &Env, pair: &AssetPair) -> Result<i128, AutoTradeError> {
     let history = get_price_history(env, pair, 4);
     if let Some(last_price) = history.get(history.len().saturating_sub(1)) {
-        return Ok(*last_price);
+        return Ok(last_price);
     }
 
     let average = average_price(&history);
@@ -409,20 +402,6 @@ pub fn cancel_twap_order(env: &Env, order_id: u64, user: Address) -> Result<Canc
     );
 
     Ok(summary)
-}
-
-// Dummy functions representing market interactions
-fn get_market_price(_env: &Env, _pair: &AssetPair) -> Result<i128, AutoTradeError> {
-    // In production, this would query a decentralized oracle or DEX liquidity pool
-    Ok(100_000)
-}
-
-fn calculate_volatility(_env: &Env, _pair: &AssetPair, _period: u32) -> Result<u32, AutoTradeError> {
-    Ok(1500)
-}
-
-fn get_baseline_volatility(_env: &Env, _pair: &AssetPair) -> Result<u32, AutoTradeError> {
-    Ok(1000)
 }
 
 #[cfg(test)]

--- a/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
@@ -1,2 +1,4 @@
 pub mod test_batch_execute;
 pub mod test_dca;
+pub mod test_market_simulation;
+pub mod test_oracle_staleness;

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_market_simulation.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_market_simulation.rs
@@ -1,0 +1,320 @@
+#![cfg(test)]
+//! Market simulation and stress tests for TradeExecutor (issue #638).
+//!
+//! Unlike `test.rs`'s `MockSdexRouter` (a fixed `amount_out`), `MockPriceRouter`
+//! here models a price ratio in bps relative to 1:1, so a sequence of
+//! `set_price_bps` calls can simulate a market price path (trending, mild
+//! moves, flash crashes) across repeated swaps. Covers:
+//! - A configurable market simulation environment.
+//! - A property-style sweep over (amount, slippage_bps, market move) asserting
+//!   the slippage/price-impact invariants hold across a wide input space —
+//!   standing in for property-based testing without an external proptest
+//!   dependency.
+//! - A high-frequency stress run of sequential trades against the daily
+//!   volume risk gate.
+
+use crate::{
+    errors::ContractError, risk_gates::DEFAULT_ESTIMATED_COPY_TRADE_FEE, sdex, OrderType,
+    TradeExecutorContract, TradeExecutorContractClient,
+};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::Address as _,
+    token::{self, StellarAssetClient},
+    Address, Env, MuxedAddress,
+};
+
+// ── Mock price-feed router ───────────────────────────────────────────────────
+
+#[contract]
+pub struct MockPriceRouter;
+
+#[contracttype]
+#[derive(Clone)]
+enum RouterKey {
+    PriceBps,
+}
+
+#[contractimpl]
+impl MockPriceRouter {
+    /// Reports unlimited liquidity at price 0 so `check_liquidity`'s guard
+    /// never blocks these tests — only the slippage path is under test.
+    pub fn get_best_ask(_env: Env, _from_token: Address, _to_token: Address) -> (i128, i128) {
+        (0, i128::MAX / 2)
+    }
+
+    pub fn set_price_bps(env: Env, bps: i128) {
+        env.storage().instance().set(&RouterKey::PriceBps, &bps);
+    }
+
+    pub fn swap(
+        env: Env,
+        pull_from: Address,
+        from_token: Address,
+        to_token: Address,
+        amount_in: i128,
+        _min_out: i128,
+        recipient: Address,
+    ) -> i128 {
+        let router = env.current_contract_address();
+        let from_c = token::Client::new(&env, &from_token);
+        from_c.transfer_from(&router, &pull_from, &router, &amount_in);
+
+        let price_bps: i128 = env
+            .storage()
+            .instance()
+            .get(&RouterKey::PriceBps)
+            .unwrap_or(10_000);
+        let amount_out = amount_in * price_bps / 10_000;
+
+        let to_c = token::Client::new(&env, &to_token);
+        let to_mux: MuxedAddress = recipient.into();
+        to_c.transfer(&router, &to_mux, &amount_out);
+
+        amount_out
+    }
+}
+
+fn sac(env: &Env) -> Address {
+    let issuer = Address::generate(env);
+    env.register_stellar_asset_contract_v2(issuer).address()
+}
+
+/// Sets up executor + price router with deep liquidity on both sides.
+fn setup() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_a = sac(&env);
+    let token_b = sac(&env);
+
+    let router_id = env.register(MockPriceRouter, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.initialize(&admin);
+    exec.set_sdex_router(&router_id);
+
+    StellarAssetClient::new(&env, &token_a).mint(&exec_id, &1_000_000_000_000);
+    StellarAssetClient::new(&env, &token_b).mint(&router_id, &1_000_000_000_000);
+
+    (env, exec_id, router_id, token_a, token_b)
+}
+
+fn set_price(env: &Env, router_id: &Address, bps: i128) {
+    MockPriceRouterClient::new(env, router_id).set_price_bps(&bps);
+}
+
+/// Minimal deterministic xorshift PRNG so simulation paths are reproducible
+/// without pulling in a `rand`/`proptest` dependency.
+fn next_rand(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+// ── Market simulation: trending / crashing price paths ───────────────────────
+
+/// A steadily improving price never trips slippage protection, across many
+/// sequential swaps along the path.
+#[test]
+fn market_sim_trending_up_path_never_trips_slippage() {
+    let (env, exec_id, router_id, token_a, token_b) = setup();
+    let amount = 1_000_000i128;
+    let max_slippage_bps = 100; // 1%
+
+    let mut price_bps = 10_000i128;
+    for step in 0..20 {
+        set_price(&env, &router_id, price_bps);
+        let out = env.as_contract(&exec_id, || {
+            TradeExecutorContract::swap_with_slippage(
+                env.clone(),
+                token_a.clone(),
+                token_b.clone(),
+                amount,
+                max_slippage_bps,
+            )
+        });
+        assert!(out.is_ok(), "uptrend step {step} should never exceed slippage tolerance");
+        price_bps += 25; // price improves 0.25% each step
+    }
+}
+
+/// A slow downtrend that stays within the configured slippage tolerance
+/// succeeds at every step along the path.
+#[test]
+fn market_sim_mild_downtrend_within_tolerance_succeeds() {
+    let (env, exec_id, router_id, token_a, token_b) = setup();
+    let amount = 1_000_000i128;
+    let max_slippage_bps = 500; // 5% tolerance
+
+    let mut price_bps = 10_000i128;
+    for step in 0..10 {
+        price_bps -= 20; // -0.2% per step, well within the 5% tolerance
+        set_price(&env, &router_id, price_bps);
+        let out = env.as_contract(&exec_id, || {
+            TradeExecutorContract::swap_with_slippage(
+                env.clone(),
+                token_a.clone(),
+                token_b.clone(),
+                amount,
+                max_slippage_bps,
+            )
+        });
+        assert!(out.is_ok(), "downtrend step {step} is within tolerance and must succeed");
+    }
+}
+
+/// A sudden flash-crash that breaches the slippage tolerance is rejected —
+/// the trade must not execute at a price worse than the configured bound,
+/// even though an earlier swap at the same tolerance succeeded.
+#[test]
+fn market_sim_flash_crash_exceeds_slippage_and_reverts() {
+    let (env, exec_id, router_id, token_a, token_b) = setup();
+    let amount = 1_000_000i128;
+    let max_slippage_bps = 100; // 1% tolerance
+
+    set_price(&env, &router_id, 10_000);
+    let warmup = env.as_contract(&exec_id, || {
+        TradeExecutorContract::swap_with_slippage(
+            env.clone(),
+            token_a.clone(),
+            token_b.clone(),
+            amount,
+            max_slippage_bps,
+        )
+    });
+    assert!(warmup.is_ok());
+
+    // Flash crash: price collapses 40% in a single step.
+    set_price(&env, &router_id, 6_000);
+    let result = env.as_contract(&exec_id, || {
+        TradeExecutorContract::swap_with_slippage(
+            env.clone(),
+            token_a.clone(),
+            token_b.clone(),
+            amount,
+            max_slippage_bps,
+        )
+    });
+    assert_eq!(result, Err(ContractError::SlippageExceeded));
+}
+
+// ── Property-style sweep: slippage / price-impact invariants ────────────────
+
+/// Sweeps a deterministic pseudo-random grid of (amount, slippage_bps,
+/// market move) combinations and asserts invariants that must hold for
+/// *any* input:
+/// - `min_received_from_slippage` never exceeds the requested amount and is
+///   never negative.
+/// - `swap_with_slippage` succeeds iff the simulated market output is at
+///   least the computed minimum, and returns exactly that market output.
+#[test]
+fn slippage_property_sweep_across_amounts_and_market_moves() {
+    let (env, exec_id, router_id, token_a, token_b) = setup();
+    let mut seed: u64 = 0x1234_5678_9abc_def0;
+
+    for _ in 0..200 {
+        let amount = 1_000 + (next_rand(&mut seed) % 10_000_000) as i128;
+        let max_slippage_bps = (next_rand(&mut seed) % 2_000) as u32; // 0–20%
+        // Market move centered on 0, roughly -30%..+30%.
+        let move_bps = (next_rand(&mut seed) % 6_000) as i128 - 3_000;
+        let price_bps = 10_000 + move_bps;
+
+        let min_received = sdex::min_received_from_slippage(amount, max_slippage_bps).unwrap();
+        assert!(min_received <= amount, "min_received must never exceed the requested amount");
+        assert!(min_received >= 0, "min_received must never be negative");
+
+        set_price(&env, &router_id, price_bps);
+        let market_output = amount * price_bps / 10_000;
+
+        let result = env.as_contract(&exec_id, || {
+            TradeExecutorContract::swap_with_slippage(
+                env.clone(),
+                token_a.clone(),
+                token_b.clone(),
+                amount,
+                max_slippage_bps,
+            )
+        });
+
+        if market_output >= min_received {
+            assert_eq!(
+                result,
+                Ok(market_output),
+                "amount={amount} bps={max_slippage_bps} move={move_bps}: should succeed at the market output"
+            );
+        } else {
+            assert_eq!(
+                result,
+                Err(ContractError::SlippageExceeded),
+                "amount={amount} bps={max_slippage_bps} move={move_bps}: should be rejected"
+            );
+        }
+    }
+}
+
+// ── Stress test: high-frequency sequential trades ───────────────────────────
+
+#[contract]
+pub struct UnlimitedPortfolio;
+
+#[contractimpl]
+impl UnlimitedPortfolio {
+    pub fn validate_and_record(_env: Env, _user: Address, _max_positions: u32) -> u32 {
+        0
+    }
+}
+
+/// Fires a high-frequency burst of sequential market-order copy trades for a
+/// single user and asserts the daily-volume risk gate holds exactly at its
+/// boundary under rapid repeated invocation, not just a single isolated call.
+#[test]
+fn stress_high_frequency_trades_respect_daily_volume_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token = sac(&env);
+    let portfolio_id = env.register(UnlimitedPortfolio, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    let per_trade = 1_000_000i128;
+    let trade_count = 50i128;
+    StellarAssetClient::new(&env, &token).mint(
+        &user,
+        &(per_trade * trade_count + trade_count * DEFAULT_ESTIMATED_COPY_TRADE_FEE),
+    );
+
+    exec.initialize(&admin);
+    exec.set_user_portfolio(&portfolio_id);
+    exec.set_daily_volume_limit(&(per_trade * trade_count));
+
+    for i in 0..trade_count {
+        let result = exec.try_execute_copy_trade(
+            &user,
+            &token,
+            &per_trade,
+            &None::<u32>,
+            &OrderType::Market,
+            &None,
+        );
+        assert!(result.is_ok(), "trade {i} within the daily volume budget should succeed");
+    }
+
+    // The next trade would push cumulative volume past the limit.
+    let result = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &per_trade,
+        &None::<u32>,
+        &OrderType::Market,
+        &None,
+    );
+    assert_eq!(result, Err(Ok(ContractError::DailyVolumeLimitExceeded)));
+}


### PR DESCRIPTION
## Summary

**#636 — auto_trade logging & monitoring**
- The `auto_trade` contract did not compile on `main` at all. Found and fixed several pre-existing, unrelated build-breaking issues: `admin.rs` had two incompatible interleaved versions of the module (conflicting `AdminStorageKey` enums, truncated functions), `storage.rs` defined `authorize_user` three times while missing functions `admin.rs` actually called, `errors.rs`'s `AutoTradeError` enum had duplicate variant names with colliding discriminants (which made the `#[contracterror]` macro panic), plus smaller issues in `lib.rs`, `twap.rs`, `kyc.rs`, `oracle.rs`, and a few test files. Full details in the first commit message.
- ~1000 lines of pre-existing tests (`dca_tests`/`exit_strategy_tests`/`insurance_tests`) were corrupted by historical bad merges across multiple PRs (interleaved test bodies from unrelated features, dangling unclosed imports). Reconstructing the original intent safely wasn't possible, so they're quarantined behind a block comment with an explanation for whoever wants to untangle them properly.
- On top of the now-working build: added `TradeMetrics` (attempts/filled/partially-filled/failed counters), structured log entries at trade start/block/outcome and on simulation failures, and `get_trade_metrics`/`get_recent_logs` query endpoints. 4 new tests.
- `auto_trade` test suite: 0 → 182 passing (59 pre-existing, unrelated test failures remain — auth-frame/SDK-version mismatches and missing `as_contract` wrappers predating this PR; documented but out of scope here).

**#638 — trade_executor test coverage & simulation**
- `trade_executor` already compiled and had a healthy test suite (82 passing). Found `test_oracle_staleness.rs` (4 real tests) was written but never wired into `tests/mod.rs`, so it had never run — fixed.
- Added `test_market_simulation.rs`: a configurable mock price-feed router exercising `swap_with_slippage` across trending/downtrend/flash-crash price paths, a 200-iteration property-style sweep over slippage/price-impact invariants, and a high-frequency stress test (50 sequential trades) against the daily-volume risk gate.
- `trade_executor` test suite: 82 → 91 passing.

## Test plan
- [x] `cargo check -p auto_trade -p trade_executor` — both compile cleanly
- [x] `cargo test -p auto_trade --lib` — 182 passed (59 pre-existing failures, unrelated to this change, documented in commit message)
- [x] `cargo test -p trade_executor --lib` — 91 passed, 0 failed

Closes #636
Closes #638

