### PR TITLE
feat: severity-tiered slashing, dynamic bridge limit, export checksum, scaffold generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to StellarSwipe-Contract
+
+## Scaffold a new contract crate
+
+Use the scaffold generator to create a new contract crate already wired with the
+shared **Pausable**, **Initializable**, and **StorageTrait** conventions:
+
+```bash
+# From the repository root
+./stellar-swipe/scripts/scaffold_contract.sh <contract_name>
+```
+
+### Example
+
+```bash
+./stellar-swipe/scripts/scaffold_contract.sh reward_distributor
+```
+
+This creates:
+
+```
+stellar-swipe/contracts/reward_distributor/
+├── Cargo.toml          # depends on soroban-sdk + stellar-swipe-common
+└── src/
+    ├── lib.rs          # initialize / pause / unpause / storage_write / storage_read
+    └── tests.rs        # starter tests covering init, pause, storage round-trip
+```
+
+The workspace `Cargo.toml` is updated automatically to include the new crate.
+
+### Verify the scaffold
+
+```bash
+cd stellar-swipe
+cargo test   -p stellar-swipe-reward-distributor
+cargo clippy -p stellar-swipe-reward-distributor -- -D warnings
+```
+
+Both should pass with no manual fixes required.
+
+### What the scaffold includes
+
+| Feature | Implementation |
+|---|---|
+| Initializable guard | `initialize()` panics/returns error on double-init |
+| Pausable | `pause()` / `unpause()` / `is_paused()` with events |
+| StorageTrait pattern | `storage_write(key, value)` / `storage_read(key)` blocked while paused |
+| Starter test file | `tests.rs` with 5 tests covering all three features |
+
+Extend `DataKey` and `{ContractName}Error` with your contract-specific variants
+before adding business logic.

--- a/stellar-swipe/contracts/analytics/src/lib.rs
+++ b/stellar-swipe/contracts/analytics/src/lib.rs
@@ -74,9 +74,41 @@ enum DataKey {
     LastReportTime,
     CurrentSnapshot,
     PreviousSnapshot,
+    /// Maps export_id (u64) -> checksum (u64) for compliance export integrity.
+    ExportChecksum(u64),
+    /// Monotonic counter for export IDs.
+    ExportCounter,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
+
+/// Compute a deterministic checksum over a `ProtocolSnapshot`.
+/// Uses FNV-1a 64-bit hash mixing each field in order.
+fn compute_snapshot_checksum(s: &ProtocolSnapshot) -> u64 {
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+
+    let mut h = FNV_OFFSET;
+    macro_rules! mix {
+        ($v:expr) => {{
+            let bytes = ($v as u64).to_le_bytes();
+            for b in bytes {
+                h ^= b as u64;
+                h = h.wrapping_mul(FNV_PRIME);
+            }
+        }};
+    }
+    mix!(s.total_signals);
+    mix!(s.active_signals);
+    mix!(s.total_providers);
+    mix!(s.total_executions);
+    // i128 volume — split into two u64 halves
+    mix!(s.total_volume as u64);
+    mix!((s.total_volume >> 64) as u64);
+    mix!(s.avg_success_rate_bps as u64);
+    mix!(s.timestamp);
+    h
+}
 
 #[contract]
 pub struct AnalyticsContract;
@@ -206,6 +238,59 @@ impl AnalyticsContract {
             .instance()
             .get(&DataKey::LastReportTime)
             .unwrap_or(0)
+    }
+
+    // ── #614 Compliance export with checksum ──────────────────────────────────
+
+    /// Export the current snapshot for compliance, computing and anchoring a
+    /// checksum over the payload.  Returns `(export_id, checksum)`.
+    pub fn export_compliance_report(env: Env) -> (u64, u64) {
+        let snapshot: ProtocolSnapshot = env
+            .storage()
+            .instance()
+            .get(&DataKey::CurrentSnapshot)
+            .unwrap_or(ProtocolSnapshot {
+                total_signals: 0,
+                active_signals: 0,
+                total_providers: 0,
+                total_executions: 0,
+                total_volume: 0,
+                avg_success_rate_bps: 0,
+                timestamp: 0,
+            });
+
+        let checksum = compute_snapshot_checksum(&snapshot);
+
+        let export_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ExportCounter)
+            .unwrap_or(0)
+            + 1;
+        env.storage().instance().set(&DataKey::ExportCounter, &export_id);
+        env.storage().instance().set(&DataKey::ExportChecksum(export_id), &checksum);
+
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "analytics"), Symbol::new(&env, "compliance_export")),
+            (export_id, checksum, snapshot.clone()),
+        );
+
+        (export_id, checksum)
+    }
+
+    /// Verify that `snapshot` matches the on-chain checksum recorded for `export_id`.
+    /// Returns `true` if integrity holds, `false` if the payload was altered.
+    pub fn verify_export_checksum(env: Env, export_id: u64, snapshot: ProtocolSnapshot) -> bool {
+        let recorded: u64 = match env
+            .storage()
+            .instance()
+            .get(&DataKey::ExportChecksum(export_id))
+        {
+            Some(v) => v,
+            None => return false,
+        };
+        compute_snapshot_checksum(&snapshot) == recorded
     }
 }
 
@@ -402,5 +487,71 @@ mod tests {
         client.initialize(&admin);
         let result = client.try_initialize(&admin);
         assert!(result.is_err(), "double initialize must fail");
+    }
+
+    // ── #614 Export checksum tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_export_checksum_roundtrip_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let id = env.register(AnalyticsContract, ());
+        let client = AnalyticsContractClient::new(&env, &id);
+
+        client.initialize(&admin);
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+        client.update_snapshot(&week1_snapshot(1_000_000));
+
+        let (export_id, _checksum) = client.export_compliance_report();
+        assert!(client.verify_export_checksum(&export_id, &week1_snapshot(1_000_000)));
+    }
+
+    #[test]
+    fn test_tampered_export_fails_verification() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let id = env.register(AnalyticsContract, ());
+        let client = AnalyticsContractClient::new(&env, &id);
+
+        client.initialize(&admin);
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+        client.update_snapshot(&week1_snapshot(1_000_000));
+
+        let (export_id, _checksum) = client.export_compliance_report();
+
+        // Tamper: use week2 snapshot instead of week1
+        let tampered = week2_snapshot(1_000_000);
+        assert!(!client.verify_export_checksum(&export_id, &tampered));
+    }
+
+    #[test]
+    fn test_export_event_emitted_with_checksum() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let id = env.register(AnalyticsContract, ());
+        let client = AnalyticsContractClient::new(&env, &id);
+
+        client.initialize(&admin);
+        env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+        client.update_snapshot(&week1_snapshot(1_000_000));
+        client.export_compliance_report();
+
+        // One export event should have been emitted
+        assert_eq!(env.events().all().len(), 1);
+    }
+
+    #[test]
+    fn test_unknown_export_id_returns_false() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let id = env.register(AnalyticsContract, ());
+        let client = AnalyticsContractClient::new(&env, &id);
+
+        client.initialize(&admin);
+        assert!(!client.verify_export_checksum(&999, &week1_snapshot(0)));
     }
 }

--- a/stellar-swipe/contracts/bridge/src/lib.rs
+++ b/stellar-swipe/contracts/bridge/src/lib.rs
@@ -27,6 +27,9 @@ pub enum BridgeError {
     InsufficientWrappedBalance = 12,
     WithdrawalNotReady = 13,
     InvalidOperation = 14,
+    /// Withdrawal exceeds the dynamic limit derived from available liquidity buffer.
+    /// Distinct from DailyLimitExceeded (static anti-spam) so callers can differentiate.
+    DynamicLiquidityLimitExceeded = 15,
 }
 
 #[contracttype]
@@ -117,6 +120,8 @@ pub enum DataKey {
     UsedSignature(Address, u64, ValidatorApprovalKind, String),
     WrappedBalance(Address, String),
     DailyVolume,
+    /// Admin-set available liquidity buffer for dynamic rate limiting.
+    LiquidityBuffer,
 }
 
 const DAY_SECONDS: u64 = 86_400;
@@ -602,6 +607,31 @@ impl BridgeContract {
     pub fn health_check(env: Env) -> stellar_swipe_common::HealthStatus {
         crate::governance::bridge_health_check(&env)
     }
+
+    // ── #613 Dynamic liquidity rate-limit ──────────────────────────────────────
+
+    /// Admin: record the current available liquidity buffer.
+    /// This is used to compute the dynamic per-transfer withdrawal cap.
+    pub fn update_liquidity_buffer(env: Env, admin: Address, buffer: i128) -> Result<(), BridgeError> {
+        require_admin(&env, &admin)?;
+        if !cfg!(test) {
+            admin.require_auth();
+        }
+        if buffer < 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        env.storage().persistent().set(&DataKey::LiquidityBuffer, &buffer);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "bridge"), Symbol::new(&env, "liquidity_buffer_updated")),
+            buffer,
+        );
+        Ok(())
+    }
+
+    pub fn get_liquidity_buffer(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::LiquidityBuffer).unwrap_or(i128::MAX)
+    }
 }
 
 fn get_config(env: &Env) -> Result<BridgeConfig, BridgeError> {
@@ -671,6 +701,21 @@ fn validate_amount_and_limits(env: &Env, amount: i128) -> Result<(), BridgeError
 
     if volume.total_amount + amount > config.security.daily_transfer_limit {
         return Err(BridgeError::DailyLimitExceeded);
+    }
+
+    // ── Dynamic liquidity-buffer cap (independent of static limits) ───────────
+    // Allowed single transfer = 10% of current buffer (minimum 1 if buffer > 0).
+    // When buffer is unset (MAX) there is no dynamic restriction.
+    let buffer: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LiquidityBuffer)
+        .unwrap_or(i128::MAX);
+    if buffer != i128::MAX {
+        let dynamic_limit = core::cmp::max(buffer / 10, 1);
+        if amount > dynamic_limit {
+            return Err(BridgeError::DynamicLiquidityLimitExceeded);
+        }
     }
 
     volume.total_amount += amount;
@@ -960,6 +1005,77 @@ mod test {
                 String::from_str(&env, "stellar:user"),
             );
             assert_eq!(daily, Err(BridgeError::DailyLimitExceeded));
+        });
+    }
+
+    // ── #613 Dynamic liquidity rate-limit tests ────────────────────────────────
+
+    #[test]
+    fn healthy_liquidity_allows_transfers_up_to_10pct() {
+        let (env, contract_id, admin, validators) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            init(&env, &admin, &validators);
+            // Buffer = 5000; dynamic limit = 500
+            BridgeContract::update_liquidity_buffer(env.clone(), admin.clone(), 5_000).unwrap();
+
+            // 500 is exactly 10% — should pass
+            BridgeContract::initiate_lock_mint(
+                env.clone(), user.clone(),
+                ChainId::Ethereum, ChainId::Polygon,
+                String::from_str(&env, "ETH"), String::from_str(&env, "wETH"),
+                500,
+                String::from_str(&env, "0xa"), 1,
+                String::from_str(&env, "r"),
+            ).unwrap();
+        });
+    }
+
+    #[test]
+    fn low_liquidity_rejects_with_dynamic_limit_error() {
+        let (env, contract_id, admin, validators) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            init(&env, &admin, &validators);
+            // Buffer = 100; dynamic limit = 10
+            BridgeContract::update_liquidity_buffer(env.clone(), admin.clone(), 100).unwrap();
+
+            let result = BridgeContract::initiate_lock_mint(
+                env.clone(), user.clone(),
+                ChainId::Ethereum, ChainId::Polygon,
+                String::from_str(&env, "ETH"), String::from_str(&env, "wETH"),
+                50,
+                String::from_str(&env, "0xb"), 2,
+                String::from_str(&env, "r"),
+            );
+            assert_eq!(result, Err(BridgeError::DynamicLiquidityLimitExceeded));
+        });
+    }
+
+    #[test]
+    fn dynamic_limit_error_is_distinct_from_daily_limit_error() {
+        // Confirms the error variant is DynamicLiquidityLimitExceeded, not DailyLimitExceeded
+        assert_ne!(
+            BridgeError::DynamicLiquidityLimitExceeded,
+            BridgeError::DailyLimitExceeded,
+        );
+    }
+
+    #[test]
+    fn no_buffer_set_means_no_dynamic_restriction() {
+        let (env, contract_id, admin, validators) = setup();
+        let user = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            init(&env, &admin, &validators);
+            // No buffer update — dynamic limit is effectively infinite
+            BridgeContract::initiate_lock_mint(
+                env.clone(), user,
+                ChainId::Ethereum, ChainId::Polygon,
+                String::from_str(&env, "ETH"), String::from_str(&env, "wETH"),
+                999,
+                String::from_str(&env, "0xc"), 3,
+                String::from_str(&env, "r"),
+            ).unwrap();
         });
     }
 }

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -7,6 +7,44 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol,
 };
 
+// ── Slash severity tiers ──────────────────────────────────────────────────────
+
+/// Severity tier for a slashing event.
+/// Controls what fraction of stake is burned.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SlashSeverity {
+    Minor = 0,
+    Major = 1,
+    Critical = 2,
+}
+
+/// On-chain configuration for how much stake each tier slashes.
+/// Values are in basis points (10_000 = 100 %).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SlashTierConfig {
+    /// Basis points slashed for a Minor violation.
+    pub minor_bps: u32,
+    /// Basis points slashed for a Major violation.
+    pub major_bps: u32,
+    /// Basis points slashed for a Critical violation (typically 10_000 = full stake).
+    pub critical_bps: u32,
+}
+
+impl SlashTierConfig {
+    pub const fn default_config() -> Self {
+        Self {
+            minor_bps: 500,    // 5 %
+            major_bps: 3_000,  // 30 %
+            critical_bps: 10_000, // 100 %
+        }
+    }
+}
+
+const BPS_DENOMINATOR: i128 = 10_000;
+
 /// Temporary-storage key for the reentrancy lock on `withdraw_stake`.
 const EXECUTION_LOCK: &str = "WithdrawLock";
 
@@ -78,6 +116,8 @@ pub enum StorageKey {
     /// Ledger sequence at which a stake was last deposited (per staker).
     /// Used to detect same-ledger stake+unstake flash loan patterns.
     LastStakeLedger(Address),
+    /// Admin-configurable slashing tier percentages.
+    SlashTierConfig,
 }
 
 #[contracterror]
@@ -99,6 +139,8 @@ pub enum StakeVaultError {
     TimelockNotElapsed = 9,
     /// Stake and unstake in the same ledger — flash loan pattern detected.
     FlashLoanDetected = 10,
+    /// Slash tier percentage would exceed 100% of stake.
+    InvalidSlashTier = 11,
 }
 
 #[contract]
@@ -494,13 +536,54 @@ impl StakeVaultContract {
 
     // ── Slash ──────────────────────────────────────────────────────────────────
 
+    /// Admin: configure the slash percentage for each severity tier (in basis points).
+    /// `minor_bps`, `major_bps`, `critical_bps` must all be <= 10_000.
+    pub fn configure_slash_tiers(
+        env: Env,
+        minor_bps: u32,
+        major_bps: u32,
+        critical_bps: u32,
+    ) -> Result<(), StakeVaultError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(StakeVaultError::NotInitialized)?;
+        admin.require_auth();
+        if minor_bps > 10_000 || major_bps > 10_000 || critical_bps > 10_000 {
+            return Err(StakeVaultError::InvalidSlashTier);
+        }
+        let cfg = SlashTierConfig { minor_bps, major_bps, critical_bps };
+        env.storage()
+            .instance()
+            .set(&StorageKey::SlashTierConfig, &cfg);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "stake_vault"), Symbol::new(&env, "slash_tiers_updated")),
+            (minor_bps, major_bps, critical_bps),
+        );
+        Ok(())
+    }
+
+    pub fn get_slash_tier_config(env: Env) -> SlashTierConfig {
+        env.storage()
+            .instance()
+            .get(&StorageKey::SlashTierConfig)
+            .unwrap_or_else(SlashTierConfig::default_config)
+    }
+
+    /// Slash `provider`'s stake according to `severity`.
+    ///
+    /// The slashed amount is computed from the configured tier percentages
+    /// (default: minor=5%, major=30%, critical=100%).  Only the signal registry
+    /// may call this.
     pub fn slash_stake(
         env: Env,
         caller: Address,
         provider: Address,
-        amount: i128,
+        severity: SlashSeverity,
         reason: Symbol,
-    ) -> Result<(), StakeVaultError> {
+    ) -> Result<i128, StakeVaultError> {
         caller.require_auth();
         let signal_registry: Address = env
             .storage()
@@ -517,6 +600,18 @@ impl StakeVaultContract {
             .get(&StorageKey::StakeToken)
             .ok_or(StakeVaultError::NotInitialized)?;
 
+        let cfg: SlashTierConfig = env
+            .storage()
+            .instance()
+            .get(&StorageKey::SlashTierConfig)
+            .unwrap_or_else(SlashTierConfig::default_config);
+
+        let tier_bps = match severity {
+            SlashSeverity::Minor    => cfg.minor_bps as i128,
+            SlashSeverity::Major    => cfg.major_bps as i128,
+            SlashSeverity::Critical => cfg.critical_bps as i128,
+        };
+
         let mut stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
             .storage()
             .persistent()
@@ -527,32 +622,34 @@ impl StakeVaultContract {
             .get(provider.clone())
             .ok_or(StakeVaultError::NoStake)?;
 
-        if amount <= 0 || amount > info.balance {
+        if info.balance == 0 {
             return Err(StakeVaultError::NoStake);
         }
 
-        info.balance = info
-            .balance
-            .checked_sub(amount)
-            .ok_or(StakeVaultError::NoStake)?;
+        // Compute slash amount from tier percentage; min 1 stroop.
+        let slash_amount = core::cmp::max(
+            (info.balance * tier_bps) / BPS_DENOMINATOR,
+            1,
+        );
+        let slash_amount = core::cmp::min(slash_amount, info.balance);
+
+        info.balance = info.balance.saturating_sub(slash_amount);
         info.last_updated = env.ledger().timestamp();
         stakes.set(provider.clone(), info);
         env.storage()
             .persistent()
             .set(&MigrationKey::StakesV2, &stakes);
 
+        // Event records severity tier and resulting slash amount for audit.
         #[allow(deprecated)]
         env.events().publish(
-            (
-                Symbol::new(&env, "stake_vault"),
-                Symbol::new(&env, "stake_slashed"),
-            ),
-            (provider.clone(), amount, reason),
+            (Symbol::new(&env, "stake_vault"), Symbol::new(&env, "stake_slashed")),
+            (provider.clone(), severity as u32, slash_amount, reason),
         );
 
-        token::Client::new(&env, &token).burn(&env.current_contract_address(), &amount);
+        token::Client::new(&env, &token).burn(&env.current_contract_address(), &slash_amount);
 
-        Ok(())
+        Ok(slash_amount)
     }
 
     // ── Read ───────────────────────────────────────────────────────────────────

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -737,3 +737,123 @@ fn timelock_request_consumed_after_withdrawal() {
         Err(Ok(StakeVaultError::TimelockRequired))
     );
 }
+
+// ── #612 Severity-tiered slashing tests ──────────────────────────────────────
+
+#[cfg(test)]
+mod slash_severity_tests {
+    use crate::{
+        migration::{MigrationKey, StakeInfoV2},
+        SlashSeverity, SlashTierConfig, StakeVaultContract, StakeVaultContractClient,
+        StakeVaultError,
+    };
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Map, Symbol};
+
+    fn sac_token(env: &Env, admin: &Address) -> Address {
+        env.register_stellar_asset_contract_v2(admin.clone()).address()
+    }
+
+    fn seed(env: &Env, contract_id: &Address, staker: &Address, balance: i128) {
+        env.as_contract(contract_id, || {
+            let mut stakes: Map<Address, StakeInfoV2> = env
+                .storage()
+                .persistent()
+                .get(&MigrationKey::StakesV2)
+                .unwrap_or_else(|| Map::new(env));
+            stakes.set(staker.clone(), StakeInfoV2 { balance, locked_until: 0, last_updated: 0 });
+            env.storage().persistent().set(&MigrationKey::StakesV2, &stakes);
+        });
+    }
+
+    fn setup() -> (Env, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let registry = Address::generate(&env);
+        let token = sac_token(&env, &admin);
+        let vault_id = env.register(StakeVaultContract, ());
+        StakeVaultContractClient::new(&env, &vault_id).initialize(&admin, &token, &registry);
+        (env, vault_id, token, admin, registry)
+    }
+
+    #[test]
+    fn minor_slash_burns_default_5_percent() {
+        let (env, vault_id, token, _admin, registry) = setup();
+        let provider = Address::generate(&env);
+        let balance: i128 = 1_000_000;
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &balance);
+        seed(&env, &vault_id, &provider, balance);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let slashed = client.slash_stake(&registry, &provider, &SlashSeverity::Minor, &Symbol::new(&env, "bad"));
+        assert_eq!(slashed, 50_000); // 5% of 1_000_000
+        assert_eq!(client.get_stake(&provider), 950_000);
+    }
+
+    #[test]
+    fn major_slash_burns_default_30_percent() {
+        let (env, vault_id, token, _admin, registry) = setup();
+        let provider = Address::generate(&env);
+        let balance: i128 = 1_000_000;
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &balance);
+        seed(&env, &vault_id, &provider, balance);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let slashed = client.slash_stake(&registry, &provider, &SlashSeverity::Major, &Symbol::new(&env, "fraud"));
+        assert_eq!(slashed, 300_000); // 30%
+        assert_eq!(client.get_stake(&provider), 700_000);
+    }
+
+    #[test]
+    fn critical_slash_burns_full_stake() {
+        let (env, vault_id, token, _admin, registry) = setup();
+        let provider = Address::generate(&env);
+        let balance: i128 = 1_000_000;
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &balance);
+        seed(&env, &vault_id, &provider, balance);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let slashed = client.slash_stake(&registry, &provider, &SlashSeverity::Critical, &Symbol::new(&env, "attack"));
+        assert_eq!(slashed, balance);
+        assert_eq!(client.get_stake(&provider), 0);
+    }
+
+    #[test]
+    fn admin_can_reconfigure_tiers() {
+        let (env, vault_id, token, _admin, registry) = setup();
+        let provider = Address::generate(&env);
+        let balance: i128 = 1_000_000;
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &balance);
+        seed(&env, &vault_id, &provider, balance);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        client.configure_slash_tiers(&100, &2_000, &10_000); // minor = 1%
+        let slashed = client.slash_stake(&registry, &provider, &SlashSeverity::Minor, &Symbol::new(&env, "test"));
+        assert_eq!(slashed, 10_000); // 1%
+    }
+
+    #[test]
+    fn invalid_tier_bps_rejected() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(
+            client.try_configure_slash_tiers(&500, &3_000, &10_001),
+            Err(Ok(StakeVaultError::InvalidSlashTier))
+        );
+    }
+
+    #[test]
+    fn unauthorized_caller_rejected() {
+        let (env, vault_id, token, _admin, _registry) = setup();
+        let provider = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &1_000);
+        seed(&env, &vault_id, &provider, 1_000);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(
+            client.try_slash_stake(&attacker, &provider, &SlashSeverity::Major, &Symbol::new(&env, "x")),
+            Err(Ok(StakeVaultError::Unauthorized))
+        );
+    }
+}

--- a/stellar-swipe/scripts/scaffold_contract.sh
+++ b/stellar-swipe/scripts/scaffold_contract.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# scaffold_contract.sh — Generate a new StellarSwipe contract crate pre-wired with
+# shared Pausable, Initializable, and storage-trait boilerplate.
+#
+# Usage:
+#   ./scripts/scaffold_contract.sh <contract_name>
+#
+# Example:
+#   ./scripts/scaffold_contract.sh my_new_contract
+#
+# The script creates contracts/<contract_name>/{Cargo.toml,src/lib.rs,src/tests.rs}
+# and adds the crate to the workspace Cargo.toml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONTRACTS_DIR="${WORKSPACE_DIR}/contracts"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <contract_name>" >&2
+  exit 1
+fi
+
+NAME="$1"
+# Validate: lowercase letters, digits, underscores only
+if ! [[ "$NAME" =~ ^[a-z][a-z0-9_]*$ ]]; then
+  echo "Error: contract name must be lowercase snake_case (got: $NAME)" >&2
+  exit 1
+fi
+
+CRATE_DIR="${CONTRACTS_DIR}/${NAME}"
+if [[ -d "$CRATE_DIR" ]]; then
+  echo "Error: directory already exists: $CRATE_DIR" >&2
+  exit 1
+fi
+
+# Pascal-case for type names: my_contract → MyContract
+PASCAL_NAME=$(echo "$NAME" | sed -E 's/(^|_)([a-z])/\u\2/g')
+
+mkdir -p "${CRATE_DIR}/src"
+
+# ── Cargo.toml ────────────────────────────────────────────────────────────────
+cat > "${CRATE_DIR}/Cargo.toml" << TOML
+[package]
+name = "stellar-swipe-${NAME//_/-}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+stellar-swipe-common = { path = "../common" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+TOML
+
+# ── src/lib.rs ────────────────────────────────────────────────────────────────
+cat > "${CRATE_DIR}/src/lib.rs" << RUST
+#![no_std]
+//! ${NAME} contract — scaffolded by scaffold_contract.sh.
+//! Pre-wired with Pausable, Initializable, and StorageTrait conventions.
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
+
+// ── Storage trait (CRUD boilerplate) ─────────────────────────────────────────
+
+pub trait StorageTrait<K, V> {
+    fn read(env: &Env, key: &K) -> Option<V>;
+    fn write(env: &Env, key: &K, value: &V);
+    fn remove(env: &Env, key: &K);
+}
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Initialized,
+    Paused,
+    // Add contract-specific keys here.
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ${PASCAL_NAME}Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    ContractPaused = 4,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct ${PASCAL_NAME}Contract;
+
+#[contractimpl]
+impl ${PASCAL_NAME}Contract {
+    // ── Initializable ─────────────────────────────────────────────────────────
+
+    /// One-time initialization guard.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ${PASCAL_NAME}Error> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(${PASCAL_NAME}Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "${NAME}"), Symbol::new(&env, "initialized")),
+            admin,
+        );
+        Ok(())
+    }
+
+    // ── Pausable ──────────────────────────────────────────────────────────────
+
+    pub fn pause(env: Env) -> Result<(), ${PASCAL_NAME}Error> {
+        let admin = Self::require_admin(&env)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &true);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "${NAME}"), Symbol::new(&env, "paused")),
+            (),
+        );
+        Ok(())
+    }
+
+    pub fn unpause(env: Env) -> Result<(), ${PASCAL_NAME}Error> {
+        let admin = Self::require_admin(&env)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &false);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "${NAME}"), Symbol::new(&env, "unpaused")),
+            (),
+        );
+        Ok(())
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    }
+
+    // ── StorageTrait example: generic persistent read/write ──────────────────
+
+    /// Write an arbitrary i128 value under a named key (demonstrates storage-trait pattern).
+    pub fn storage_write(env: Env, key: Symbol, value: i128) -> Result<(), ${PASCAL_NAME}Error> {
+        Self::require_not_paused(&env)?;
+        env.storage().persistent().set(&key, &value);
+        Ok(())
+    }
+
+    pub fn storage_read(env: Env, key: Symbol) -> Option<i128> {
+        env.storage().persistent().get(&key)
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    fn require_admin(env: &Env) -> Result<Address, ${PASCAL_NAME}Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(${PASCAL_NAME}Error::NotInitialized)
+    }
+
+    fn require_not_paused(env: &Env) -> Result<(), ${PASCAL_NAME}Error> {
+        if env.storage().instance().get::<_, bool>(&DataKey::Paused).unwrap_or(false) {
+            Err(${PASCAL_NAME}Error::ContractPaused)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;
+RUST
+
+# ── src/tests.rs ──────────────────────────────────────────────────────────────
+cat > "${CRATE_DIR}/src/tests.rs" << RUST
+#![cfg(test)]
+
+use crate::{${PASCAL_NAME}Contract, ${PASCAL_NAME}ContractClient, ${PASCAL_NAME}Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(${PASCAL_NAME}Contract, ());
+    (env, contract_id, admin)
+}
+
+#[test]
+fn initialize_sets_admin_and_emits_event() {
+    let (env, id, admin) = setup();
+    let client = ${PASCAL_NAME}ContractClient::new(&env, &id);
+    client.initialize(&admin);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn double_initialize_fails() {
+    let (env, id, admin) = setup();
+    let client = ${PASCAL_NAME}ContractClient::new(&env, &id);
+    client.initialize(&admin);
+    assert_eq!(
+        client.try_initialize(&admin),
+        Err(Ok(${PASCAL_NAME}Error::AlreadyInitialized))
+    );
+}
+
+#[test]
+fn pause_and_unpause() {
+    let (env, id, admin) = setup();
+    let client = ${PASCAL_NAME}ContractClient::new(&env, &id);
+    client.initialize(&admin);
+
+    client.pause();
+    assert!(client.is_paused());
+
+    client.unpause();
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn storage_write_read_roundtrip() {
+    let (env, id, admin) = setup();
+    let client = ${PASCAL_NAME}ContractClient::new(&env, &id);
+    client.initialize(&admin);
+
+    let key = Symbol::new(&env, "mykey");
+    client.storage_write(&key, &42);
+    assert_eq!(client.storage_read(&key), Some(42));
+}
+
+#[test]
+fn write_blocked_when_paused() {
+    let (env, id, admin) = setup();
+    let client = ${PASCAL_NAME}ContractClient::new(&env, &id);
+    client.initialize(&admin);
+    client.pause();
+
+    let key = Symbol::new(&env, "k");
+    assert_eq!(
+        client.try_storage_write(&key, &1),
+        Err(Ok(${PASCAL_NAME}Error::ContractPaused))
+    );
+}
+RUST
+
+# ── Wire into workspace Cargo.toml ────────────────────────────────────────────
+WORKSPACE_TOML="${WORKSPACE_DIR}/Cargo.toml"
+# Add "contracts/<name>" to the members list if not already present
+if grep -q "\"contracts/${NAME}\"" "$WORKSPACE_TOML"; then
+  echo "Note: workspace already contains contracts/${NAME}"
+else
+  sed -i "s|members = \[|members = [\n  \"contracts/${NAME}\",|" "$WORKSPACE_TOML"
+fi
+
+echo ""
+echo "✓ Scaffolded: ${CRATE_DIR}"
+echo "  • Cargo.toml  — depends on soroban-sdk + stellar-swipe-common"
+echo "  • src/lib.rs  — initialize/pause/unpause + storage_write/storage_read"
+echo "  • src/tests.rs — starter tests"
+echo ""
+echo "Workspace Cargo.toml updated with: contracts/${NAME}"
+echo ""
+echo "Next steps:"
+echo "  cd stellar-swipe && cargo test -p stellar-swipe-${NAME//_/-}"


### PR DESCRIPTION
## Summary

Implements all four issues from task1.md.

Closes #612
Closes #613
Closes #614
Closes #615

---

### #612 — Severity-tiered slashing curve (StakeVault)
- Added `SlashSeverity` enum (Minor / Major / Critical) and `SlashTierConfig` with default percentages (5% / 30% / 100%)
- `slash_stake` now requires an explicit severity tier and computes the burn amount from the configured percentages
- `configure_slash_tiers` admin function for governance-controlled updates
- Slash events record both `severity` and `slash_amount` for audit
- Tests cover all three tiers, reconfiguration, invalid bps, and unauthorized caller

### #613 — Dynamic bridge withdrawal rate-limit tied to liquidity buffer
- New `DynamicLiquidityLimitExceeded` error (distinct from the static `DailyLimitExceeded`)
- `update_liquidity_buffer` admin entrypoint; dynamic single-transfer cap = 10% of buffer
- Check is additive — existing static anti-spam limits continue to apply independently
- Tests cover healthy-liquidity (higher cap), low-liquidity (rejection), and no-buffer-set (no restriction)

### #614 — Compliance export checksum verification
- `export_compliance_report` computes an FNV-1a-64 checksum over the `ProtocolSnapshot` payload and anchors it on-chain
- Checksum is emitted in the `compliance_export` event alongside the payload
- `verify_export_checksum(export_id, snapshot)` recomputes and compares against the stored value
- Tests cover successful verification, tampered-payload failure, event emission, and unknown export ID

### #615 — Contract crate scaffold generator
- `stellar-swipe/scripts/scaffold_contract.sh <name>` generates a compilable crate pre-wired with Initializable, Pausable, and StorageTrait boilerplate
- Auto-updates workspace `Cargo.toml`
- Starter test file covers initialize, pause/unpause, and storage read/write
- Usage documented in `CONTRIBUTING.md`