### PR TITLE
feat(bridge): automatic circuit breaker for finality-latency anomalies (#572)

### DIFF
--- a/stellar-swipe/contracts/bridge/src/monitoring.rs
+++ b/stellar-swipe/contracts/bridge/src/monitoring.rs
@@ -103,7 +103,28 @@ pub enum MonitoringDataKey {
     ChainConfig(u32),                      // By chain discriminant
     PendingTransactions,                   // List of pending transfer IDs
     TransactionIndex(u64),                 // Meta index
+    /// Rolling window of recent finality latencies (seconds).
+    LatencyWindow,
+    /// Whether the automatic latency circuit breaker is tripped.
+    CircuitBreakerTripped,
+    /// Configurable latency threshold and window size for the circuit breaker.
+    LatencyCircuitBreakerConfig,
 }
+
+/// Configuration for the automatic finality-latency circuit breaker.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LatencyCircuitBreakerConfig {
+    /// Maximum acceptable average latency (seconds) over the rolling window.
+    pub latency_threshold_secs: u64,
+    /// Number of recent transactions used to compute the rolling average.
+    pub window_size: u32,
+}
+
+/// Default latency threshold: 2× the expected maximum confirmation time
+/// for Ethereum (32 blocks × 12 s/block = 384 s → threshold ≈ 800 s).
+const DEFAULT_LATENCY_THRESHOLD_SECS: u64 = 800;
+const DEFAULT_WINDOW_SIZE: u32 = 10;
 
 // Constants for finality configurations
 const ETHEREUM_FINALITY: u32 = 32;  // 32 blocks (~6.4 min)
@@ -323,12 +344,17 @@ pub fn update_transaction_confirmation_count(
     Ok(false)
 }
 
-/// Mark transaction as finalized
+/// Mark transaction as finalized and record confirmation latency for the circuit breaker.
 fn mark_as_finalized(env: &Env, monitored: &mut MonitoredTransaction) -> Result<(), String> {
+    let now = env.ledger().timestamp();
     monitored.status = MonitoringStatus::Finalized;
-    monitored.finalized_at = Some(env.ledger().timestamp());
+    monitored.finalized_at = Some(now);
 
     store_monitored_tx(env, monitored.transfer_id, monitored);
+
+    // Record latency and potentially trip the circuit breaker.
+    let latency_secs = now.saturating_sub(monitored.first_seen);
+    record_finality_latency(env, latency_secs);
 
     // Emit finalization event
     env.events().publish(
@@ -336,10 +362,107 @@ fn mark_as_finalized(env: &Env, monitored: &mut MonitoredTransaction) -> Result<
             Symbol::new(env, "transaction_finalized"),
             monitored.transfer_id,
         ),
-        monitored.confirmations,
+        (monitored.confirmations, latency_secs),
     );
 
     Ok(())
+}
+
+// ── Circuit Breaker ─────────────────────────────────────────────────────────
+
+/// Record the finality latency for one bridge transaction.
+///
+/// Maintains a rolling window of the last N latencies. If the window average
+/// exceeds the configured threshold, the circuit breaker is tripped automatically
+/// and new bridge transactions are blocked until `clear_circuit_breaker` is called.
+pub fn record_finality_latency(env: &Env, latency_secs: u64) {
+    let config = get_latency_circuit_breaker_config(env);
+
+    let mut window: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&MonitoringDataKey::LatencyWindow)
+        .unwrap_or(Vec::new(env));
+
+    window.push_back(latency_secs);
+
+    // Keep only the last `window_size` entries.
+    let max = config.window_size as u32;
+    while window.len() > max {
+        window.remove(0);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&MonitoringDataKey::LatencyWindow, &window);
+
+    if window.len() >= max {
+        let sum: u64 = (0..window.len()).fold(0u64, |acc, i| {
+            acc.saturating_add(window.get(i).unwrap_or(0))
+        });
+        let avg = sum / window.len() as u64;
+
+        if avg > config.latency_threshold_secs {
+            trip_circuit_breaker(env, avg, config.latency_threshold_secs);
+        }
+    }
+}
+
+/// Check whether the automatic latency circuit breaker is currently tripped.
+pub fn is_circuit_breaker_tripped(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get(&MonitoringDataKey::CircuitBreakerTripped)
+        .unwrap_or(false)
+}
+
+/// Clear the circuit breaker (recovery path).
+/// Should be called by an admin after the underlying latency issue is resolved.
+pub fn clear_circuit_breaker(env: &Env) {
+    env.storage()
+        .persistent()
+        .set(&MonitoringDataKey::CircuitBreakerTripped, &false);
+
+    // Also clear the latency window so recovery starts fresh.
+    env.storage()
+        .persistent()
+        .set(&MonitoringDataKey::LatencyWindow, &Vec::<u64>::new(env));
+
+    env.events().publish(
+        (Symbol::new(env, "circuit_breaker_cleared"),),
+        env.ledger().timestamp(),
+    );
+}
+
+/// Configure the circuit breaker thresholds.
+pub fn set_latency_circuit_breaker_config(env: &Env, config: &LatencyCircuitBreakerConfig) {
+    env.storage()
+        .persistent()
+        .set(&MonitoringDataKey::LatencyCircuitBreakerConfig, config);
+}
+
+/// Get the current circuit breaker configuration (falling back to defaults).
+pub fn get_latency_circuit_breaker_config(env: &Env) -> LatencyCircuitBreakerConfig {
+    env.storage()
+        .persistent()
+        .get(&MonitoringDataKey::LatencyCircuitBreakerConfig)
+        .unwrap_or(LatencyCircuitBreakerConfig {
+            latency_threshold_secs: DEFAULT_LATENCY_THRESHOLD_SECS,
+            window_size: DEFAULT_WINDOW_SIZE,
+        })
+}
+
+fn trip_circuit_breaker(env: &Env, avg_latency_secs: u64, threshold_secs: u64) {
+    env.storage()
+        .persistent()
+        .set(&MonitoringDataKey::CircuitBreakerTripped, &true);
+
+    // Emit a distinct event so monitoring systems can differentiate automatic
+    // trips from a manually triggered pause.
+    env.events().publish(
+        (Symbol::new(env, "circuit_breaker_auto_tripped"),),
+        (avg_latency_secs, threshold_secs, env.ledger().timestamp()),
+    );
 }
 
 /// ==========================
@@ -469,7 +592,10 @@ pub fn store_bridge_transfer(env: &Env, transfer: &BridgeTransfer) {
         .set(&MonitoringDataKey::BridgeTransfer(transfer.transfer_id), transfer);
 }
 
-/// Create new bridge transfer
+/// Create new bridge transfer.
+///
+/// Returns an error if the automatic latency circuit breaker is tripped — new
+/// bridge transactions are blocked until the breaker is cleared by an admin.
 pub fn create_bridge_transfer(
     env: &Env,
     transfer_id: u64,
@@ -481,6 +607,13 @@ pub fn create_bridge_transfer(
     stellar_asset: Asset,
     user: String,
 ) -> Result<(), String> {
+    if is_circuit_breaker_tripped(env) {
+        return Err(String::from_str(
+            env,
+            "CircuitBreakerTripped: bridge paused due to abnormal finality latency",
+        ));
+    }
+
     if amount <= 0 {
         return Err(String::from_str(env, "Invalid amount"));
     }
@@ -1092,5 +1225,136 @@ mod tests {
 
         let transfer = get_bridge_transfer(&env, 1).unwrap();
         assert_eq!(transfer.status, TransferStatus::Complete);
+    }
+
+    // ── Circuit breaker tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn circuit_breaker_not_tripped_under_normal_latency() {
+        let env = setup_env();
+        let config = LatencyCircuitBreakerConfig {
+            latency_threshold_secs: 500,
+            window_size: 3,
+        };
+        set_latency_circuit_breaker_config(&env, &config);
+
+        // Record 3 fast confirmations — well under the threshold.
+        record_finality_latency(&env, 100);
+        record_finality_latency(&env, 150);
+        record_finality_latency(&env, 120);
+
+        assert!(!is_circuit_breaker_tripped(&env));
+    }
+
+    #[test]
+    fn circuit_breaker_trips_when_average_exceeds_threshold() {
+        let env = setup_env();
+        let config = LatencyCircuitBreakerConfig {
+            latency_threshold_secs: 200,
+            window_size: 3,
+        };
+        set_latency_circuit_breaker_config(&env, &config);
+
+        // Push average above threshold.
+        record_finality_latency(&env, 300);
+        record_finality_latency(&env, 400);
+        record_finality_latency(&env, 500);
+
+        assert!(is_circuit_breaker_tripped(&env));
+    }
+
+    #[test]
+    fn circuit_breaker_blocks_new_transfers_when_tripped() {
+        let env = setup_env();
+        let config = LatencyCircuitBreakerConfig {
+            latency_threshold_secs: 100,
+            window_size: 2,
+        };
+        set_latency_circuit_breaker_config(&env, &config);
+
+        // Trip the breaker.
+        record_finality_latency(&env, 500);
+        record_finality_latency(&env, 600);
+        assert!(is_circuit_breaker_tripped(&env));
+
+        // Attempting a new transfer should now fail.
+        let user = String::from_str(&env, "user123");
+        let asset = Asset {
+            code: String::from_str(&env, "XLM"),
+            issuer: None,
+        };
+        let result = create_bridge_transfer(
+            &env,
+            99,
+            1,
+            ChainId::Ethereum,
+            ChainId::Polygon,
+            1_000_000,
+            100,
+            asset,
+            user,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn circuit_breaker_cleared_allows_new_transfers() {
+        let env = setup_env();
+        let config = LatencyCircuitBreakerConfig {
+            latency_threshold_secs: 100,
+            window_size: 2,
+        };
+        set_latency_circuit_breaker_config(&env, &config);
+
+        // Trip the breaker.
+        record_finality_latency(&env, 500);
+        record_finality_latency(&env, 500);
+        assert!(is_circuit_breaker_tripped(&env));
+
+        // Recovery.
+        clear_circuit_breaker(&env);
+        assert!(!is_circuit_breaker_tripped(&env));
+
+        // New transfers should now succeed.
+        let user = String::from_str(&env, "user123");
+        let asset = Asset {
+            code: String::from_str(&env, "XLM"),
+            issuer: None,
+        };
+        let result = create_bridge_transfer(
+            &env,
+            99,
+            1,
+            ChainId::Ethereum,
+            ChainId::Polygon,
+            1_000_000,
+            100,
+            asset,
+            user,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn finality_latency_recorded_on_finalization() {
+        let env = setup_env();
+        let tx_hash = String::from_str(&env, "0xabcd1234");
+
+        monitor_source_transaction(&env, 1, tx_hash, ChainId::Ethereum, 100).unwrap();
+
+        // Advance time so there is a measurable latency.
+        env.ledger().set_timestamp(1500);
+
+        // Finalize — should record latency (1500 - 1000 = 500 s).
+        let config = LatencyCircuitBreakerConfig {
+            latency_threshold_secs: 10_000,
+            window_size: 1,
+        };
+        set_latency_circuit_breaker_config(&env, &config);
+
+        update_transaction_confirmation_count(&env, 1, 132).unwrap();
+
+        // Circuit breaker NOT tripped (500 < 10000).
+        assert!(!is_circuit_breaker_tripped(&env));
     }
 }


### PR DESCRIPTION
## Summary

Closes #572

Implements an automatic circuit breaker that monitors bridge finality-confirmation latency and pauses new transfers when anomalies are detected.

## Changes

- `stellar-swipe/contracts/bridge/src/monitoring.rs` — added:
  - `LatencyCircuitBreakerConfig` struct (configurable threshold + window size)
  - `MonitoringDataKey` variants: `LatencyWindow`, `CircuitBreakerTripped`, `LatencyCircuitBreakerConfig`
  - `record_finality_latency(env, latency_secs)` — appends to rolling window, auto-trips when average exceeds threshold
  - `is_circuit_breaker_tripped(env)` — check guard used in `create_bridge_transfer`
  - `clear_circuit_breaker(env)` — admin recovery path (clears flag + resets window)
  - `set_latency_circuit_breaker_config` / `get_latency_circuit_breaker_config` — configure thresholds at runtime
  - `trip_circuit_breaker` — sets the flag and emits `circuit_breaker_auto_tripped` event
  - `mark_as_finalized` now calls `record_finality_latency` so every confirmed transfer feeds the window
  - Guard at the top of `create_bridge_transfer` returns error when breaker is tripped

## Testing

- `circuit_breaker_not_tripped_under_normal_latency` — 3 samples below threshold → no trip
- `circuit_breaker_trips_when_average_exceeds_threshold` — 3 samples above threshold → tripped
- `circuit_breaker_blocks_new_transfers_when_tripped` — `create_bridge_transfer` fails while tripped
- `circuit_breaker_cleared_allows_new_transfers` — after `clear_circuit_breaker`, transfers succeed again
- `finality_latency_recorded_on_finalization` — latency is captured when a tx reaches finality

## Notes

Defaults: 800 s threshold, 10-sample window. Both are runtime-configurable via `set_latency_circuit_breaker_config`.