### PR TITLE
feat(shared): add shared Pausable module and migrate stake_vault/governance (#561)

### DIFF
--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -77,6 +77,7 @@ use reputation::{
     GovernanceReputation, ReputationConfig, ReputationTier, StalenessLevel,
 };
 pub use shadow_mode::ShadowModeState;
+use shared::pausable;
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Map, String, Symbol,
     Vec,
@@ -128,8 +129,6 @@ pub enum StorageKey {
     ConvictionState,
     /// Voting-power snapshot taken at proposal creation: Map<Address, i128>.
     VoteSnapshots(u64),
-    /// Global pause flag surfaced by `health_check` (admin-controlled).
-    ContractPaused,
     /// Reputation decay and stale-score configuration.
     ReputationConfig,
     /// Conviction calibration configuration (penalty, reward, cap parameters).
@@ -271,9 +270,10 @@ impl GovernanceContract {
         env.storage()
             .instance()
             .set(&StorageKey::Initialized, &true);
+        // Initialize pause state via shared::pausable (no event on init).
         env.storage()
             .instance()
-            .set(&StorageKey::ContractPaused, &false);
+            .set(&pausable::PausableKey::Paused, &false);
         track_holder(&env, &recipients.team);
         track_holder(&env, &recipients.early_investors);
         track_holder(&env, &recipients.community_rewards);
@@ -300,11 +300,7 @@ impl GovernanceContract {
             .instance()
             .get(&StorageKey::Admin)
             .unwrap_or_else(|| stellar_swipe_common::placeholder_admin(&env));
-        let is_paused = env
-            .storage()
-            .instance()
-            .get(&StorageKey::ContractPaused)
-            .unwrap_or(false);
+        let is_paused = pausable::is_paused(&env);
         stellar_swipe_common::HealthStatus {
             is_initialized: true,
             is_paused,
@@ -313,16 +309,17 @@ impl GovernanceContract {
         }
     }
 
-    /// Sets the global pause flag read by `health_check` (admin only).
+    /// Sets the global pause flag (admin only).
+    ///
+    /// Uses the shared [`pausable`] module so pause behavior and event shape
+    /// are consistent across all contracts that adopt it (Issue #561).
     pub fn set_contract_paused(
         env: Env,
         admin: Address,
         paused: bool,
     ) -> Result<(), GovernanceError> {
         require_admin(&env, &admin)?;
-        env.storage()
-            .instance()
-            .set(&StorageKey::ContractPaused, &paused);
+        pausable::set_paused(&env, paused);
         Ok(())
     }
 
@@ -1574,17 +1571,12 @@ fn is_initialized(env: &Env) -> bool {
 /// Returns `Err(GovernanceError::ContractPaused)` when the governance contract
 /// is administratively paused.  Call this at the top of every state-mutating
 /// entry-point that should be blocked during a pause.
+///
+/// Delegates to [`shared::pausable::require_not_paused`] so the pause check
+/// is consistent with all other contracts that adopt the shared module
+/// (Issue #561).
 pub(crate) fn require_not_paused(env: &Env) -> Result<(), GovernanceError> {
-    let paused: bool = env
-        .storage()
-        .instance()
-        .get(&StorageKey::ContractPaused)
-        .unwrap_or(false);
-    if paused {
-        Err(GovernanceError::ContractPaused)
-    } else {
-        Ok(())
-    }
+    pausable::require_not_paused(env).map_err(|_| GovernanceError::ContractPaused)
 }
 
 fn metadata(env: &Env) -> Result<TokenMetadata, GovernanceError> {

--- a/stellar-swipe/contracts/shared/src/lib.rs
+++ b/stellar-swipe/contracts/shared/src/lib.rs
@@ -13,6 +13,8 @@ pub mod initializable;
 /// Minimum-liquidity threshold guard for pooled-fund withdrawals (issue #591).
 pub mod liquidity_pool;
 pub mod math;
+/// Shared emergency-pause state and guard (Issue #561).
+pub mod pausable;
 #[allow(deprecated)]
 pub mod version;
 
@@ -21,4 +23,5 @@ pub use cross_contract::{
     CrossContractVersionClient, MessageStatus, MAX_MESSAGE_SIZE,
 };
 pub use errors::{ErrorCategory, RecoveryStrategy};
+pub use pausable::{is_paused, require_not_paused, set_paused, PausableKey};
 pub use version::{ContractKind, VersionError};

--- a/stellar-swipe/contracts/shared/src/pausable.rs
+++ b/stellar-swipe/contracts/shared/src/pausable.rs
@@ -1,0 +1,173 @@
+/// Shared pausable module (Issue #561).
+///
+/// Provides a consistent pause-state storage key, pause/unpause helpers, a
+/// "reject if paused" guard, and a uniform event emitted on every state
+/// change.  Any contract that needs an emergency-pause capability imports
+/// these helpers instead of rolling its own.
+///
+/// # Migration from bespoke pause logic
+/// A contract that already stores a paused flag under a different key can
+/// migrate without losing its current pause status by running a one-time
+/// upgrade that reads the old key and writes it to [`PausableKey::Paused`]:
+///
+/// ```ignore
+/// // Inside an upgrade entrypoint (or a one-time migration call):
+/// let was_paused: bool = env.storage().instance()
+///     .get(&OldPauseKey::Paused)          // old enum variant / key
+///     .unwrap_or(false);
+/// shared::pausable::set_paused(&env, was_paused);
+/// env.storage().instance().remove(&OldPauseKey::Paused);  // clean up old key
+/// ```
+///
+/// After migration the old key is no longer consulted; only
+/// [`PausableKey::Paused`] is read.
+use soroban_sdk::{contracttype, symbol_short, Env, Symbol};
+
+/// Storage key for the pause flag.  Defined as a distinct enum so it cannot
+/// collide with contract-local key enums whose variants have different
+/// discriminants.
+#[contracttype]
+#[derive(Clone)]
+pub enum PausableKey {
+    Paused,
+}
+
+/// Returns `true` when the contract is paused.
+pub fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get::<_, bool>(&PausableKey::Paused)
+        .unwrap_or(false)
+}
+
+/// Persists the new pause state and emits a consistent event.
+///
+/// Event topic  : `("contract_paused",)`  or  `("contract_unpaused",)`
+/// Event data   : `(paused: bool)`
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage()
+        .instance()
+        .set(&PausableKey::Paused, &paused);
+
+    let topic: Symbol = if paused {
+        symbol_short!("paused")
+    } else {
+        symbol_short!("unpaused")
+    };
+    #[allow(deprecated)]
+    env.events().publish((topic,), (paused,));
+}
+
+/// Returns `Err(true)` (a sentinel) if the contract is currently paused,
+/// `Ok(())` otherwise.
+///
+/// Callers translate the boolean sentinel into their own error type:
+///
+/// ```ignore
+/// shared::pausable::require_not_paused(&env)
+///     .map_err(|_| MyError::ContractPaused)?;
+/// ```
+pub fn require_not_paused(env: &Env) -> Result<(), bool> {
+    if is_paused(env) {
+        Err(true)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{contract, contractimpl, Address, Env};
+
+    #[contract]
+    struct TestPausable;
+
+    #[contractimpl]
+    impl TestPausable {
+        pub fn pause(env: Env) {
+            set_paused(&env, true);
+        }
+        pub fn unpause(env: Env) {
+            set_paused(&env, false);
+        }
+        pub fn paused(env: Env) -> bool {
+            is_paused(&env)
+        }
+        pub fn guard(env: Env) -> bool {
+            require_not_paused(&env).is_err()
+        }
+    }
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register(TestPausable, ());
+        (env, id)
+    }
+
+    #[test]
+    fn fresh_contract_is_not_paused() {
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        assert!(!c.paused());
+    }
+
+    #[test]
+    fn pause_sets_flag() {
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        c.pause();
+        assert!(c.paused());
+    }
+
+    #[test]
+    fn unpause_clears_flag() {
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        c.pause();
+        c.unpause();
+        assert!(!c.paused());
+    }
+
+    #[test]
+    fn guard_returns_err_when_paused() {
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        c.pause();
+        assert!(c.guard(), "guard must return Err (true) when paused");
+    }
+
+    #[test]
+    fn guard_returns_ok_when_not_paused() {
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        assert!(!c.guard(), "guard must return Ok when not paused");
+    }
+
+    #[test]
+    fn pause_emits_event() {
+        use soroban_sdk::testutils::Events;
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        c.pause();
+        let events = env.events().all();
+        assert!(!events.is_empty(), "pause must emit an event");
+    }
+
+    #[test]
+    fn unpause_emits_event() {
+        use soroban_sdk::testutils::Events;
+        let (env, id) = setup();
+        let c = TestPausableClient::new(&env, &id);
+        c.pause();
+        let before = env.events().all().len();
+        c.unpause();
+        assert!(
+            env.events().all().len() > before,
+            "unpause must emit an event"
+        );
+    }
+}

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod migration;
 
 use migration::{MigrationKey, StakeInfoV2};
-use shared::initializable;
+use shared::{initializable, pausable};
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol,
 };
@@ -110,8 +110,6 @@ pub enum StorageKey {
     /// Timestamp when a provider's stake first dropped below minimum.
     /// `None` means stake is currently at or above minimum.
     StakeBelowMinSince(Address),
-    /// Emergency pause flag — when true all stake/unstake ops are blocked.
-    Paused,
     /// Timestamp when a large-withdrawal request was initiated (per staker).
     LargeWithdrawalRequestedAt(Address),
     /// Ledger sequence at which a stake was last deposited (per staker).
@@ -170,13 +168,19 @@ impl StakeVaultContract {
         env.storage()
             .instance()
             .set(&StorageKey::SignalRegistry, &signal_registry);
-        env.storage().instance().set(&StorageKey::Paused, &false);
+        // Initialize pause state to false via shared::pausable (no event on init).
+        env.storage()
+            .instance()
+            .set(&pausable::PausableKey::Paused, &false);
         initializable::mark_initialized(&env);
     }
 
-    // ── Emergency pause ────────────────────────────────────────────────────────
+    // ── Emergency pause (shared::pausable) ────────────────────────────────────
 
     /// Admin: pause all stake/unstake operations.
+    ///
+    /// Uses the shared [`pausable`] module so pause behavior and event shape
+    /// are consistent across all contracts that adopt it (Issue #561).
     pub fn pause(env: Env) {
         let admin: Address = env
             .storage()
@@ -184,15 +188,7 @@ impl StakeVaultContract {
             .get(&StorageKey::Admin)
             .expect("not initialized");
         admin.require_auth();
-        env.storage().instance().set(&StorageKey::Paused, &true);
-        #[allow(deprecated)]
-        env.events().publish(
-            (
-                Symbol::new(&env, "stake_vault"),
-                Symbol::new(&env, "paused"),
-            ),
-            (),
-        );
+        pausable::set_paused(&env, true);
     }
 
     /// Admin: resume operations.
@@ -203,36 +199,17 @@ impl StakeVaultContract {
             .get(&StorageKey::Admin)
             .expect("not initialized");
         admin.require_auth();
-        env.storage().instance().set(&StorageKey::Paused, &false);
-        #[allow(deprecated)]
-        env.events().publish(
-            (
-                Symbol::new(&env, "stake_vault"),
-                Symbol::new(&env, "unpaused"),
-            ),
-            (),
-        );
+        pausable::set_paused(&env, false);
     }
 
     pub fn is_paused(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&StorageKey::Paused)
-            .unwrap_or(false)
+        pausable::is_paused(&env)
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────
 
     fn require_not_paused(env: &Env) -> Result<(), StakeVaultError> {
-        if env
-            .storage()
-            .instance()
-            .get::<_, bool>(&StorageKey::Paused)
-            .unwrap_or(false)
-        {
-            return Err(StakeVaultError::ContractPaused);
-        }
-        Ok(())
+        pausable::require_not_paused(env).map_err(|_| StakeVaultError::ContractPaused)
     }
 
     // ── Deposit stake (records ledger for flash-loan detection) ────────────────


### PR DESCRIPTION
## Summary

Closes #561

Extracts a shared pausable module into the `shared` crate so pause behavior, storage, and event shape are consistent across all contracts, eliminating duplicated bespoke pause logic.

## Changes

- `contracts/shared/src/pausable.rs` — new module with `PausableKey` storage enum, `is_paused`, `set_paused`, `require_not_paused`; emits consistent `"paused"` / `"unpaused"` event on every state change; includes unit tests
- `contracts/shared/src/lib.rs` — exports the new module and its public items
- `contracts/stake_vault/src/lib.rs` — removes `StorageKey::Paused` and the bespoke `pause`/`unpause`/`is_paused`/`require_not_paused` implementations; delegates to `shared::pausable`
- `contracts/governance/src/lib.rs` — removes `StorageKey::ContractPaused` and the bespoke `require_not_paused`; delegates to `shared::pausable`

## Migration notes

A contract already storing a pause flag under a different key can migrate without losing its current pause status by running a one-time upgrade that reads the old key and writes it to `PausableKey::Paused`:

```rust
let was_paused: bool = env.storage().instance()
    .get(&OldPauseKey::Paused).unwrap_or(false);
shared::pausable::set_paused(&env, was_paused);
env.storage().instance().remove(&OldPauseKey::Paused);
```

## Testing

- `shared` — unit tests in `pausable.rs` covering fresh state, pause, unpause, guard, and event emission
- `stake_vault` — existing pause tests exercise the shared path
- `governance` — existing pause propagation tests exercise the shared path