### PR TITLE
feat: implement fee waterfall, provider payout currency, quadratic/category governance (#690-#693)

### DIFF
--- a/stellar-swipe/contracts/fee_collector/src/errors.rs
+++ b/stellar-swipe/contracts/fee_collector/src/errors.rs
@@ -24,4 +24,7 @@ pub enum ContractError {
     FailedCollectionNotFound = 18,
     RetryLimitExceeded = 19,
     IterationLimitExceeded = 20,
+    WaterfallNotConfigured = 21,
+    PreferredTokenInsufficient = 22,
+    PayoutCurrencyUnchanged = 23,
 }

--- a/stellar-swipe/contracts/fee_collector/src/events.rs
+++ b/stellar-swipe/contracts/fee_collector/src/events.rs
@@ -1,5 +1,6 @@
 use shared::errors::{ErrorCategory, RecoveryStrategy};
-use soroban_sdk::{contractevent, Address, Env, String, Symbol};
+use soroban_sdk::{contractevent, Address, Env, String, Symbol, Vec};
+use crate::storage::WaterfallTierResult;
 
 #[contractevent]
 pub struct WithdrawalQueued {
@@ -227,5 +228,58 @@ pub fn emit_revenue_share_distributed(
             Symbol::new(env, "revenue_share_distributed"),
         ),
         (token.clone(), total_amount, snapshot_ledger),
+    );
+}
+
+// ── #690: Waterfall Distribution event ──────────────────────────────────────
+
+/// Emitted after a waterfall distribution run, listing every tier's allocation.
+pub fn emit_waterfall_distribution(
+    env: &Env,
+    token: &Address,
+    total_distributed: i128,
+    tier_results: &Vec<WaterfallTierResult>,
+) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "waterfall_distribution"),
+        ),
+        (token.clone(), total_distributed, tier_results.clone()),
+    );
+}
+
+// ── #691: Payout Currency Set event ─────────────────────────────────────────
+
+pub fn emit_payout_currency_set(env: &Env, provider: &Address, preferred_token: &Address) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "payout_currency_set"),
+        ),
+        (provider.clone(), preferred_token.clone()),
+    );
+}
+
+pub fn emit_fees_claimed_converted(
+    env: &Env,
+    provider: &Address,
+    source_token: &Address,
+    preferred_token: &Address,
+    source_amount: i128,
+    preferred_amount: i128,
+) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "fees_claimed_converted"),
+        ),
+        (
+            provider.clone(),
+            source_token.clone(),
+            preferred_token.clone(),
+            source_amount,
+            preferred_amount,
+        ),
     );
 }

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -7,8 +7,9 @@ mod events;
 mod fee_cache;
 use events::{
     emit_error_reported, emit_fee_collected, emit_fee_rate_updated, emit_fees_claimed,
-    emit_first_trade_fee_waived, emit_network_condition_updated, emit_retry_attempted,
-    emit_treasury_withdrawal, emit_withdrawal_queued, EvtErrorReported, EvtFeeCollected,
+    emit_fees_claimed_converted, emit_first_trade_fee_waived, emit_network_condition_updated,
+    emit_payout_currency_set, emit_retry_attempted, emit_treasury_withdrawal,
+    emit_waterfall_distribution, emit_withdrawal_queued, EvtErrorReported, EvtFeeCollected,
     EvtFeeRateUpdated, EvtFeesClaimed, EvtNetworkConditionUpdated, EvtRetryAttempted,
     EvtTreasuryWithdrawal, EvtWithdrawalQueued,
 };
@@ -27,19 +28,22 @@ pub use storage::BalanceMismatch;
 use storage::{
     get_admin, get_burn_rate, get_failed_fee_collection, get_fee_optimization_config, get_fee_rate,
     get_last_error_report, get_monthly_trade_volume, get_network_condition_score,
-    get_oracle_contract, get_pending_fees, get_queued_withdrawal, get_treasury_balance, has_traded,
-    is_initialized, remove_failed_fee_collection, remove_monthly_trade_volume,
+    get_oracle_contract, get_pending_fees, get_provider_payout_currency, get_queued_withdrawal,
+    get_treasury_balance, get_waterfall_config, has_traded, is_initialized,
+    remove_failed_fee_collection, remove_monthly_trade_volume, remove_provider_payout_currency,
     remove_queued_withdrawal, set_admin, set_burn_rate as set_burn_rate_storage,
     set_failed_fee_collection, set_fee_optimization_config, set_fee_rate as set_fee_rate_storage,
     set_has_traded, set_initialized, set_last_error_report, set_monthly_trade_volume,
     set_network_condition_score, set_oracle_contract as set_oracle_contract_storage,
-    set_pending_fees, set_queued_withdrawal, set_treasury_balance, ErrorReport,
-    FailedFeeCollection, FeeOptimizationConfig, MonthlyTradeVolume, QueuedWithdrawal, StorageKey,
-    MAX_BURN_RATE_BPS, MAX_FEE_RATE_BPS, MIN_FEE_RATE_BPS,
+    set_pending_fees, set_provider_payout_currency,
+    set_queued_withdrawal, set_treasury_balance,
+    set_waterfall_config as set_waterfall_config_storage, ErrorReport, FailedFeeCollection,
+    FeeOptimizationConfig, MonthlyTradeVolume, QueuedWithdrawal, StorageKey, WaterfallConfig,
+    WaterfallTier, WaterfallTierResult, MAX_BURN_RATE_BPS, MAX_FEE_RATE_BPS, MIN_FEE_RATE_BPS,
 };
 
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, IntoVal, String, Val,
-    Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, IntoVal, String,
+    Symbol, Val, Vec};
 
 use shared::errors::{ErrorCategory, RecoveryStrategy};
 use stellar_swipe_common::Asset;
@@ -753,8 +757,13 @@ impl FeeCollector {
     }
 
     /// Claim all pending fee earnings for a provider and token.
-    /// Returns the amount claimed (0 if no pending balance).
-    /// Claim accumulated fees for `provider` in `token`.
+    ///
+    /// If the provider has set a preferred payout currency via
+    /// [`set_payout_currency`] and the preferred token differs from `token`,
+    /// this function attempts to convert the accrued fees at claim time using
+    /// the configured oracle price feed.  On any conversion failure (stale
+    /// oracle, no oracle configured, insufficient treasury balance of the
+    /// preferred token) it silently falls back to settling in `token`.
     ///
     /// Authorization is scoped to `(provider, token)` via `require_auth_for_args`
     /// so a valid signature cannot be replayed against a different token or
@@ -771,24 +780,121 @@ impl FeeCollector {
         let amount = get_pending_fees(&env, &provider, &token);
 
         if amount > 0 {
-            token::Client::new(&env, &token).transfer(
-                &env.current_contract_address(),
-                &provider,
-                &amount,
+            // #691 – honour preferred payout currency when set and conversion succeeds.
+            let converted = if let Some(pref_token) =
+                get_provider_payout_currency(&env, &provider)
+            {
+                if pref_token != token {
+                    Self::try_claim_in_preferred_currency(
+                        &env,
+                        &provider,
+                        &token,
+                        amount,
+                        &pref_token,
+                    )
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            if converted.is_none() {
+                // Default: settle in source token.
+                token::Client::new(&env, &token).transfer(
+                    &env.current_contract_address(),
+                    &provider,
+                    &amount,
+                );
+                set_pending_fees(&env, &provider, &token, 0);
+                emit_fees_claimed(
+                    &env,
+                    EvtFeesClaimed {
+                        provider: provider.clone(),
+                        token: token.clone(),
+                        amount,
+                    },
+                );
+            }
+        } else {
+            emit_fees_claimed(
+                &env,
+                EvtFeesClaimed {
+                    provider: provider.clone(),
+                    token: token.clone(),
+                    amount: 0,
+                },
             );
-            set_pending_fees(&env, &provider, &token, 0);
         }
 
-        emit_fees_claimed(
-            &env,
-            EvtFeesClaimed {
-                provider: provider.clone(),
-                token: token.clone(),
-                amount,
-            },
+        Ok(amount)
+    }
+
+    /// Attempt to convert `source_amount` of `source_token` into `pref_token`
+    /// using the oracle, then transfer `pref_token` from the treasury.
+    ///
+    /// Returns `Some(preferred_amount)` on success, `None` on any failure
+    /// (including stale oracle or insufficient preferred-token treasury balance).
+    fn try_claim_in_preferred_currency(
+        env: &Env,
+        provider: &Address,
+        source_token: &Address,
+        source_amount: i128,
+        pref_token: &Address,
+    ) -> Option<i128> {
+        let oracle_addr = get_oracle_contract(env)?;
+
+        // Ask the oracle for an exchange rate from source_token to pref_token.
+        // Method signature expected: get_rate(from: Address, to: Address) -> i128
+        // where the rate is scaled by ORACLE_RATE_PRECISION (1_000_000).
+        // If the oracle does not support this method or the feed is stale,
+        // try_invoke_contract returns an error and we fall back.
+        const ORACLE_RATE_PRECISION: i128 = 1_000_000;
+        let rate_result = env.try_invoke_contract::<i128, soroban_sdk::Error>(
+            &oracle_addr,
+            &Symbol::new(env, "get_rate"),
+            (source_token.clone(), pref_token.clone()).into_val(env),
         );
 
-        Ok(amount)
+        let rate = match rate_result {
+            Ok(Ok(r)) if r > 0 => r,
+            _ => return None, // oracle stale or unsupported – fall back
+        };
+
+        let pref_amount = source_amount
+            .checked_mul(rate)?
+            .checked_div(ORACLE_RATE_PRECISION)?;
+
+        if pref_amount <= 0 {
+            return None;
+        }
+
+        // Ensure the contract holds enough of the preferred token.
+        let pref_client = token::Client::new(env, pref_token);
+        let pref_balance = pref_client.balance(&env.current_contract_address());
+        if pref_balance < pref_amount {
+            return None;
+        }
+
+        // Execute the conversion: zero out source pending fees and pay preferred.
+        set_pending_fees(env, provider, source_token, 0);
+
+        pref_client.transfer(
+            &env.current_contract_address(),
+            provider,
+            &pref_amount,
+        );
+
+        emit_fees_claimed_converted(
+            env,
+            provider,
+            source_token,
+            pref_token,
+            source_amount,
+            pref_amount,
+        );
+
+        Some(pref_amount)
     }
 
     // ── Issue #366: Provider Earnings Report ─────────────────────────────────
@@ -931,5 +1037,198 @@ impl FeeCollector {
         Ok(reports::get_provider_earnings_report(
             &env, &provider, period,
         ))
+    }
+
+    // ── Issue #690: Fee Distribution Waterfall ───────────────────────────────
+
+    /// Admin: store an ordered waterfall configuration for fee distribution.
+    ///
+    /// Tiers are processed in ascending `priority` order; tiers with the same
+    /// priority value are processed in the order they appear in the Vec.
+    pub fn set_waterfall_config(
+        env: Env,
+        config: WaterfallConfig,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+        set_waterfall_config_storage(&env, &config);
+        Ok(())
+    }
+
+    /// Returns the currently configured waterfall, or an error if none has been
+    /// configured yet.
+    pub fn get_waterfall_config_fn(env: Env) -> Result<WaterfallConfig, ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        get_waterfall_config(&env).ok_or(ContractError::WaterfallNotConfigured)
+    }
+
+    /// Distribute `total_amount` of `token` from the treasury according to the
+    /// configured waterfall, funding higher-priority tiers first.
+    ///
+    /// Each tier receives up to `target_amount`. When funds are insufficient:
+    /// - If remaining >= tier.minimum_amount the tier receives the remaining
+    ///   funds and lower tiers receive nothing.
+    /// - If remaining < tier.minimum_amount the tier is skipped entirely
+    ///   (minimum not met).
+    ///
+    /// Admin auth required.  Emits [`waterfall_distribution`].
+    pub fn distribute_waterfall(
+        env: Env,
+        token: Address,
+        total_amount: i128,
+    ) -> Result<Vec<WaterfallTierResult>, ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+
+        if total_amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let config =
+            get_waterfall_config(&env).ok_or(ContractError::WaterfallNotConfigured)?;
+
+        let treasury_bal = get_treasury_balance(&env, &token);
+        if treasury_bal < total_amount {
+            return Err(ContractError::InsufficientTreasuryBalance);
+        }
+
+        // Sort a local index by priority (insertion sort – tier count is small).
+        let n = config.tiers.len();
+        let mut indices: Vec<u32> = Vec::new(&env);
+        let mut i = 0u32;
+        while i < n {
+            indices.push_back(i);
+            i += 1;
+        }
+        // Bubble sort ascending by priority value (lower = funded first).
+        loop {
+            let mut swapped = false;
+            let m = indices.len();
+            let mut j = 0u32;
+            while j + 1 < m {
+                let ia = indices.get(j).unwrap();
+                let ib = indices.get(j + 1).unwrap();
+                let pa = config.tiers.get(ia).unwrap().priority;
+                let pb = config.tiers.get(ib).unwrap().priority;
+                if pa > pb {
+                    indices.set(j, ib);
+                    indices.set(j + 1, ia);
+                    swapped = true;
+                }
+                j += 1;
+            }
+            if !swapped {
+                break;
+            }
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        let mut remaining = total_amount;
+        let mut total_distributed: i128 = 0;
+        let mut tier_results: Vec<WaterfallTierResult> = Vec::new(&env);
+
+        let mut k = 0u32;
+        while k < indices.len() {
+            let tier_idx = indices.get(k).unwrap();
+            let tier: WaterfallTier = config.tiers.get(tier_idx).unwrap();
+
+            let allocated = if remaining >= tier.target_amount {
+                tier.target_amount
+            } else if remaining >= tier.minimum_amount {
+                remaining
+            } else {
+                // Minimum not met – skip this tier.
+                tier_results.push_back(WaterfallTierResult {
+                    name: tier.name,
+                    recipient: tier.recipient,
+                    priority: tier.priority,
+                    allocated: 0,
+                });
+                k += 1;
+                continue;
+            };
+
+            token_client.transfer(
+                &env.current_contract_address(),
+                &tier.recipient,
+                &allocated,
+            );
+            remaining = remaining
+                .checked_sub(allocated)
+                .ok_or(ContractError::ArithmeticOverflow)?;
+            total_distributed = total_distributed
+                .checked_add(allocated)
+                .ok_or(ContractError::ArithmeticOverflow)?;
+
+            tier_results.push_back(WaterfallTierResult {
+                name: tier.name,
+                recipient: tier.recipient,
+                priority: tier.priority,
+                allocated,
+            });
+
+            k += 1;
+        }
+
+        // Deduct from treasury balance.
+        let new_bal = treasury_bal
+            .checked_sub(total_distributed)
+            .ok_or(ContractError::ArithmeticOverflow)?;
+        set_treasury_balance(&env, &token, new_bal);
+
+        emit_waterfall_distribution(&env, &token, total_distributed, &tier_results);
+
+        Ok(tier_results)
+    }
+
+    // ── Issue #691: Provider Settlement Currency ─────────────────────────────
+
+    /// Set or update the preferred payout currency for `provider`.
+    ///
+    /// At [`claim_fees`] time the contract will attempt to convert accrued fees
+    /// into `preferred_token` using the configured oracle price feed.  If the
+    /// oracle feed is stale or unavailable the claim falls back to the default
+    /// settlement token.
+    ///
+    /// Only the provider themselves may call this.
+    pub fn set_payout_currency(
+        env: Env,
+        provider: Address,
+        preferred_token: Address,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        provider.require_auth();
+        set_provider_payout_currency(&env, &provider, &preferred_token);
+        emit_payout_currency_set(&env, &provider, &preferred_token);
+        Ok(())
+    }
+
+    /// Clear the payout currency preference for `provider`, reverting to the
+    /// default settlement asset.
+    ///
+    /// Only the provider themselves may call this.
+    pub fn clear_payout_currency(env: Env, provider: Address) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        provider.require_auth();
+        remove_provider_payout_currency(&env, &provider);
+        Ok(())
+    }
+
+    /// Returns the preferred payout token for `provider`, or `None` if the
+    /// provider has not set a preference.
+    pub fn get_payout_currency(env: Env, provider: Address) -> Option<Address> {
+        get_provider_payout_currency(&env, &provider)
     }
 }

--- a/stellar-swipe/contracts/fee_collector/src/storage.rs
+++ b/stellar-swipe/contracts/fee_collector/src/storage.rs
@@ -3,6 +3,53 @@ use shared::initializable;
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 use stellar_swipe_common::Asset;
 
+// ── #690: Fee Distribution Waterfall ────────────────────────────────────────
+
+/// A single tier in the fee distribution waterfall, processed in ascending
+/// priority order (lower `priority` value = funded first).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WaterfallTier {
+    /// Human-readable label (e.g. "treasury", "insurance", "rewards").
+    pub name: String,
+    /// Lower value = higher priority. Tiers are processed in ascending order.
+    pub priority: u32,
+    /// Full allocation for this tier; lower-priority tiers receive leftovers.
+    pub target_amount: i128,
+    /// Minimum the tier must receive to be funded at all. If remaining funds
+    /// fall below this, the tier receives nothing.
+    pub minimum_amount: i128,
+    /// Address that receives the allocation for this tier.
+    pub recipient: Address,
+}
+
+/// Admin-configurable ordered waterfall of fee destinations.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WaterfallConfig {
+    pub tiers: Vec<WaterfallTier>,
+}
+
+/// Per-tier allocation record emitted in the waterfall_distribution event.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WaterfallTierResult {
+    pub name: String,
+    pub recipient: Address,
+    pub priority: u32,
+    pub allocated: i128,
+}
+
+// ── #691: Provider Settlement Currency ──────────────────────────────────────
+
+/// Stored preference for a provider's claim payout currency.
+/// `preferred_token` is the SEP-41 token contract to receive fees in.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PayoutCurrency {
+    pub preferred_token: Address,
+}
+
 pub const MAX_FEE_RATE_BPS: u32 = 100; // 1%
 pub const MIN_FEE_RATE_BPS: u32 = 1; // 0.01%
 pub const DEFAULT_FEE_RATE_BPS: u32 = 30; // 0.3%
@@ -56,6 +103,10 @@ pub enum StorageKey {
     LastErrorReport,
     /// Persisted failed fee collection operation for retry.
     FailedFeeCollection(String),
+    /// #690: Admin-configured waterfall distribution tiers.
+    WaterfallConfig,
+    /// #691: Per-provider preferred payout token.
+    ProviderPayoutCurrency(Address),
 }
 
 #[contracttype]
@@ -454,4 +505,42 @@ pub fn clear_revenue_share_pool(env: &Env, token: &Address) {
     env.storage()
         .persistent()
         .remove(&StorageKey::RevenueSharePool(token.clone()));
+}
+
+// ── #690: Waterfall Config ───────────────────────────────────────────────────
+
+pub fn get_waterfall_config(env: &Env) -> Option<WaterfallConfig> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::WaterfallConfig)
+}
+
+pub fn set_waterfall_config(env: &Env, config: &WaterfallConfig) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::WaterfallConfig, config);
+}
+
+// ── #691: Provider Payout Currency ──────────────────────────────────────────
+
+pub fn get_provider_payout_currency(env: &Env, provider: &Address) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get::<_, PayoutCurrency>(&StorageKey::ProviderPayoutCurrency(provider.clone()))
+        .map(|p| p.preferred_token)
+}
+
+pub fn set_provider_payout_currency(env: &Env, provider: &Address, preferred_token: &Address) {
+    env.storage().persistent().set(
+        &StorageKey::ProviderPayoutCurrency(provider.clone()),
+        &PayoutCurrency {
+            preferred_token: preferred_token.clone(),
+        },
+    );
+}
+
+pub fn remove_provider_payout_currency(env: &Env, provider: &Address) {
+    env.storage()
+        .persistent()
+        .remove(&StorageKey::ProviderPayoutCurrency(provider.clone()));
 }

--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -56,12 +56,13 @@ use distribution::{
     DistributionRecipients, DistributionState, VestingCategory, VestingSchedule,
 };
 pub use errors::GovernanceError;
-pub use proposals::GovernanceConfig;
+pub use proposals::{CategoryThreshold, GovernanceConfig, ProposalCategory};
 use proposals::{
     calculate_proposal_statistics, cancel_proposal, configure_governance, create_proposal,
     default_governance_config, execute_proposal, finalize_proposal, get_all_proposals,
-    get_governance_config, get_proposal, Proposal, ProposalStatistics, ProposalStatus,
-    ProposalType, Vote, VoteDelegation, VoteType as GovernanceVoteType,
+    get_category_threshold, get_governance_config, get_proposal, set_category_thresholds,
+    Proposal, ProposalStatistics, ProposalStatus, ProposalType, Vote, VoteDelegation,
+    VoteType as GovernanceVoteType,
 };
 use quadratic_voting::{
     allocate_vote_credits, calculate_marginal_cost, cast_quadratic_vote, compare_voting_systems,
@@ -148,6 +149,8 @@ pub enum StorageKey {
     TreasuryAddress,
     /// Shadow-mode canary upgrade trial state (issue #589).
     ShadowMode,
+    /// #693: Per-category quorum and supermajority thresholds (Map<u32, CategoryThreshold>).
+    CategoryThresholds,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -375,6 +378,31 @@ impl GovernanceContract {
         proposals::configure_governance(&env, &admin, config)
     }
 
+    // ── Issue #693: Category-specific quorum thresholds ───────────────────────
+
+    /// Admin: set per-category quorum and supermajority thresholds.
+    ///
+    /// A value of 0 in either field means "inherit from global GovernanceConfig".
+    /// Thresholds are validated to be ≤ 10 000 bps (100 %).
+    pub fn set_category_thresholds(
+        env: Env,
+        admin: Address,
+        category: ProposalCategory,
+        threshold: CategoryThreshold,
+    ) -> Result<(), GovernanceError> {
+        require_initialized(&env)?;
+        set_category_thresholds(&env, &admin, category, threshold)
+    }
+
+    /// Returns the per-category threshold overrides for `category`, or `None`
+    /// if no override has been configured (global thresholds apply).
+    pub fn get_category_thresholds(
+        env: Env,
+        category: ProposalCategory,
+    ) -> Option<CategoryThreshold> {
+        get_category_threshold(&env, &category)
+    }
+
     /// Configure the spam-deposit requirement for proposal creation.
     ///
     /// `config.amount` is the token amount locked from the proposer. Set to 0
@@ -405,6 +433,8 @@ impl GovernanceContract {
     /// - `title`: Short human-readable title.
     /// - `description`: Full proposal description.
     /// - `execution_payload`: Arbitrary bytes attached to the proposal (e.g. migration notes hash).
+    /// - `category`: Proposal category used to select per-category quorum/supermajority thresholds.
+    /// - `use_quadratic_voting`: When `true`, votes are weighted by sqrt(staked_balance).
     ///
     /// # Returns
     /// The new proposal ID.
@@ -421,6 +451,8 @@ impl GovernanceContract {
         title: String,
         description: String,
         execution_payload: Bytes,
+        category: ProposalCategory,
+        use_quadratic_voting: bool,
     ) -> Result<u64, GovernanceError> {
         require_initialized(&env)?;
         require_not_paused(&env)?;
@@ -431,6 +463,8 @@ impl GovernanceContract {
             title,
             description,
             execution_payload,
+            category,
+            use_quadratic_voting,
         )?;
         proposal_deposit::lock_proposal_deposit(&env, proposal_id, &proposer)?;
         let _ = record_proposal_creation(&env, proposer);

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -7,6 +7,50 @@ use crate::{
     require_admin, GovernanceError, StorageKey,
 };
 
+// ── #692: Integer square root (Newton's method, no floating-point) ───────────
+
+/// Compute floor(sqrt(n)) using integer arithmetic only.
+pub fn isqrt(n: i128) -> i128 {
+    if n <= 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+// ── #693: Proposal Category ──────────────────────────────────────────────────
+
+/// Classification for a governance proposal.  Each category can have its own
+/// quorum and supermajority threshold configured by the admin.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProposalCategory {
+    /// Low-risk configuration adjustments (e.g. fee rate tweaks).
+    ParameterChange,
+    /// High-risk WASM upgrades to any contract.
+    ContractUpgrade,
+    /// Treasury asset transfers to external addresses.
+    TreasuryTransfer,
+    /// Catch-all for proposals that don't fit the above categories.
+    General,
+}
+
+/// Per-category quorum and supermajority overrides. Values are in basis points
+/// (10 000 = 100 %). A value of 0 means "use the global GovernanceConfig".
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CategoryThreshold {
+    /// Minimum participation as a fraction of total supply (bps, 0 = global).
+    pub quorum_bps: u32,
+    /// Required for-vote fraction of cast votes (bps, 0 = global).
+    pub supermajority_bps: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposalType {
@@ -65,6 +109,16 @@ pub struct Proposal {
     pub voters: Map<Address, Vote>,
     pub voter_list: Vec<Address>,
     pub executed_at: Option<u64>,
+    // ── #693: Category classification ────────────────────────────────────────
+    /// Category used to select per-category quorum/supermajority thresholds.
+    pub category: ProposalCategory,
+    // ── #692: Per-proposal quadratic voting flag ──────────────────────────────
+    /// When `true`, each voter's effective weight is floor(sqrt(staked_balance))
+    /// instead of the raw staked balance.
+    pub use_quadratic_voting: bool,
+    /// Sum of floor(sqrt(p)) for all snapshotted holders at proposal creation.
+    /// Used as the quadratic-adjusted total supply for quorum checks.
+    pub quadratic_total_supply: i128,
 }
 
 #[contracttype]
@@ -201,6 +255,8 @@ pub fn create_proposal(
     title: String,
     description: String,
     execution_payload: Bytes,
+    category: ProposalCategory,
+    use_quadratic_voting: bool,
 ) -> Result<u64, GovernanceError> {
     proposer.require_auth();
     if title.is_empty() || description.is_empty() {
@@ -223,12 +279,17 @@ pub fn create_proposal(
     // or unstaking after this point cannot affect votes on this proposal.
     let holders = get_holders(env);
     let mut snapshots: Map<Address, i128> = Map::new(env);
+    // #692: accumulate the quadratic total supply at snapshot time.
+    let mut quadratic_total_supply: i128 = 0;
     let mut hi = 0;
     while hi < holders.len() {
         let h = holders.get(hi).unwrap();
         let p = get_effective_voting_power(env, &h);
         if p > 0 {
             snapshots.set(h, p);
+            if use_quadratic_voting {
+                quadratic_total_supply = quadratic_total_supply.saturating_add(isqrt(p));
+            }
         }
         hi += 1;
     }
@@ -253,6 +314,9 @@ pub fn create_proposal(
         voters: Map::new(env),
         voter_list: Vec::new(env),
         executed_at: None,
+        category,
+        use_quadratic_voting,
+        quadratic_total_supply,
     };
 
     state.proposals.set(id, proposal.clone());
@@ -309,10 +373,22 @@ pub fn cast_vote(
         return Err(GovernanceError::AlreadyVoted);
     }
 
-    let power = get_vote_snapshot(env, proposal_id, &voter).unwrap_or(0);
-    if power <= 0 {
+    let raw_power = get_vote_snapshot(env, proposal_id, &voter).unwrap_or(0);
+    if raw_power <= 0 {
         return Err(GovernanceError::NoVotingPower);
     }
+
+    // #692: when quadratic voting is enabled the effective weight is
+    // floor(sqrt(staked_balance)) rather than the raw balance.
+    let power = if proposal.use_quadratic_voting {
+        let q = isqrt(raw_power);
+        if q <= 0 {
+            return Err(GovernanceError::NoVotingPower);
+        }
+        q
+    } else {
+        raw_power
+    };
 
     let vote = Vote {
         voter: voter.clone(),
@@ -345,18 +421,29 @@ pub fn finalize_proposal(env: &Env, proposal_id: u64) -> Result<ProposalStatus, 
     }
 
     let cfg = get_governance_config(env);
+
+    // #693: look up category-specific thresholds, fall back to global config.
+    let (quorum_bps, approval_bps) = resolve_category_thresholds(env, &proposal.category, &cfg);
+
     let total_votes = proposal
         .votes_for
         .saturating_add(proposal.votes_against)
         .saturating_add(proposal.votes_abstain);
-    let total_supply = get_total_supply(env)?;
 
-    if total_supply <= 0 {
-        return Err(GovernanceError::InvalidSupply);
-    }
+    // #692: when quadratic voting is active, compare against the quadratic
+    // total supply stored at proposal creation rather than the linear supply.
+    let reference_supply = if proposal.use_quadratic_voting && proposal.quadratic_total_supply > 0 {
+        proposal.quadratic_total_supply
+    } else {
+        let ts = get_total_supply(env)?;
+        if ts <= 0 {
+            return Err(GovernanceError::InvalidSupply);
+        }
+        ts
+    };
 
     let quorum_met = total_votes.saturating_mul(BPS_DENOMINATOR)
-        >= total_supply.saturating_mul(cfg.quorum_threshold as i128);
+        >= reference_supply.saturating_mul(quorum_bps as i128);
 
     if !quorum_met {
         proposal.status = ProposalStatus::Failed;
@@ -367,7 +454,7 @@ pub fn finalize_proposal(env: &Env, proposal_id: u64) -> Result<ProposalStatus, 
     let cast_votes = proposal.votes_for.saturating_add(proposal.votes_against);
     let approved = cast_votes > 0
         && proposal.votes_for.saturating_mul(BPS_DENOMINATOR)
-            >= cast_votes.saturating_mul(cfg.approval_threshold as i128);
+            >= cast_votes.saturating_mul(approval_bps as i128);
 
     proposal.status = if approved {
         ProposalStatus::Succeeded
@@ -763,4 +850,80 @@ fn contains_address(list: &Vec<Address>, target: &Address) -> bool {
         i += 1;
     }
     false
+}
+
+// ── #693: Category threshold helpers ─────────────────────────────────────────
+
+/// Return `(quorum_bps, supermajority_bps)` for the given category, falling
+/// back to the global [`GovernanceConfig`] when no per-category override exists
+/// or when the stored values are 0.
+pub fn resolve_category_thresholds(
+    env: &Env,
+    category: &ProposalCategory,
+    global: &GovernanceConfig,
+) -> (u32, u32) {
+    let thresholds: Map<u32, CategoryThreshold> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::CategoryThresholds)
+        .unwrap_or_else(|| Map::new(env));
+
+    let key = category_to_key(category);
+    if let Some(t) = thresholds.get(key) {
+        let quorum = if t.quorum_bps > 0 {
+            t.quorum_bps
+        } else {
+            global.quorum_threshold
+        };
+        let approval = if t.supermajority_bps > 0 {
+            t.supermajority_bps
+        } else {
+            global.approval_threshold
+        };
+        (quorum, approval)
+    } else {
+        (global.quorum_threshold, global.approval_threshold)
+    }
+}
+
+/// Admin-callable: store per-category quorum and supermajority overrides.
+pub fn set_category_thresholds(
+    env: &Env,
+    admin: &Address,
+    category: ProposalCategory,
+    threshold: CategoryThreshold,
+) -> Result<(), GovernanceError> {
+    require_admin(env, admin)?;
+    if threshold.quorum_bps > 10_000 || threshold.supermajority_bps > 10_000 {
+        return Err(GovernanceError::InvalidGovernanceConfig);
+    }
+    let mut thresholds: Map<u32, CategoryThreshold> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::CategoryThresholds)
+        .unwrap_or_else(|| Map::new(env));
+    thresholds.set(category_to_key(&category), threshold);
+    env.storage()
+        .instance()
+        .set(&StorageKey::CategoryThresholds, &thresholds);
+    Ok(())
+}
+
+/// Read per-category thresholds for a given category (returns default if not set).
+pub fn get_category_threshold(env: &Env, category: &ProposalCategory) -> Option<CategoryThreshold> {
+    let thresholds: Map<u32, CategoryThreshold> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::CategoryThresholds)
+        .unwrap_or_else(|| Map::new(env));
+    thresholds.get(category_to_key(category))
+}
+
+fn category_to_key(category: &ProposalCategory) -> u32 {
+    match category {
+        ProposalCategory::ParameterChange => 0,
+        ProposalCategory::ContractUpgrade => 1,
+        ProposalCategory::TreasuryTransfer => 2,
+        ProposalCategory::General => 3,
+    }
 }


### PR DESCRIPTION


fee_collector — closes #690 (fee distribution waterfall):
- Add WaterfallTier and WaterfallConfig contracttype structs to storage.rs. Each tier carries a name, priority (ascending = funded first), target_amount (full allocation), minimum_amount (floor), and recipient.
- Add WaterfallTierResult for per-tier event data and PayoutCurrency for provider payout preferences.
- Add StorageKey::WaterfallConfig and StorageKey::ProviderPayoutCurrency(Address).
- Expose set_waterfall_config (admin), get_waterfall_config_fn, and distribute_waterfall on the contract.  distribute_waterfall bubble-sorts tiers by priority, funds each tier up to target_amount, falls back to minimum_amount when funds are tight, and skips tiers whose minimum cannot be met.  Emits waterfall_distribution event with per-tier allocations.

fee_collector — closes #691 (configurable settlement currency per provider):
- Expose set_payout_currency(provider, preferred_token) restricted to the provider themselves; clear_payout_currency and get_payout_currency helpers.
- claim_fees now checks for a stored payout preference.  When set and different from the source token, try_claim_in_preferred_currency attempts an oracle-mediated conversion via get_rate(from, to) → rate (scaled 1e6). On any failure (stale oracle, unsupported method, insufficient contract balance) it falls back silently to the original source-token settlement.
- Emits fees_claimed_converted on successful conversion; existing fees_claimed event is retained for the default path.

governance — closes #692 (per-proposal quadratic voting flag):
- Add isqrt(n: i128) integer square root function (Newton's method, no_std).
- Add use_quadratic_voting: bool and quadratic_total_supply: i128 fields to the Proposal struct.
- create_proposal now accepts use_quadratic_voting; when true it computes quadratic_total_supply = Σ floor(√staked) over all holders at snapshot time.
- cast_vote applies floor(√snapshotted_power) as the effective weight when use_quadratic_voting is set; the stored Vote.voting_power reflects the adjusted weight so tally queries are consistent.
- finalize_proposal uses quadratic_total_supply as the reference supply for quorum checks when the flag is set, ensuring the same scale as the cast votes.

governance — closes #693 (proposal category classification with per-category thresholds):
- Add ProposalCategory enum: ParameterChange, ContractUpgrade, TreasuryTransfer, General.
- Add CategoryThreshold struct: quorum_bps and supermajority_bps (0 = inherit global).
- Add StorageKey::CategoryThresholds and Map<u32, CategoryThreshold> storage.
- Add category: ProposalCategory field to Proposal struct; required at creation.
- set_category_thresholds (admin) / get_category_thresholds contract endpoints.
- finalize_proposal calls resolve_category_thresholds which returns per-category overrides when configured, falling back to global GovernanceConfig values. This makes quorum and approval thresholds differ correctly by category under identical vote counts.