### PR TITLE
feat: add shared utilities — emit_event! macro, sanitize_string, Expirable trait, priority queue (#675-#679)

### DIFF
--- a/stellar-swipe/contracts/auto_trade/src/lib.rs
+++ b/stellar-swipe/contracts/auto_trade/src/lib.rs
@@ -48,6 +48,8 @@ mod storage;
 pub mod storage;
 mod strategies;
 mod twap;
+/// Fee-aware execution priority queue (issue #675).
+pub mod priority_queue;
 
 pub use errors::AutoTradeError;
 pub use risk::RiskConfig;
@@ -2010,6 +2012,13 @@ impl AutoTradeContract {
     /// pause via `unpause_category`.
     pub fn trigger_inactivity_pause(env: Env, caller: Address) -> Result<(), AutoTradeError> {
         admin::trigger_inactivity_pause(&env, &caller)
+    }
+
+    /// Read-only snapshot of all pending auto-trade actions ordered by
+    /// execution priority (StopLoss > TakeProfit > Rebalance), then FIFO
+    /// within the same priority level.
+    pub fn get_queue_snapshot(env: Env) -> soroban_sdk::Vec<priority_queue::QueuedAction> {
+        priority_queue::get_queue_snapshot(&env)
     }
 }
 

--- a/stellar-swipe/contracts/auto_trade/src/priority_queue.rs
+++ b/stellar-swipe/contracts/auto_trade/src/priority_queue.rs
@@ -1,0 +1,127 @@
+use soroban_sdk::{contracttype, Env, Vec};
+
+/// Classification of an auto-trade trigger.  Higher priority values are
+/// processed first within a batch.  Within the same priority, actions are
+/// processed in FIFO order (by `enqueued_at`).
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TriggerType {
+    StopLoss,
+    TakeProfit,
+    Rebalance,
+}
+
+impl TriggerType {
+    pub fn priority(self) -> u32 {
+        match self {
+            TriggerType::StopLoss => 3,
+            TriggerType::TakeProfit => 2,
+            TriggerType::Rebalance => 1,
+        }
+    }
+}
+
+/// A single auto-trade action waiting for execution.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct QueuedAction {
+    /// Monotonically increasing identifier assigned at enqueue time.
+    pub id: u64,
+    /// What kind of trade this is (determines processing priority).
+    pub trigger: TriggerType,
+    /// The signal that triggered this action.
+    pub signal_id: u64,
+    /// Ledger timestamp when this action was enqueued (used for FIFO tiebreak).
+    pub enqueued_at: u64,
+}
+
+#[contracttype]
+enum QueueKey {
+    Actions,
+    NextId,
+}
+
+/// Add a new action to the priority queue.
+///
+/// The queue is kept in descending priority order.  Within the same priority
+/// the action is appended after all existing same-priority entries (FIFO).
+pub fn enqueue_action(env: &Env, trigger: TriggerType, signal_id: u64) -> u64 {
+    let next_id: u64 = env
+        .storage()
+        .instance()
+        .get(&QueueKey::NextId)
+        .unwrap_or(0u64);
+
+    let action = QueuedAction {
+        id: next_id,
+        trigger,
+        signal_id,
+        enqueued_at: env.ledger().timestamp(),
+    };
+
+    let queue: Vec<QueuedAction> = env
+        .storage()
+        .instance()
+        .get(&QueueKey::Actions)
+        .unwrap_or_else(|| Vec::new(env));
+
+    // Build a new vec inserting `action` at the correct priority position.
+    // Entries with strictly lower priority than `action` are shifted right;
+    // same-priority entries that are already present come before it (FIFO).
+    let mut sorted = Vec::new(env);
+    let mut inserted = false;
+    for i in 0..queue.len() {
+        let existing = queue.get(i).unwrap();
+        if !inserted && action.trigger.priority() > existing.trigger.priority() {
+            sorted.push_back(action.clone());
+            inserted = true;
+        }
+        sorted.push_back(existing);
+    }
+    if !inserted {
+        sorted.push_back(action);
+    }
+
+    env.storage().instance().set(&QueueKey::Actions, &sorted);
+    env.storage()
+        .instance()
+        .set(&QueueKey::NextId, &(next_id + 1));
+
+    next_id
+}
+
+/// Remove and return up to `limit` actions from the front of the queue
+/// (i.e. the highest-priority, earliest-enqueued actions).
+pub fn drain_priority_batch(env: &Env, limit: u32) -> Vec<QueuedAction> {
+    let queue: Vec<QueuedAction> = env
+        .storage()
+        .instance()
+        .get(&QueueKey::Actions)
+        .unwrap_or_else(|| Vec::new(env));
+
+    let take = limit.min(queue.len());
+    let mut batch = Vec::new(env);
+    let mut remaining = Vec::new(env);
+
+    for i in 0..queue.len() {
+        let entry = queue.get(i).unwrap();
+        if i < take {
+            batch.push_back(entry);
+        } else {
+            remaining.push_back(entry);
+        }
+    }
+
+    env.storage().instance().set(&QueueKey::Actions, &remaining);
+    batch
+}
+
+/// Read-only snapshot of all pending actions (highest priority first).
+///
+/// Intended for off-chain observability; does not mutate state.
+pub fn get_queue_snapshot(env: &Env) -> Vec<QueuedAction> {
+    env.storage()
+        .instance()
+        .get(&QueueKey::Actions)
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/stellar-swipe/contracts/common/src/emit.rs
+++ b/stellar-swipe/contracts/common/src/emit.rs
@@ -1,0 +1,29 @@
+/// Emit a contract event with a single-Symbol topic tuple.
+///
+/// Standardizes the pattern of constructing a 1-element topic tuple and
+/// calling `env.events().publish(...)` at every event call site.
+///
+/// # Usage
+///
+/// ```ignore
+/// // Instead of:
+/// let topics = (soroban_sdk::Symbol::new(env, "my_event"),);
+/// env.events().publish(topics, (field1, field2));
+///
+/// // Write:
+/// stellar_swipe_common::emit_event!(env, "my_event", (field1, field2));
+/// ```
+///
+/// The macro expands to a single `env.events().publish(...)` call with a
+/// 1-element topic tuple containing the given event name as a `Symbol`.
+///
+/// See `docs/emit_event_macro.md` for the full usage guide.
+#[macro_export]
+macro_rules! emit_event {
+    ($env:expr, $name:literal, $data:expr) => {
+        $env.events().publish(
+            (soroban_sdk::Symbol::new($env, $name),),
+            $data,
+        )
+    };
+}

--- a/stellar-swipe/contracts/common/src/lib.rs
+++ b/stellar-swipe/contracts/common/src/lib.rs
@@ -1,5 +1,11 @@
 #![no_std]
 
+/// Shared event-emission macro (issue #677).
+pub mod emit;
+/// Shared input-sanitization helper for string-based metadata fields (issue #676).
+pub mod sanitize;
+pub use sanitize::{sanitize_string, SanitizeError};
+
 #[allow(deprecated)]
 pub mod amm_bridge;
 pub mod retry_backoff;

--- a/stellar-swipe/contracts/common/src/sanitize.rs
+++ b/stellar-swipe/contracts/common/src/sanitize.rs
@@ -1,0 +1,32 @@
+use soroban_sdk::{Env, String};
+
+/// Errors returned by [`sanitize_string`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SanitizeError {
+    /// The UTF-8 byte length of the string exceeds the allowed maximum.
+    StringTooLong,
+    /// The string contains an ASCII control character (byte value 0x00–0x1F).
+    ControlCharacterFound,
+}
+
+/// Validate a soroban `String` field for safe use in on-chain metadata.
+///
+/// Checks:
+/// - Byte length ≤ `max_len`.
+/// - No ASCII control characters (bytes 0x00–0x1F) present.
+///
+/// Call sites should map the returned [`SanitizeError`] to their own
+/// `ContractError` variant (e.g. `InvalidInput` or `InvalidProposal`).
+pub fn sanitize_string(_env: &Env, value: &String, max_len: u32) -> Result<(), SanitizeError> {
+    let bytes = value.to_bytes();
+    let len = bytes.len();
+    if len > max_len {
+        return Err(SanitizeError::StringTooLong);
+    }
+    for i in 0..len {
+        if bytes.get(i).unwrap() < 0x20 {
+            return Err(SanitizeError::ControlCharacterFound);
+        }
+    }
+    Ok(())
+}

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Map, String, Vec};
-use stellar_swipe_common::Asset;
+use stellar_swipe_common::{sanitize_string, Asset};
 
 use crate::{
     add_balance, checked_add, checked_mul, checked_sub, get_holders, get_staked_balance,
@@ -262,6 +262,8 @@ pub fn create_proposal(
     if title.is_empty() || description.is_empty() {
         return Err(GovernanceError::InvalidProposal);
     }
+    sanitize_string(env, &title, 256).map_err(|_| GovernanceError::InvalidProposal)?;
+    sanitize_string(env, &description, 4096).map_err(|_| GovernanceError::InvalidProposal)?;
 
     let config = get_governance_config(env);
     let power = get_effective_voting_power(env, &proposer);

--- a/stellar-swipe/contracts/oracle/src/events.rs
+++ b/stellar-swipe/contracts/oracle/src/events.rs
@@ -3,9 +3,10 @@ use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
 use crate::staleness::OracleStatus;
 
 pub fn emit_oracle_removed(env: &Env, oracle: Address, reason: &str) {
-    env.events().publish(
-        (Symbol::new(env, "oracle_removed"),),
-        (oracle, String::from_str(env, reason)),
+    stellar_swipe_common::emit_event!(
+        env,
+        "oracle_removed",
+        (oracle, String::from_str(env, reason))
     );
 }
 
@@ -16,9 +17,10 @@ pub fn emit_weight_adjusted(
     new_weight: u32,
     reputation: u32,
 ) {
-    env.events().publish(
-        (Symbol::new(env, "oracle_weight_adjusted"),),
-        (oracle, old_weight, new_weight, reputation),
+    stellar_swipe_common::emit_event!(
+        env,
+        "oracle_weight_adjusted",
+        (oracle, old_weight, new_weight, reputation)
     );
 }
 

--- a/stellar-swipe/contracts/shared/src/expiry.rs
+++ b/stellar-swipe/contracts/shared/src/expiry.rs
@@ -1,0 +1,31 @@
+/// Trait for values that carry a timestamp-based expiry.
+///
+/// Boundary semantics: a value is expired when `current_ledger_time` is
+/// **strictly greater** than `expiry_timestamp()`.  At the exact expiry
+/// second the value is still considered live (exclusive upper bound).
+///
+/// # Example
+///
+/// ```ignore
+/// impl Expirable for MyStruct {
+///     fn expiry_timestamp(&self) -> u64 {
+///         self.expires_at
+///     }
+/// }
+///
+/// if record.is_expired(env.ledger().timestamp()) {
+///     // handle expiry
+/// }
+/// ```
+pub trait Expirable {
+    /// The ledger timestamp (Unix seconds) at which this value expires.
+    fn expiry_timestamp(&self) -> u64;
+
+    /// Returns `true` when `current_ledger_time > expiry_timestamp()`.
+    ///
+    /// At the exact expiry second (`current_ledger_time == expiry_timestamp()`)
+    /// the value is **not** yet expired.
+    fn is_expired(&self, current_ledger_time: u64) -> bool {
+        current_ledger_time > self.expiry_timestamp()
+    }
+}

--- a/stellar-swipe/contracts/shared/src/lib.rs
+++ b/stellar-swipe/contracts/shared/src/lib.rs
@@ -1,5 +1,9 @@
 #![no_std]
 
+/// Shared timestamp-based expiry trait (issue #679).
+pub mod expiry;
+pub use expiry::Expirable;
+
 pub mod access_control;
 
 pub mod auth;

--- a/stellar-swipe/contracts/signal_registry/src/events.rs
+++ b/stellar-swipe/contracts/signal_registry/src/events.rs
@@ -17,13 +17,11 @@ pub fn emit_admin_transfer_proposed(
 }
 
 pub fn emit_admin_transfer_completed(env: &Env, old_admin: Address, new_admin: Address) {
-    let topics = (Symbol::new(env, "admin_transfer_completed"),);
-    env.events().publish(topics, (old_admin, new_admin));
+    stellar_swipe_common::emit_event!(env, "admin_transfer_completed", (old_admin, new_admin));
 }
 
 pub fn emit_admin_transferred(env: &Env, old_admin: Address, new_admin: Address) {
-    let topics = (Symbol::new(env, "admin_transferred"),);
-    env.events().publish(topics, (old_admin, new_admin));
+    stellar_swipe_common::emit_event!(env, "admin_transferred", (old_admin, new_admin));
 }
 
 pub fn emit_parameter_updated(env: &Env, parameter: Symbol, old_value: i128, new_value: i128) {

--- a/stellar-swipe/contracts/signal_registry/src/expiry.rs
+++ b/stellar-swipe/contracts/signal_registry/src/expiry.rs
@@ -4,6 +4,8 @@ use stellar_swipe_common::{SECONDS_PER_30_DAY_MONTH, SECONDS_PER_DAY};
 use crate::events::emit_signal_expired;
 use crate::types::{Signal, SignalStatus};
 
+use shared::Expirable;
+
 pub const DEFAULT_EXPIRY_SECONDS: u64 = SECONDS_PER_DAY; // 24 hours
 pub const MAX_CLEANUP_BATCH_SIZE: u32 = 100; // Process max 100 signals per cleanup call
 pub const ARCHIVE_THRESHOLD_SECONDS: u64 = SECONDS_PER_30_DAY_MONTH; // 30 days
@@ -14,10 +16,19 @@ pub struct CleanupResult {
     pub signals_expired: u32,
 }
 
-/// Check if a signal has expired based on current time
+impl Expirable for Signal {
+    fn expiry_timestamp(&self) -> u64 {
+        self.expiry
+    }
+}
+
+/// Check if a signal has expired based on current ledger time.
+///
+/// Delegates to the shared [`Expirable`] trait implementation on [`Signal`].
+/// Boundary: `current_time > signal.expiry` (exclusive — at the exact
+/// expiry second the signal is still considered live).
 pub fn is_expired(env: &Env, signal: &Signal) -> bool {
-    let current_time = env.ledger().timestamp();
-    current_time > signal.expiry
+    signal.is_expired(env.ledger().timestamp())
 }
 
 /// Check if signal should be archived (expired for more than 30 days)

--- a/stellar-swipe/contracts/signal_registry/src/submission.rs
+++ b/stellar-swipe/contracts/signal_registry/src/submission.rs
@@ -4,6 +4,7 @@ use crate::validation::{
     check_duplicate_signal, check_price_reasonableness, validate_rationale_hash_string,
 };
 use soroban_sdk::{contracttype, Address, Env, Map, String};
+use stellar_swipe_common::sanitize_string;
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -72,11 +73,11 @@ pub fn submit_signal(
         return Err(Error::InvalidPrice);
     }
 
-    // Validate rationale
-    let rationale_len = rationale.to_bytes().len();
-    if rationale_len == 0 || rationale_len > 500 {
+    // Validate rationale: non-empty, max 500 bytes, no control characters.
+    if rationale.to_bytes().len() == 0 {
         return Err(Error::EmptyRationale);
     }
+    sanitize_string(env, &rationale, 500).map_err(|_| Error::EmptyRationale)?;
 
     // Validate rationale hash (must be present and not all zeros)
     validate_rationale_hash_string(env, &rationale_hash).map_err(|e| match e {

--- a/stellar-swipe/docs/emit_event_macro.md
+++ b/stellar-swipe/docs/emit_event_macro.md
@@ -1,0 +1,72 @@
+# `emit_event!` macro — usage guide
+
+The `emit_event!` macro, defined in `stellar_swipe_common::emit`, provides a
+single, consistent way to publish Soroban contract events across all crates in
+this workspace.
+
+## Motivation
+
+Every contract previously hand-wrote a 2-step topic-construction + publish
+pattern at each call site:
+
+```rust
+// Before (repeated at every event site)
+let topics = (Symbol::new(env, "admin_transfer_completed"),);
+env.events().publish(topics, (old_admin, new_admin));
+```
+
+Inconsistencies crept in (trailing commas in topic tuples, stray `let topics`
+bindings, mixed `symbol_short!` / `Symbol::new` usage).  The macro enforces a
+uniform 1-element topic tuple for all standard events.
+
+## Syntax
+
+```rust
+stellar_swipe_common::emit_event!(env, "event_name", data_payload);
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `env` | `&Env` or `Env` expression | The Soroban environment reference |
+| `"event_name"` | string literal | Event name; becomes a `Symbol` topic |
+| `data_payload` | any `contracttype`-serialisable value | Event body (tuple, struct, scalar, …) |
+
+## Expansion
+
+```rust
+env.events().publish(
+    (soroban_sdk::Symbol::new(env, "event_name"),),
+    data_payload,
+)
+```
+
+## Examples
+
+```rust
+// Single-field payload
+stellar_swipe_common::emit_event!(env, "guardian_set", guardian_address);
+
+// Tuple payload
+stellar_swipe_common::emit_event!(
+    env,
+    "admin_transfer_completed",
+    (old_admin, new_admin)
+);
+
+// Struct payload (must derive #[contracttype])
+stellar_swipe_common::emit_event!(env, "fee_collected", fee_event_struct);
+```
+
+## When to use
+
+Use `emit_event!` for every new event that uses a single-Symbol topic.  For
+legacy events that already use `symbol_short!` or multi-Symbol topics (e.g.
+`(symbol_short!("gov"), symbol_short!("propnew"))`), leave them as-is until a
+planned migration is scheduled.
+
+## Reference implementations
+
+- `signal_registry::events::emit_admin_transfer_completed`
+- `signal_registry::events::emit_admin_transferred`
+- `oracle::events::emit_oracle_removed`
+- `oracle::events::emit_weight_adjusted`


### PR DESCRIPTION
## Summary

- **closes #675 ** — Fee-aware execution priority queue (`auto_trade/src/priority_queue.rs`): `TriggerType` with priority ordering (`StopLoss=3 > TakeProfit=2 > Rebalance=1`), `QueuedAction` struct, and `enqueue_action` / `drain_priority_batch` / `get_queue_snapshot` helpers. Exposed via `AutoTradeContract::get_queue_snapshot`.
- **closes #676  ** — `sanitize_string` helper (`common/src/sanitize.rs`): validates max byte length and rejects ASCII control characters. Adopted in `signal_registry/submission.rs` and `governance/proposals.rs`.
- **closes #677 ** — `emit_event!` macro (`common/src/emit.rs`): standardises single-Symbol topic tuple event publishing across contracts. Adopted in `signal_registry/events.rs` and `oracle/events.rs`. Usage guide added at `docs/emit_event_macro.md`.
- **closes #679 ** — `Expirable` trait (`shared/src/expiry.rs`): timestamp-based expiry with `is_expired(current_ledger_time)` default method. `Signal` in `signal_registry/expiry.rs` now implements it and delegates `is_expired` calls through the trait.

## Test plan

- [ ] `cargo build -p stellar-swipe-auto-trade` compiles without errors
- [ ] `cargo build -p stellar-swipe-common` compiles without errors
- [ ] `cargo build -p stellar-swipe-shared` compiles without errors
- [ ] `cargo build -p stellar-swipe-signal-registry` compiles without errors
- [ ] `cargo test -p stellar-swipe-signal-registry` — `expiry` module unit tests pass (is_expired, check_and_update_expiry, get_active_signals, should_archive, count_* helpers)
- [ ] `cargo test -p stellar-swipe-auto-trade` — existing test suites unaffected
