### PR TITLE
feat: drawdown trigger, discussion period, bridge nonce tracking and chain allowlist (#667-#669-#674)

### DIFF
--- a/stellar-swipe/contracts/auto_trade/src/drawdown.rs
+++ b/stellar-swipe/contracts/auto_trade/src/drawdown.rs
@@ -1,0 +1,173 @@
+//! Portfolio drawdown trigger (Issue #674).
+//!
+//! Tracks a per-user high-water mark and fires a configurable action when the
+//! current portfolio value drops more than a threshold below that mark.
+
+#![allow(dead_code)]
+
+use soroban_sdk::{contracttype, Address, Env, Symbol};
+
+use crate::errors::AutoTradeError;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Action taken when the drawdown threshold is breached.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DrawdownAction {
+    /// Close all open positions for the user.
+    ClosePositions,
+    /// Pause copy-trading for the user.
+    PauseCopying,
+}
+
+/// Per-user drawdown trigger configuration.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DrawdownTrigger {
+    /// Enabled flag; when false no action fires.
+    pub enabled: bool,
+    /// Drawdown threshold in basis points (e.g. 1000 = 10 %).
+    pub threshold_bps: u32,
+    /// Action to execute when threshold is breached.
+    pub action: DrawdownAction,
+}
+
+/// Per-user high-water mark state.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HighWaterMark {
+    /// The highest portfolio value (scaled ×10^7) observed for this user.
+    pub peak_value: i128,
+    /// Ledger timestamp of the last update.
+    pub updated_at: u64,
+}
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DrawdownKey {
+    /// Per-user high-water mark.
+    HighWaterMark(Address),
+    /// Per-user drawdown trigger configuration.
+    Trigger(Address),
+}
+
+// ── Storage helpers ───────────────────────────────────────────────────────────
+
+pub fn get_high_water_mark(env: &Env, user: &Address) -> Option<HighWaterMark> {
+    env.storage()
+        .persistent()
+        .get(&DrawdownKey::HighWaterMark(user.clone()))
+}
+
+pub fn set_high_water_mark(env: &Env, user: &Address, hwm: &HighWaterMark) {
+    env.storage()
+        .persistent()
+        .set(&DrawdownKey::HighWaterMark(user.clone()), hwm);
+}
+
+pub fn get_drawdown_trigger(env: &Env, user: &Address) -> Option<DrawdownTrigger> {
+    env.storage()
+        .persistent()
+        .get(&DrawdownKey::Trigger(user.clone()))
+}
+
+pub fn set_drawdown_trigger_config(env: &Env, user: &Address, trigger: &DrawdownTrigger) {
+    env.storage()
+        .persistent()
+        .set(&DrawdownKey::Trigger(user.clone()), trigger);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Configure the drawdown trigger for `user`.
+pub fn configure_drawdown_trigger(
+    env: &Env,
+    user: &Address,
+    threshold_bps: u32,
+    action: DrawdownAction,
+) -> Result<DrawdownTrigger, AutoTradeError> {
+    if threshold_bps == 0 || threshold_bps > 10_000 {
+        return Err(AutoTradeError::InvalidAmount);
+    }
+    let trigger = DrawdownTrigger {
+        enabled: true,
+        threshold_bps,
+        action,
+    };
+    set_drawdown_trigger_config(env, user, &trigger);
+    Ok(trigger)
+}
+
+/// Update the high-water mark with `current_value` and check whether the
+/// drawdown trigger fires.
+///
+/// Returns `Some(action)` if the threshold was breached and the trigger is
+/// enabled, `None` otherwise.
+pub fn update_and_check(
+    env: &Env,
+    user: &Address,
+    current_value: i128,
+) -> Result<Option<DrawdownAction>, AutoTradeError> {
+    if current_value < 0 {
+        return Err(AutoTradeError::InvalidAmount);
+    }
+    let now = env.ledger().timestamp();
+    let mut hwm = get_high_water_mark(env, user).unwrap_or(HighWaterMark {
+        peak_value: current_value,
+        updated_at: now,
+    });
+
+    if current_value > hwm.peak_value {
+        hwm.peak_value = current_value;
+        hwm.updated_at = now;
+        set_high_water_mark(env, user, &hwm);
+        env.events().publish(
+            (Symbol::new(env, "hwm_updated"), user.clone()),
+            (hwm.peak_value, now),
+        );
+        return Ok(None);
+    }
+
+    set_high_water_mark(env, user, &hwm);
+
+    let trigger = match get_drawdown_trigger(env, user) {
+        Some(t) if t.enabled => t,
+        _ => return Ok(None),
+    };
+
+    if is_drawdown_breached(hwm.peak_value, current_value, trigger.threshold_bps) {
+        env.events().publish(
+            (Symbol::new(env, "drawdown_triggered"), user.clone()),
+            (hwm.peak_value, current_value, trigger.threshold_bps, now),
+        );
+        return Ok(Some(trigger.action));
+    }
+
+    Ok(None)
+}
+
+/// Pure check: is `current_value` below `peak_value * (1 - threshold_bps/10000)`?
+pub fn is_drawdown_breached(peak_value: i128, current_value: i128, threshold_bps: u32) -> bool {
+    if peak_value <= 0 {
+        return false;
+    }
+    // current_value * 10000 < peak_value * (10000 - threshold_bps)
+    let lhs = current_value.saturating_mul(10_000);
+    let rhs = peak_value.saturating_mul((10_000i128 - threshold_bps as i128).max(0));
+    lhs < rhs
+}
+
+/// Check if the drawdown trigger fires for `user` at `current_value` without
+/// updating the high-water mark (read-only evaluation).
+pub fn check_drawdown_trigger(env: &Env, user: &Address, current_value: i128) -> bool {
+    let trigger = match get_drawdown_trigger(env, user) {
+        Some(t) if t.enabled => t,
+        _ => return false,
+    };
+    match get_high_water_mark(env, user) {
+        Some(hwm) => is_drawdown_breached(hwm.peak_value, current_value, trigger.threshold_bps),
+        None => false,
+    }
+}

--- a/stellar-swipe/contracts/auto_trade/src/lib.rs
+++ b/stellar-swipe/contracts/auto_trade/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Sy
 
 mod admin;
 mod advanced_risk;
+mod drawdown;
 mod loss_streak;
 #[cfg(feature = "testutils")]
 pub mod amm_bridge;
@@ -1548,6 +1549,48 @@ impl AutoTradeContract {
         user: Address,
     ) -> Option<portfolio_insurance::PortfolioInsurance> {
         portfolio_insurance::get_insurance(&env, &user)
+    }
+
+    // ── Drawdown trigger (Issue #674) ─────────────────────────────────────────
+
+    /// Configure a drawdown trigger for the user.
+    /// `threshold_bps` is the drop from peak (in basis points, e.g. 1000 = 10%).
+    /// When breached, `action` is returned by `update_portfolio_value`.
+    pub fn configure_drawdown_trigger(
+        env: Env,
+        user: Address,
+        threshold_bps: u32,
+        action: drawdown::DrawdownAction,
+    ) -> Result<drawdown::DrawdownTrigger, AutoTradeError> {
+        if !cfg!(test) {
+            user.require_auth();
+        }
+        drawdown::configure_drawdown_trigger(&env, &user, threshold_bps, action)
+    }
+
+    /// Update the per-user high-water mark with the latest `current_value` and
+    /// check whether the drawdown threshold is breached.
+    ///
+    /// Returns `Some(action)` when the trigger fires.
+    pub fn update_portfolio_value(
+        env: Env,
+        user: Address,
+        current_value: i128,
+    ) -> Result<Option<drawdown::DrawdownAction>, AutoTradeError> {
+        if !cfg!(test) {
+            user.require_auth();
+        }
+        drawdown::update_and_check(&env, &user, current_value)
+    }
+
+    /// Read-only: check if the drawdown trigger fires for `user` at `current_value`.
+    pub fn check_drawdown_trigger(env: Env, user: Address, current_value: i128) -> bool {
+        drawdown::check_drawdown_trigger(&env, &user, current_value)
+    }
+
+    /// Return the stored high-water mark for `user`.
+    pub fn get_high_water_mark(env: Env, user: Address) -> Option<drawdown::HighWaterMark> {
+        drawdown::get_high_water_mark(&env, &user)
     }
 
     // ── Exit Strategy ────────────────────────────────────────────────────────

--- a/stellar-swipe/contracts/bridge/src/lib.rs
+++ b/stellar-swipe/contracts/bridge/src/lib.rs
@@ -31,6 +31,12 @@ pub enum BridgeError {
     /// Distinct from DailyLimitExceeded (static anti-spam) so callers can differentiate.
     DynamicLiquidityLimitExceeded = 15,
     InvalidThreshold = 16,
+    /// Destination chain is not on the admin-managed allowlist (Issue #669).
+    UnsupportedDestinationChain = 17,
+    /// Message nonce is out of order; earlier messages must be confirmed first (Issue #668).
+    OutOfOrderNonce = 18,
+    /// Message nonce was already confirmed; duplicate delivery rejected (Issue #668).
+    DuplicateNonce = 19,
 }
 
 #[contracttype]
@@ -125,6 +131,8 @@ pub enum DataKey {
     LiquidityBuffer,
     TotalMinted,
     ReserveThreshold,
+    /// Admin-managed set of supported destination chain IDs (Issue #669).
+    SupportedChains,
 }
 
 const DAY_SECONDS: u64 = 86_400;
@@ -261,6 +269,8 @@ impl BridgeContract {
         if !cfg!(test) {
             user.require_auth();
         }
+        // ── #669: allowlist check ─────────────────────────────────────────────
+        ensure_chain_allowed(&env, destination_chain)?;
         validate_amount_and_limits(&env, amount)?;
         ensure_wrapped_asset_exists(&env, wrapped_asset.clone())?;
 
@@ -408,6 +418,8 @@ impl BridgeContract {
         if !cfg!(test) {
             user.require_auth();
         }
+        // ── #669: allowlist check ─────────────────────────────────────────────
+        ensure_chain_allowed(&env, destination_chain)?;
         validate_amount_and_limits(&env, amount)?;
 
         let balance_key = DataKey::WrappedBalance(user.clone(), wrapped_asset.clone());
@@ -716,6 +728,71 @@ impl BridgeContract {
     pub fn get_liquidity_buffer(env: Env) -> i128 {
         env.storage().persistent().get(&DataKey::LiquidityBuffer).unwrap_or(i128::MAX)
     }
+
+    // ── #669: Destination-chain allowlist ─────────────────────────────────────
+
+    /// Admin: add `chain` to the supported destination-chain allowlist.
+    pub fn add_supported_chain(env: Env, admin: Address, chain: ChainId) -> Result<(), BridgeError> {
+        require_admin(&env, &admin)?;
+        if !cfg!(test) {
+            admin.require_auth();
+        }
+        let mut chains = load_supported_chains(&env);
+        for i in 0..chains.len() {
+            if chains.get(i) == Some(chain) {
+                return Ok(());
+            }
+        }
+        chains.push_back(chain);
+        env.storage().instance().set(&DataKey::SupportedChains, &chains);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "chain_added"),),
+            chain as u32,
+        );
+        Ok(())
+    }
+
+    /// Admin: remove `chain` from the supported destination-chain allowlist.
+    pub fn remove_supported_chain(env: Env, admin: Address, chain: ChainId) -> Result<(), BridgeError> {
+        require_admin(&env, &admin)?;
+        if !cfg!(test) {
+            admin.require_auth();
+        }
+        let chains = load_supported_chains(&env);
+        let mut updated: Vec<ChainId> = Vec::new(&env);
+        for i in 0..chains.len() {
+            if let Some(c) = chains.get(i) {
+                if c != chain {
+                    updated.push_back(c);
+                }
+            }
+        }
+        env.storage().instance().set(&DataKey::SupportedChains, &updated);
+        #[allow(deprecated)]
+        env.events().publish(
+            (Symbol::new(&env, "chain_removed"),),
+            chain as u32,
+        );
+        Ok(())
+    }
+
+    /// Return the current destination-chain allowlist.
+    pub fn get_supported_chains(env: Env) -> Vec<ChainId> {
+        load_supported_chains(&env)
+    }
+
+    // ── #668: Message nonce read-only entrypoint ───────────────────────────────
+
+    /// Return the next expected delivery-confirmation nonce for `source_chain_id`.
+    /// `source_chain_id` is the numeric value of `monitoring::ChainId`
+    /// (Stellar=0, Ethereum=1, Bitcoin=2, Polygon=3, BNB=4).
+    pub fn get_expected_nonce(env: Env, source_chain_id: u32) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&messaging::MessagingKey::ExpectedNonce(source_chain_id))
+            .unwrap_or(0u64)
+    }
 }
 
 fn get_config(env: &Env) -> Result<BridgeConfig, BridgeError> {
@@ -744,6 +821,29 @@ fn store_transfer(env: &Env, transfer: &BridgeTransfer) {
     env.storage()
         .persistent()
         .set(&DataKey::Transfer(transfer.id), transfer);
+}
+
+/// Retrieve the current destination-chain allowlist.
+fn load_supported_chains(env: &Env) -> Vec<ChainId> {
+    env.storage()
+        .instance()
+        .get(&DataKey::SupportedChains)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Return `Ok(())` when `destination_chain` is on the allowlist, or when the
+/// allowlist is empty (not yet configured). Returns `Err` otherwise.
+fn ensure_chain_allowed(env: &Env, destination_chain: ChainId) -> Result<(), BridgeError> {
+    let chains = load_supported_chains(env);
+    if chains.is_empty() {
+        return Ok(());
+    }
+    for i in 0..chains.len() {
+        if chains.get(i) == Some(destination_chain) {
+            return Ok(());
+        }
+    }
+    Err(BridgeError::UnsupportedDestinationChain)
 }
 
 fn ensure_wrapped_asset_exists(env: &Env, wrapped_asset: String) -> Result<(), BridgeError> {

--- a/stellar-swipe/contracts/bridge/src/messaging.rs
+++ b/stellar-swipe/contracts/bridge/src/messaging.rs
@@ -41,6 +41,8 @@ pub struct CrossChainMessage {
     pub status: MessageStatus,
     pub sent_at: u64,
     pub delivered_at: Option<u64>,
+    /// Monotonically increasing sequence number per target chain (Issue #668).
+    pub nonce: u64,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
@@ -50,9 +52,35 @@ pub enum MessagingKey {
     Message(u64),
     NextMessageId,
     BridgeForChain(u32),
+    /// Monotonically assigned outbound sequence counter per target chain (Issue #668).
+    OutboundSeq(u32),
+    /// Next expected delivery-confirmation nonce per target chain (Issue #668).
+    ExpectedNonce(u32),
 }
 
 // ── Storage helpers ───────────────────────────────────────────────────────────
+
+/// Return the next expected delivery-confirmation nonce for `chain` (Issue #668).
+/// Messages to `chain` must be confirmed in this sequence order.
+pub fn get_expected_nonce(env: &Env, chain: ChainId) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&MessagingKey::ExpectedNonce(chain as u32))
+        .unwrap_or(0u64)
+}
+
+/// Assign the next outbound sequence number for messages sent to `chain`.
+fn assign_outbound_nonce(env: &Env, chain: ChainId) -> u64 {
+    let seq: u64 = env
+        .storage()
+        .persistent()
+        .get(&MessagingKey::OutboundSeq(chain as u32))
+        .unwrap_or(0u64);
+    env.storage()
+        .persistent()
+        .set(&MessagingKey::OutboundSeq(chain as u32), &(seq + 1));
+    seq
+}
 
 fn get_message(env: &Env, id: u64) -> Result<CrossChainMessage, String> {
     env.storage()
@@ -148,6 +176,7 @@ pub fn send_cross_chain_message(
     }
 
     let id = next_message_id(env);
+    let nonce = assign_outbound_nonce(env, target_chain);
 
     let msg = CrossChainMessage {
         id,
@@ -161,6 +190,7 @@ pub fn send_cross_chain_message(
         status: MessageStatus::Pending,
         sent_at: env.ledger().timestamp(),
         delivered_at: None,
+        nonce,
     };
 
     save_message(env, &msg);
@@ -224,6 +254,21 @@ pub fn confirm_message_delivery(
     if msg.status != MessageStatus::Relayed {
         return Err(String::from_str(env, "Message not relayed"));
     }
+
+    // ── #668: enforce in-order delivery ──────────────────────────────────────
+    // Deliveries for a given target chain must be confirmed in the same order
+    // messages were sent (nonce 0, 1, 2, …).
+    let expected = get_expected_nonce(env, msg.target_chain);
+    if msg.nonce != expected {
+        if msg.nonce < expected {
+            return Err(String::from_str(env, "Duplicate nonce: already delivered"));
+        }
+        return Err(String::from_str(env, "Out-of-order nonce: expected lower sequence"));
+    }
+    // Advance the expected delivery nonce for this target chain.
+    env.storage()
+        .persistent()
+        .set(&MessagingKey::ExpectedNonce(msg.target_chain as u32), &(expected + 1));
 
     verify_delivery_proof(env, msg.target_chain, message_id, &delivery_proof)?;
 

--- a/stellar-swipe/contracts/governance/src/errors.rs
+++ b/stellar-swipe/contracts/governance/src/errors.rs
@@ -70,4 +70,6 @@ impl GovernanceError {
     pub const ContractPaused: GovernanceError = GovernanceError::Unauthorized;
     pub const InvalidCalibrationConfig: GovernanceError = GovernanceError::InvalidGovernanceConfig;
     pub const IterationLimitExceeded: GovernanceError = GovernanceError::InvalidCommitteeAction;
+    /// Vote rejected because the mandatory discussion window has not yet elapsed (Issue #667).
+    pub const DiscussionPeriodActive: GovernanceError = GovernanceError::VotingNotStarted;
 }

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -109,6 +109,9 @@ pub struct Proposal {
     pub voters: Map<Address, Vote>,
     pub voter_list: Vec<Address>,
     pub executed_at: Option<u64>,
+    // ── #667: Mandatory discussion period ────────────────────────────────────
+    /// Timestamp after which votes are accepted. Zero means no discussion window.
+    pub discussion_ends_at: u64,
     // ── #693: Category classification ────────────────────────────────────────
     /// Category used to select per-category quorum/supermajority thresholds.
     pub category: ProposalCategory,
@@ -130,6 +133,9 @@ pub struct GovernanceConfig {
     pub quorum_threshold: u32,
     pub approval_threshold: u32,
     pub execution_delay: u64,
+    /// Mandatory discussion window (seconds) before votes can be cast (Issue #667).
+    /// A value of 0 disables the discussion period.
+    pub discussion_duration: u64,
 }
 
 #[contracttype]
@@ -178,6 +184,7 @@ pub fn default_governance_config() -> GovernanceConfig {
         quorum_threshold: 1_000,
         approval_threshold: 5_000,
         execution_delay: 0,
+        discussion_duration: 0,
     }
 }
 
@@ -296,6 +303,12 @@ pub fn create_proposal(
     put_vote_snapshots(env, id, &snapshots);
     let now = env.ledger().timestamp();
 
+    let discussion_ends_at = if config.discussion_duration > 0 {
+        now.saturating_add(config.discussion_duration)
+    } else {
+        0
+    };
+
     let proposal = Proposal {
         id,
         proposer: proposer.clone(),
@@ -314,6 +327,7 @@ pub fn create_proposal(
         voters: Map::new(env),
         voter_list: Vec::new(env),
         executed_at: None,
+        discussion_ends_at,
         category,
         use_quadratic_voting,
         quadratic_total_supply,
@@ -327,7 +341,13 @@ pub fn create_proposal(
     #[allow(deprecated)]
     env.events().publish(
         (symbol_short!("gov"), symbol_short!("propnew")),
-        (id, proposer, proposal.voting_starts, proposal.voting_ends),
+        (
+            id,
+            proposer,
+            proposal.discussion_ends_at,
+            proposal.voting_starts,
+            proposal.voting_ends,
+        ),
     );
 
     Ok(id)
@@ -359,6 +379,21 @@ pub fn cast_vote(
     voter.require_auth();
     let mut proposal = get_proposal(env, proposal_id)?;
     let now = env.ledger().timestamp();
+
+    // ── #667: Enforce discussion period ──────────────────────────────────────
+    if proposal.discussion_ends_at > 0 && now < proposal.discussion_ends_at {
+        return Err(GovernanceError::DiscussionPeriodActive);
+    }
+
+    // Emit a one-time event when the proposal first transitions out of the
+    // discussion phase (voter_list is still empty on the first accepted vote).
+    if proposal.discussion_ends_at > 0 && proposal.voter_list.is_empty() {
+        #[allow(deprecated)]
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("discend")),
+            (proposal_id, proposal.discussion_ends_at, now),
+        );
+    }
 
     if now < proposal.voting_starts {
         return Err(GovernanceError::VotingNotStarted);

--- a/stellar-swipe/contracts/governance/src/test.rs
+++ b/stellar-swipe/contracts/governance/src/test.rs
@@ -824,6 +824,7 @@ fn timelock_queue_execute_and_cancel_flow() {
         quorum_threshold: 1_000,
         approval_threshold: 5_000,
         execution_delay: 60,
+        discussion_duration: 0,
     };
     client.configure_governance(&admin, &cfg);
     client.initialize_timelock(&admin, &3_600u64, &(7 * 86_400u64), &admin);
@@ -879,6 +880,7 @@ fn queue_underfunded_treasury_spend_action(
         quorum_threshold: 1_000,
         approval_threshold: 5_000,
         execution_delay: 60,
+        discussion_duration: 0,
     };
     client.configure_governance(admin, &cfg);
     client.initialize_timelock(admin, &3_600u64, &(7 * 86_400u64), admin);

--- a/stellar-swipe/contracts/governance/src/test_pause_propagation.rs
+++ b/stellar-swipe/contracts/governance/src/test_pause_propagation.rs
@@ -67,6 +67,7 @@ fn prevent_auto_execution(c: &GovernanceContractClient<'_>, admin: &Address) {
             quorum_threshold: 1_000,
             approval_threshold: 5_000,
             execution_delay: 3_600,
+            discussion_duration: 0,
         },
     );
 }


### PR DESCRIPTION
## Summary

Implements four independent features across three contracts:

- **Issue #674 — auto_trade: Portfolio drawdown trigger**
  - New `drawdown.rs` module with `HighWaterMark`, `DrawdownTrigger`, and `DrawdownAction` types
  - Per-user HWM updated on every `update_portfolio_value` call; emits `hwm_updated` event on new highs and `drawdown_triggered` when threshold is breached
  - Configurable threshold in basis points; action is either `ClosePositions` or `PauseCopying`
  - New entrypoints: `configure_drawdown_trigger`, `update_portfolio_value`, `check_drawdown_trigger`, `get_high_water_mark`

- **Issue #667 — governance: Mandatory discussion period before voting**
  - `GovernanceConfig` gains `discussion_duration: u64` (default 0, backward-compatible)
  - `Proposal` gains `discussion_ends_at: u64` set at creation time
  - `cast_vote` returns `DiscussionPeriodActive` (alias for `VotingNotStarted`) if called before the window ends
  - Emits `gov/discend` event when the first vote is cast after discussion ends
  - Updated all direct `GovernanceConfig` struct constructions in tests

- **Issue #668 — bridge: Message ordering with nonce tracking**
  - `CrossChainMessage` gets a `nonce: u64` field assigned at send time via per-target-chain `OutboundSeq` counter
  - `confirm_message_delivery` enforces in-order delivery via `ExpectedNonce` per target chain; rejects duplicates and out-of-order messages with descriptive string errors
  - New `get_expected_nonce(source_chain_id: u32)` read-only contract entrypoint

- **Issue #669 — bridge: Destination-chain allowlist for withdrawals**
  - New `DataKey::SupportedChains` storing `Vec<ChainId>` in instance storage
  - `add_supported_chain` / `remove_supported_chain` admin entrypoints with events
  - `get_supported_chains` read-only entrypoint
  - `initiate_lock_mint` and `initiate_burn_unlock` reject unsupported chains with `BridgeError::UnsupportedDestinationChain`; empty allowlist is permissive for backward compatibility

## Closes

Closes #667 
closes #668 
closes #669 
closes #674 

