### PR TITLE
feat: implement oracle SLA monitoring, deviation alerts, cohort retention, and TVL tracking

### DIFF
--- a/stellar-swipe/contracts/analytics/src/lib.rs
+++ b/stellar-swipe/contracts/analytics/src/lib.rs
@@ -6,6 +6,9 @@
 //! deltas against the previous snapshot, emits a `WeeklyHealthReport` event, then
 //! rotates current → previous for next week's comparison.
 
+// Closes #673 — real-time TVL tracking
+pub mod tvl;
+
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
 use stellar_swipe_common::SECONDS_PER_WEEK;
 
@@ -307,6 +310,25 @@ impl AnalyticsContract {
             None => return false,
         };
         compute_snapshot_checksum(&snapshot) == recorded
+    }
+
+    // ── Issue #673: TVL tracking entrypoints ──────────────────────────────────
+
+    /// Read-only: return the current aggregated TVL across all sources.
+    pub fn get_protocol_tvl(env: Env) -> tvl::TvlSnapshot {
+        tvl::get_protocol_tvl(&env)
+    }
+
+    /// Record an incremental deposit into one TVL source.
+    /// `source`: 0 = StakeVault, 1 = LiquidityPool, 2 = Escrow.
+    pub fn record_tvl_deposit(env: Env, source: tvl::TvlSource, amount: i128) {
+        tvl::apply_delta(&env, source, amount);
+    }
+
+    /// Record an incremental withdrawal from one TVL source.
+    /// `source`: 0 = StakeVault, 1 = LiquidityPool, 2 = Escrow.
+    pub fn record_tvl_withdrawal(env: Env, source: tvl::TvlSource, amount: i128) {
+        tvl::apply_delta(&env, source, -amount);
     }
 }
 

--- a/stellar-swipe/contracts/analytics/src/tvl.rs
+++ b/stellar-swipe/contracts/analytics/src/tvl.rs
@@ -1,0 +1,181 @@
+//! Real-time TVL tracking across all vaults (Issue #673).
+//!
+//! Aggregates balances from stake_vault, liquidity_pool, and escrow/holding
+//! into a single TVL figure updated incrementally on each deposit/withdrawal.
+
+use soroban_sdk::{contracttype, Env, Symbol};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Source categories contributing to TVL.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TvlSource {
+    StakeVault,
+    LiquidityPool,
+    Escrow,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TvlSnapshot {
+    pub stake_vault: i128,
+    pub liquidity_pool: i128,
+    pub escrow: i128,
+    pub total: i128,
+    pub last_updated: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum TvlKey {
+    Snapshot,
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+fn load(env: &Env) -> TvlSnapshot {
+    env.storage()
+        .instance()
+        .get(&TvlKey::Snapshot)
+        .unwrap_or(TvlSnapshot {
+            stake_vault: 0,
+            liquidity_pool: 0,
+            escrow: 0,
+            total: 0,
+            last_updated: 0,
+        })
+}
+
+fn save(env: &Env, snapshot: &TvlSnapshot) {
+    env.storage()
+        .instance()
+        .set(&TvlKey::Snapshot, snapshot);
+}
+
+// ── Incremental updates ───────────────────────────────────────────────────────
+
+/// Apply an incremental delta (positive = deposit, negative = withdrawal)
+/// to the specified source and update the aggregate total.
+pub fn apply_delta(env: &Env, source: TvlSource, delta: i128) {
+    let mut snap = load(env);
+
+    match source {
+        TvlSource::StakeVault => {
+            snap.stake_vault = snap.stake_vault.saturating_add(delta);
+        }
+        TvlSource::LiquidityPool => {
+            snap.liquidity_pool = snap.liquidity_pool.saturating_add(delta);
+        }
+        TvlSource::Escrow => {
+            snap.escrow = snap.escrow.saturating_add(delta);
+        }
+    }
+
+    // Recompute total from components to avoid accumulated drift
+    snap.total = snap
+        .stake_vault
+        .saturating_add(snap.liquidity_pool)
+        .saturating_add(snap.escrow);
+    snap.last_updated = env.ledger().timestamp();
+
+    save(env, &snap);
+}
+
+// ── Query ─────────────────────────────────────────────────────────────────────
+
+/// Return the current aggregated TVL snapshot.
+pub fn get_protocol_tvl(env: &Env) -> TvlSnapshot {
+    load(env)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    fn setup_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    #[test]
+    fn test_initial_tvl_is_zero() {
+        let env = setup_env();
+        let snap = get_protocol_tvl(&env);
+        assert_eq!(snap.total, 0);
+        assert_eq!(snap.stake_vault, 0);
+        assert_eq!(snap.liquidity_pool, 0);
+        assert_eq!(snap.escrow, 0);
+    }
+
+    #[test]
+    fn test_deposit_increases_tvl() {
+        let env = setup_env();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        apply_delta(&env, TvlSource::StakeVault, 500);
+        let snap = get_protocol_tvl(&env);
+        assert_eq!(snap.stake_vault, 500);
+        assert_eq!(snap.total, 500);
+        assert_eq!(snap.last_updated, 1000);
+    }
+
+    #[test]
+    fn test_multi_source_aggregation() {
+        let env = setup_env();
+        apply_delta(&env, TvlSource::StakeVault, 1000);
+        apply_delta(&env, TvlSource::LiquidityPool, 2000);
+        apply_delta(&env, TvlSource::Escrow, 300);
+        let snap = get_protocol_tvl(&env);
+        assert_eq!(snap.stake_vault, 1000);
+        assert_eq!(snap.liquidity_pool, 2000);
+        assert_eq!(snap.escrow, 300);
+        assert_eq!(snap.total, 3300);
+    }
+
+    #[test]
+    fn test_withdrawal_decreases_tvl() {
+        let env = setup_env();
+        apply_delta(&env, TvlSource::StakeVault, 1000);
+        apply_delta(&env, TvlSource::StakeVault, -400);
+        let snap = get_protocol_tvl(&env);
+        assert_eq!(snap.stake_vault, 600);
+        assert_eq!(snap.total, 600);
+    }
+
+    #[test]
+    fn test_tvl_consistent_across_deposit_withdraw_sequences() {
+        let env = setup_env();
+        // Series of deposits and withdrawals
+        apply_delta(&env, TvlSource::StakeVault, 1000);
+        apply_delta(&env, TvlSource::LiquidityPool, 500);
+        apply_delta(&env, TvlSource::StakeVault, -200);
+        apply_delta(&env, TvlSource::Escrow, 100);
+        apply_delta(&env, TvlSource::LiquidityPool, -50);
+        apply_delta(&env, TvlSource::Escrow, -30);
+
+        let snap = get_protocol_tvl(&env);
+        // stake_vault: 1000 - 200 = 800
+        // liquidity_pool: 500 - 50 = 450
+        // escrow: 100 - 30 = 70
+        // total: 1320
+        assert_eq!(snap.stake_vault, 800);
+        assert_eq!(snap.liquidity_pool, 450);
+        assert_eq!(snap.escrow, 70);
+        assert_eq!(snap.total, snap.stake_vault + snap.liquidity_pool + snap.escrow);
+        assert_eq!(snap.total, 1320);
+    }
+
+    #[test]
+    fn test_full_withdrawal_returns_zero() {
+        let env = setup_env();
+        apply_delta(&env, TvlSource::StakeVault, 500);
+        apply_delta(&env, TvlSource::StakeVault, -500);
+        let snap = get_protocol_tvl(&env);
+        assert_eq!(snap.stake_vault, 0);
+        assert_eq!(snap.total, 0);
+    }
+}

--- a/stellar-swipe/contracts/oracle/src/deviation.rs
+++ b/stellar-swipe/contracts/oracle/src/deviation.rs
@@ -1,0 +1,88 @@
+//! Cross-source price deviation alerting (Issue #671).
+//!
+//! On each `submit_pair_price` call, computes the max pairwise deviation
+//! across all currently reporting sources and emits `price_deviation_alert`
+//! when the deviation exceeds an admin-configured threshold — independently
+//! of whether aggregation or fallback logic triggers.
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+use stellar_swipe_common::AssetPair;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+enum DeviationKey {
+    Threshold(AssetPair),
+}
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+/// Set admin-configurable deviation alert threshold in basis points (100 = 1 %).
+pub fn set_deviation_threshold(env: &Env, pair: &AssetPair, threshold_bps: u32) {
+    env.storage()
+        .persistent()
+        .set(&DeviationKey::Threshold(pair.clone()), &threshold_bps);
+}
+
+/// Get deviation alert threshold in basis points. Returns 0 if not configured.
+pub fn get_deviation_threshold(env: &Env, pair: &AssetPair) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DeviationKey::Threshold(pair.clone()))
+        .unwrap_or(0)
+}
+
+// ── Check & emit ──────────────────────────────────────────────────────────────
+
+/// Compute max deviation across fresh price sources and emit
+/// `price_deviation_alert` if it exceeds the configured threshold.
+///
+/// `prices` is the slice of (source, price) from all currently reporting sources.
+pub fn check_deviation(env: &Env, pair: &AssetPair, sources: &Vec<(Address, i128)>) {
+    let threshold_bps = get_deviation_threshold(env, pair);
+    if threshold_bps == 0 || sources.is_empty() {
+        return;
+    }
+
+    // Find min and max price across all sources
+    let mut min_price = i128::MAX;
+    let mut max_price = i128::MIN;
+
+    for i in 0..sources.len() {
+        let (_, price) = sources.get(i).unwrap();
+        if price < min_price {
+            min_price = price;
+        }
+        if price > max_price {
+            max_price = price;
+        }
+    }
+
+    if min_price <= 0 {
+        return;
+    }
+
+    let deviation_bps = ((max_price - min_price) * 10_000) / min_price;
+    if deviation_bps as u32 > threshold_bps {
+        // Collect offending source identifiers (all sources contributing to max deviation)
+        let mut offending: Vec<Address> = Vec::new(env);
+        for i in 0..sources.len() {
+            let (source, price) = sources.get(i).unwrap();
+            let src_deviation_bps = ((price - min_price).abs() * 10_000) / min_price;
+            if src_deviation_bps as u32 > threshold_bps {
+                offending.push_back(source);
+            }
+        }
+
+        env.events().publish(
+            (Symbol::new(env, "price_deviation_alert"),),
+            (
+                pair.clone(),
+                deviation_bps as u32,
+                threshold_bps,
+                offending,
+            ),
+        );
+    }
+}

--- a/stellar-swipe/contracts/oracle/src/lib.rs
+++ b/stellar-swipe/contracts/oracle/src/lib.rs
@@ -3,6 +3,8 @@
 #[allow(deprecated)]
 mod admin;
 mod conversion;
+// Closes #671 — cross-source price deviation alerting
+mod deviation;
 mod errors;
 #[allow(deprecated)]
 mod events;
@@ -11,6 +13,8 @@ mod history;
 mod multi_hop;
 mod reputation;
 mod sdex;
+// Closes #670 — per-asset update frequency SLA monitoring
+mod sla;
 mod staleness;
 mod storage;
 mod types;
@@ -32,8 +36,10 @@ use types::{
 };
 
 pub use conversion::{convert_to_base, ConversionPath};
+pub use deviation::{check_deviation, get_deviation_threshold, set_deviation_threshold};
 pub use history::{calculate_twap, get_historical_price, get_twap_deviation, store_price};
 pub use multi_hop::{calculate_multi_hop_price, find_optimal_path, LiquidityPath};
+pub use sla::{get_feed_health, record_update as sla_record_update, set_sla, FeedHealth};
 pub use storage::{get_base_currency, get_price, set_base_currency, set_price};
 
 soroban_sdk::contractmeta!(
@@ -485,6 +491,46 @@ impl OracleContract {
             .unwrap_or(Vec::new(env))
     }
 
+    // ── Issue #670: SLA monitoring entrypoints ─────────────────────────────────
+
+    /// Admin: set the expected update interval SLA for an asset pair.
+    pub fn set_feed_sla(
+        env: Env,
+        caller: Address,
+        pair: AssetPair,
+        expected_interval_secs: u64,
+    ) -> Result<(), OracleError> {
+        Self::require_admin(&env, &caller)?;
+        caller.require_auth();
+        sla::set_sla(&env, &pair, expected_interval_secs);
+        Ok(())
+    }
+
+    /// Read-only: return the feed health summary (rolling avg, SLA, breach flag).
+    pub fn get_feed_health(env: Env, pair: AssetPair) -> sla::FeedHealth {
+        sla::get_feed_health(&env, &pair)
+    }
+
+    // ── Issue #671: Deviation alert entrypoints ────────────────────────────────
+
+    /// Admin: set the deviation alert threshold for a pair (basis points).
+    pub fn set_deviation_threshold(
+        env: Env,
+        caller: Address,
+        pair: AssetPair,
+        threshold_bps: u32,
+    ) -> Result<(), OracleError> {
+        Self::require_admin(&env, &caller)?;
+        caller.require_auth();
+        deviation::set_deviation_threshold(&env, &pair, threshold_bps);
+        Ok(())
+    }
+
+    /// Read-only: return current deviation alert threshold in bps (0 = disabled).
+    pub fn get_deviation_threshold(env: Env, pair: AssetPair) -> u32 {
+        deviation::get_deviation_threshold(&env, &pair)
+    }
+
     /// Get all registered oracles
     pub fn get_oracles(env: Env) -> Vec<Address> {
         Self::read_oracles(&env)
@@ -752,6 +798,14 @@ impl OracleContract {
         env.storage().temporary().set(&key, &prices);
         env.storage().temporary().extend_ttl(&key, 60, 60);
 
+        // #671: compute cross-source deviation and emit alert if threshold exceeded
+        let mut source_prices: Vec<(Address, i128)> = Vec::new(&env);
+        for i in 0..prices.len() {
+            let p = prices.get(i).unwrap();
+            source_prices.push_back((p.source, p.price));
+        }
+        deviation::check_deviation(&env, &pair, &source_prices);
+
         Ok(())
     }
 
@@ -822,6 +876,9 @@ pub fn on_price_update(env: &Env, pair: AssetPair) {
     metadata.update_count_24h += 1;
     metadata.last_heartbeat_status = OracleStatus::Healthy;
     staleness::set_metadata(env, &pair, metadata);
+
+    // #670: update rolling SLA cadence tracking
+    sla::record_update(env, &pair);
 }
 
 fn maybe_emit_heartbeat_missed(env: &Env, pair: &AssetPair, health: &OracleHealth) {

--- a/stellar-swipe/contracts/oracle/src/sla.rs
+++ b/stellar-swipe/contracts/oracle/src/sla.rs
@@ -1,0 +1,120 @@
+//! Per-asset update frequency SLA monitoring (Issue #670).
+//!
+//! Tracks rolling average update intervals per asset pair and emits
+//! an `sla_breach` event when the rolling average exceeds the configured SLA.
+
+use soroban_sdk::{contracttype, symbol_short, Env, Symbol};
+use stellar_swipe_common::AssetPair;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Stores the rolling-average update cadence and SLA config for one pair.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeedSlaRecord {
+    /// Admin-configured maximum acceptable average interval (seconds).
+    pub expected_interval_secs: u64,
+    /// Running sum of observed inter-update intervals (seconds).
+    pub interval_sum: u64,
+    /// Number of intervals recorded (one less than number of updates).
+    pub interval_count: u64,
+    /// Timestamp of the previous update (0 = no prior update).
+    pub prev_update_ts: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeedHealth {
+    /// Rolling average seconds between updates (0 if < 2 updates seen).
+    pub avg_update_interval_secs: u64,
+    /// Configured SLA (seconds). 0 = no SLA configured.
+    pub expected_interval_secs: u64,
+    /// True when avg_update_interval_secs > expected_interval_secs (and both > 0).
+    pub sla_breached: bool,
+    /// Total update intervals recorded.
+    pub interval_count: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum SlaKey {
+    Record(AssetPair),
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────────
+
+fn load(env: &Env, pair: &AssetPair) -> FeedSlaRecord {
+    env.storage()
+        .persistent()
+        .get(&SlaKey::Record(pair.clone()))
+        .unwrap_or(FeedSlaRecord {
+            expected_interval_secs: 0,
+            interval_sum: 0,
+            interval_count: 0,
+            prev_update_ts: 0,
+        })
+}
+
+fn save(env: &Env, pair: &AssetPair, record: &FeedSlaRecord) {
+    env.storage()
+        .persistent()
+        .set(&SlaKey::Record(pair.clone()), record);
+}
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+/// Set the admin-configurable expected update interval SLA for a pair.
+pub fn set_sla(env: &Env, pair: &AssetPair, expected_interval_secs: u64) {
+    let mut record = load(env, pair);
+    record.expected_interval_secs = expected_interval_secs;
+    save(env, pair, &record);
+}
+
+// ── Update hook ───────────────────────────────────────────────────────────────
+
+/// Called on each price update. Updates the rolling average and emits
+/// `sla_breach` if the new average exceeds the configured SLA.
+pub fn record_update(env: &Env, pair: &AssetPair) {
+    let now = env.ledger().timestamp();
+    let mut record = load(env, pair);
+
+    if record.prev_update_ts > 0 && now > record.prev_update_ts {
+        let interval = now - record.prev_update_ts;
+        record.interval_sum = record.interval_sum.saturating_add(interval);
+        record.interval_count = record.interval_count.saturating_add(1);
+
+        // Check SLA breach
+        if record.expected_interval_secs > 0 && record.interval_count > 0 {
+            let avg = record.interval_sum / record.interval_count;
+            if avg > record.expected_interval_secs {
+                env.events().publish(
+                    (Symbol::new(env, "sla_breach"),),
+                    (pair.clone(), avg, record.expected_interval_secs),
+                );
+            }
+        }
+    }
+
+    record.prev_update_ts = now;
+    save(env, pair, &record);
+}
+
+// ── Query ─────────────────────────────────────────────────────────────────────
+
+/// Read-only summary of recent update cadence for an asset pair.
+pub fn get_feed_health(env: &Env, pair: &AssetPair) -> FeedHealth {
+    let record = load(env, pair);
+    let avg = if record.interval_count > 0 {
+        record.interval_sum / record.interval_count
+    } else {
+        0
+    };
+    let sla_breached =
+        record.expected_interval_secs > 0 && avg > 0 && avg > record.expected_interval_secs;
+    FeedHealth {
+        avg_update_interval_secs: avg,
+        expected_interval_secs: record.expected_interval_secs,
+        sla_breached,
+        interval_count: record.interval_count,
+    }
+}

--- a/stellar-swipe/contracts/signal_registry/src/cohort_retention.rs
+++ b/stellar-swipe/contracts/signal_registry/src/cohort_retention.rs
@@ -1,0 +1,252 @@
+//! Cohort retention analysis for signal followers (Issue #672).
+//!
+//! Groups followers into cohorts by the week they first followed a provider,
+//! and tracks what fraction of each cohort is still actively copy-trading
+//! at +1, +4, and +12 weeks.
+
+use soroban_sdk::{contracttype, Address, Env};
+
+const SECONDS_PER_WEEK: u64 = 7 * 24 * 3600;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// A cohort is identified by the week-slot of first-follow.
+/// `week_slot` = first_follow_timestamp / SECONDS_PER_WEEK.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CohortData {
+    /// Total followers who joined in this cohort week.
+    pub total_followers: u32,
+    /// Followers still active at +1 week (i.e., recorded activity within week 1-2).
+    pub active_at_week_1: u32,
+    /// Followers still active at +4 weeks.
+    pub active_at_week_4: u32,
+    /// Followers still active at +12 weeks.
+    pub active_at_week_12: u32,
+}
+
+/// Summary returned by `get_cohort_retention`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CohortRetention {
+    pub week_slot: u64,
+    pub total_followers: u32,
+    /// Retention rate at +1 week in basis points (10_000 = 100 %).
+    pub retention_bps_week_1: u32,
+    /// Retention rate at +4 weeks in basis points.
+    pub retention_bps_week_4: u32,
+    /// Retention rate at +12 weeks in basis points.
+    pub retention_bps_week_12: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum CohortKey {
+    /// (provider, week_slot) -> CohortData
+    Cohort(Address, u64),
+    /// (provider, user) -> week_slot of first follow
+    FirstFollow(Address, Address),
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn week_slot(ts: u64) -> u64 {
+    ts / SECONDS_PER_WEEK
+}
+
+fn load_cohort(env: &Env, provider: &Address, slot: u64) -> CohortData {
+    env.storage()
+        .persistent()
+        .get(&CohortKey::Cohort(provider.clone(), slot))
+        .unwrap_or(CohortData {
+            total_followers: 0,
+            active_at_week_1: 0,
+            active_at_week_4: 0,
+            active_at_week_12: 0,
+        })
+}
+
+fn save_cohort(env: &Env, provider: &Address, slot: u64, data: &CohortData) {
+    env.storage()
+        .persistent()
+        .set(&CohortKey::Cohort(provider.clone(), slot), data);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Called when a user first follows a provider.
+/// Records the cohort entry for the user.
+pub fn record_follow(env: &Env, provider: &Address, user: &Address) {
+    let key = CohortKey::FirstFollow(provider.clone(), user.clone());
+    if env.storage().persistent().has(&key) {
+        return; // already recorded
+    }
+    let now = env.ledger().timestamp();
+    let slot = week_slot(now);
+    env.storage().persistent().set(&key, &slot);
+
+    let mut data = load_cohort(env, provider, slot);
+    data.total_followers = data.total_followers.saturating_add(1);
+    save_cohort(env, provider, slot, &data);
+}
+
+/// Called when a user copy-trades a signal from a provider.
+/// Updates active-at-week-N buckets for their cohort.
+pub fn record_activity(env: &Env, provider: &Address, user: &Address) {
+    let key = CohortKey::FirstFollow(provider.clone(), user.clone());
+    let slot: u64 = match env.storage().persistent().get(&key) {
+        Some(s) => s,
+        None => return, // user hasn't formally followed; skip
+    };
+
+    let now = env.ledger().timestamp();
+    let current_slot = week_slot(now);
+    let weeks_since = current_slot.saturating_sub(slot);
+
+    let mut data = load_cohort(env, provider, slot);
+
+    // Accumulate into the highest applicable bucket (not mutually exclusive —
+    // being active at week 12 implies active at 4 and 1 too).
+    if weeks_since >= 12 {
+        data.active_at_week_12 = data.active_at_week_12.saturating_add(1);
+        data.active_at_week_4 = data.active_at_week_4.saturating_add(1);
+        data.active_at_week_1 = data.active_at_week_1.saturating_add(1);
+    } else if weeks_since >= 4 {
+        data.active_at_week_4 = data.active_at_week_4.saturating_add(1);
+        data.active_at_week_1 = data.active_at_week_1.saturating_add(1);
+    } else if weeks_since >= 1 {
+        data.active_at_week_1 = data.active_at_week_1.saturating_add(1);
+    }
+
+    save_cohort(env, provider, slot, &data);
+}
+
+/// Read-only: return cohort retention summary for `(provider, week_slot)`.
+pub fn get_cohort_retention(env: &Env, provider: &Address, cohort_week_slot: u64) -> CohortRetention {
+    let data = load_cohort(env, provider, cohort_week_slot);
+    let total = data.total_followers;
+
+    let bps = |active: u32| -> u32 {
+        if total == 0 {
+            0
+        } else {
+            (active * 10_000) / total
+        }
+    };
+
+    CohortRetention {
+        week_slot: cohort_week_slot,
+        total_followers: total,
+        retention_bps_week_1: bps(data.active_at_week_1),
+        retention_bps_week_4: bps(data.active_at_week_4),
+        retention_bps_week_12: bps(data.active_at_week_12),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let provider = Address::generate(&env);
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        (env, provider, user1, user2)
+    }
+
+    #[test]
+    fn test_new_follower_joins_cohort() {
+        let (env, provider, user1, _) = setup();
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 5);
+
+        record_follow(&env, &provider, &user1);
+
+        let retention = get_cohort_retention(&env, &provider, 5);
+        assert_eq!(retention.total_followers, 1);
+        assert_eq!(retention.retention_bps_week_1, 0); // no activity yet
+    }
+
+    #[test]
+    fn test_activity_at_week_1_recorded() {
+        let (env, provider, user1, _) = setup();
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 10);
+        record_follow(&env, &provider, &user1);
+
+        // Advance 1 week
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 11);
+        record_activity(&env, &provider, &user1);
+
+        let retention = get_cohort_retention(&env, &provider, 10);
+        assert_eq!(retention.total_followers, 1);
+        assert_eq!(retention.retention_bps_week_1, 10_000); // 100 %
+        assert_eq!(retention.retention_bps_week_4, 0);
+        assert_eq!(retention.retention_bps_week_12, 0);
+    }
+
+    #[test]
+    fn test_activity_at_week_12_fills_all_buckets() {
+        let (env, provider, user1, _) = setup();
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 0);
+        record_follow(&env, &provider, &user1);
+
+        // Advance 12 weeks
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 12);
+        record_activity(&env, &provider, &user1);
+
+        let retention = get_cohort_retention(&env, &provider, 0);
+        assert_eq!(retention.retention_bps_week_1, 10_000);
+        assert_eq!(retention.retention_bps_week_4, 10_000);
+        assert_eq!(retention.retention_bps_week_12, 10_000);
+    }
+
+    #[test]
+    fn test_multi_cohort_two_users() {
+        let (env, provider, user1, user2) = setup();
+
+        // user1 follows in week 0
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        record_follow(&env, &provider, &user1);
+
+        // user2 follows in week 1
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK);
+        record_follow(&env, &provider, &user2);
+
+        // user1 is active at week 1 (relative to their cohort)
+        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK + 1);
+        record_activity(&env, &provider, &user1);
+
+        // cohort 0: user1 joined, 100% at week 1
+        let c0 = get_cohort_retention(&env, &provider, 0);
+        assert_eq!(c0.total_followers, 1);
+        assert_eq!(c0.retention_bps_week_1, 10_000);
+
+        // cohort 1: user2 joined, 0% activity yet
+        let c1 = get_cohort_retention(&env, &provider, 1);
+        assert_eq!(c1.total_followers, 1);
+        assert_eq!(c1.retention_bps_week_1, 0);
+    }
+
+    #[test]
+    fn test_no_double_count_follow() {
+        let (env, provider, user1, _) = setup();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        record_follow(&env, &provider, &user1);
+        record_follow(&env, &provider, &user1); // idempotent
+
+        let retention = get_cohort_retention(&env, &provider, 0);
+        assert_eq!(retention.total_followers, 1);
+    }
+
+    #[test]
+    fn test_empty_cohort_returns_zero() {
+        let (env, provider, _, _) = setup();
+        let retention = get_cohort_retention(&env, &provider, 99);
+        assert_eq!(retention.total_followers, 0);
+        assert_eq!(retention.retention_bps_week_1, 0);
+    }
+}

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -8,6 +8,7 @@ mod admin;
 mod analytics;
 mod categories;
 mod churn_risk;
+mod cohort_retention;
 mod collaboration;
 mod combos;
 mod community_voting;
@@ -100,6 +101,7 @@ use types::{
 // SignalData is a type alias for SignalDataV2; keep the alias re-export for
 // any external clients compiled against the old name (Issue #568).
 pub use types::SignalData;
+pub use cohort_retention::{CohortRetention, get_cohort_retention as cohort_retention_get};
 use versioning::{CopyRecord, SignalVersion};
 
 const MAX_EXPIRY_SECONDS: u64 = SECONDS_PER_30_DAY_MONTH;
@@ -1931,6 +1933,9 @@ impl SignalRegistry {
             },
         );
 
+        // #672: record copy-trade activity for cohort retention
+        cohort_retention::record_activity(&env, &signal.provider, &caller);
+
         // Emit event
         events::emit_signal_adopted(&env, signal_id, caller.clone(), signal.adoption_count);
 
@@ -2050,6 +2055,9 @@ impl SignalRegistry {
         social::follow_provider(&env, user.clone(), provider.clone())
             .map_err(|_| AdminError::CannotFollowSelf)?;
 
+        // #672: record cohort membership on first follow
+        cohort_retention::record_follow(&env, &provider, &user);
+
         Self::sync_provider_social_metrics(&env, &provider);
         Self::update_provider_trust_score(env, provider);
 
@@ -2075,6 +2083,18 @@ impl SignalRegistry {
     /// Get follower count for a provider
     pub fn get_follower_count(env: Env, provider: Address) -> u32 {
         social::get_follower_count(&env, &provider)
+    }
+
+    // ── Issue #672: Cohort retention ──────────────────────────────────────────
+
+    /// Read-only: return cohort retention summary for a provider and week slot.
+    /// `cohort_week_slot` = first_follow_timestamp / (7 * 24 * 3600).
+    pub fn get_cohort_retention(
+        env: Env,
+        provider: Address,
+        cohort_week_slot: u64,
+    ) -> cohort_retention::CohortRetention {
+        cohort_retention::get_cohort_retention(&env, &provider, cohort_week_slot)
     }
 
     fn sync_provider_social_metrics(env: &Env, provider: &Address) {


### PR DESCRIPTION
…

Closes #670 
— oracle: per-asset update frequency SLA monitoring
- Add sla.rs: FeedSlaRecord, FeedHealth types with rolling avg tracking
- set_sla() admin entrypoint per asset pair; record_update() called on every price update via on_price_update(); emits sla_breach event when rolling avg exceeds configured interval; get_feed_health() read-only entrypoint

Closes #671
 — oracle: cross-source price deviation alert
- Add deviation.rs: computes max pairwise deviation across all reporting sources on each submit_pair_price call; emits price_deviation_alert with offending source identifiers when deviation_bps exceeds admin threshold; set_deviation_threshold()/get_deviation_threshold() admin entrypoints

Closes #672 
— analytics: cohort retention analysis for signal followers
- Add cohort_retention.rs: groups followers by week-slot of first follow; record_follow() called in follow_provider(); record_activity() called on each signal adoption (copy-trade); tracks active_at_week_1/4/12 buckets; get_cohort_retention(provider, cohort_week_slot) read-only entrypoint; includes unit tests for single/multi-cohort follower activity

Closes #673 
— analytics: real-time TVL tracking across all vaults
- Add tvl.rs: TvlSource enum (StakeVault, LiquidityPool, Escrow); apply_delta() for incremental updates; get_protocol_tvl() read-only entrypoint returning TvlSnapshot with per-source and aggregate totals; record_tvl_deposit()/record_tvl_withdrawal() on AnalyticsContract; includes unit tests verifying consistency across deposit/withdraw sequences