### PR TITLE
feat: add proposal self-withdrawal entrypoint

### DIFF
--- a/stellar-swipe/contracts/governance/src/errors.rs
+++ b/stellar-swipe/contracts/governance/src/errors.rs
@@ -72,4 +72,6 @@ impl GovernanceError {
     pub const IterationLimitExceeded: GovernanceError = GovernanceError::InvalidCommitteeAction;
     /// Vote rejected because the mandatory discussion window has not yet elapsed (Issue #667).
     pub const DiscussionPeriodActive: GovernanceError = GovernanceError::VotingNotStarted;
+    /// Proposal has already been withdrawn — cannot be withdrawn again.
+    pub const ProposalAlreadyWithdrawn: GovernanceError = GovernanceError::ProposalNotActive;
 }

--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -61,8 +61,8 @@ use proposals::{
     calculate_proposal_statistics, cancel_proposal, configure_governance, create_proposal,
     default_governance_config, execute_proposal, finalize_proposal, get_all_proposals,
     get_category_threshold, get_governance_config, get_proposal, set_category_thresholds,
-    Proposal, ProposalStatistics, ProposalStatus, ProposalType, Vote, VoteDelegation,
-    VoteType as GovernanceVoteType,
+    withdraw_proposal, Proposal, ProposalStatistics, ProposalStatus, ProposalType, Vote,
+    VoteDelegation, VoteType as GovernanceVoteType,
 };
 use quadratic_voting::{
     allocate_vote_credits, calculate_marginal_cost, cast_quadratic_vote, compare_voting_systems,
@@ -588,6 +588,42 @@ impl GovernanceContract {
     ) -> Result<ProposalStatus, GovernanceError> {
         require_initialized(&env)?;
         proposals::cancel_proposal(&env, proposal_id, canceller)
+    }
+
+    /// # Summary
+    /// Voluntarily withdraw a proposal before voting opens.  Only callable by
+    /// the original proposer while the proposal is still in `Pending` status.
+    ///
+    /// # Behaviour
+    /// - Authorization: only the original `proposer` may call this.
+    /// - State guard: proposal must be `Pending` (pre-vote).  Rejected if
+    ///   voting has already started (`Active`) or any terminal state is reached.
+    /// - Deposit: the spam-deposit is **refunded** to the proposer (unlike
+    ///   failed proposals which forfeit the deposit).  See inline docs in
+    ///   `proposals::withdraw_proposal` for the rationale.
+    /// - Event: a `propwdr` event is emitted on success.
+    ///
+    /// # Parameters
+    /// - `env`: Soroban environment.
+    /// - `proposal_id`: ID of the proposal to withdraw.
+    /// - `proposer`: Address of the original proposer (must authorize).
+    ///
+    /// # Returns
+    /// `Ok(ProposalStatus::Withdrawn)` on success.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] — contract not initialized.
+    /// - [`GovernanceError::Unauthorized`] — caller is not the original proposer.
+    /// - [`GovernanceError::ProposalNotFound`] — proposal_id does not exist.
+    /// - [`GovernanceError::ProposalNotActive`] — proposal is not in Pending status.
+    pub fn withdraw_proposal(
+        env: Env,
+        proposal_id: u64,
+        proposer: Address,
+    ) -> Result<ProposalStatus, GovernanceError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+        proposals::withdraw_proposal(&env, proposal_id, proposer)
     }
 
     // ── Issue #666: Proposal execution payload simulation (dry-run) ───────────

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -72,6 +72,10 @@ pub enum ProposalStatus {
     Executed,
     Cancelled,
     Expired,
+    /// Proposal was voluntarily withdrawn by the original proposer before
+    /// voting opened.  This status is immutable once set — the proposal is
+    /// permanently excluded from future voting-eligible listings.
+    Withdrawn,
 }
 
 #[contracttype]
@@ -645,6 +649,107 @@ pub fn cancel_proposal(
     proposal.status = ProposalStatus::Cancelled;
     put_proposal(env, &proposal)?;
     Ok(ProposalStatus::Cancelled)
+}
+
+/// Voluntarily withdraw a proposal by its original proposer.
+///
+/// # Behaviour
+/// - Only the original proposer may call this entrypoint (authorization check).
+/// - Only allowed while the proposal is in `Pending` status (pre-vote state).
+///   Once voting has opened (status transitions to `Active`) or the proposal
+///   has reached any other terminal state, withdrawal is rejected.
+/// - On success:
+///   1. Status is set to `Withdrawn` (immutable — cannot be further modified).
+///   2. The spam-deposit is **refunded** to the proposer (区别 from failed
+///      proposals which forfeit the deposit). The rationale is that a
+///      responsible self-withdrawal (e.g. correcting a mistake) should not
+///      penalise the proposer, unlike a proposal that fails due to lack of
+///      community support.
+///   3. A `propwdr` event is emitted with the proposer, proposal ID, and
+///      timestamp.
+///
+/// # Deposit Handling Policy
+/// Self-withdrawal **always refunds** the deposit, regardless of participation
+/// thresholds. This distinguishes it from `finalize_proposal` where a failed
+/// proposal forfeits its deposit to the treasury. The reasoning:
+/// - A proposer who self-withdraws is acting responsibly (e.g. fixing errors).
+/// - Penalising responsible behaviour would discourage honest participation.
+/// - The spam-deposit's purpose (deterring frivolous proposals) is served by
+///   the forfeit path for proposals that actually fail, not by penalising
+///   voluntary corrections.
+///
+/// # Errors
+/// - [`GovernanceError::Unauthorized`] — caller is not the original proposer.
+/// - [`GovernanceError::ProposalNotFound`] — proposal_id does not exist.
+/// - [`GovernanceError::ProposalNotActive`] — proposal is not in Pending status
+///   (voting has already started or the proposal reached a terminal state).
+pub fn withdraw_proposal(
+    env: &Env,
+    proposal_id: u64,
+    proposer: Address,
+) -> Result<ProposalStatus, GovernanceError> {
+    proposer.require_auth();
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    // Only the original proposer may withdraw their own proposal.
+    if proposer != proposal.proposer {
+        return Err(GovernanceError::Unauthorized);
+    }
+
+    // Must still be in Pending status — once voting opens (Active) or any
+    // terminal state is reached, withdrawal is no longer permitted.
+    if proposal.status == ProposalStatus::Withdrawn {
+        return Err(GovernanceError::ProposalAlreadyWithdrawn);
+    }
+    if proposal.status != ProposalStatus::Pending {
+        return Err(GovernanceError::ProposalNotActive);
+    }
+
+    proposal.status = ProposalStatus::Withdrawn;
+    put_proposal(env, &proposal)?;
+
+    // Refund the spam-deposit to the proposer (see deposit handling policy above).
+    // Directly refund via add_balance and clean up the lock record.
+    let config = crate::proposal_deposit::get_deposit_config(env);
+    if config.amount > 0 {
+        // Check if a deposit was locked for this proposal.
+        let locked: Option<Address> = env
+            .storage()
+            .persistent()
+            .get(&crate::proposal_deposit::DepositKey::LockedDeposit(proposal_id));
+        if let Some(deposit_proposer) = locked {
+            if deposit_proposer == proposer {
+                // Refund the full deposit amount to the proposer.
+                let _ = crate::add_balance(env, &proposer, config.amount);
+                env.storage()
+                    .persistent()
+                    .remove(&crate::proposal_deposit::DepositKey::LockedDeposit(
+                        proposal_id,
+                    ));
+                #[allow(deprecated)]
+                env.events().publish(
+                    (
+                        symbol_short!("deposit"),
+                        symbol_short!("refund"),
+                    ),
+                    (proposal_id, proposer.clone(), config.amount),
+                );
+            }
+        }
+    }
+
+    // Emit self-withdrawal event.
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("propwdr")),
+        (
+            proposal_id,
+            proposer,
+            env.ledger().timestamp(),
+        ),
+    );
+
+    Ok(ProposalStatus::Withdrawn)
 }
 
 pub fn calculate_proposal_statistics(env: &Env) -> Result<ProposalStatistics, GovernanceError> {

--- a/stellar-swipe/contracts/governance/src/test.rs
+++ b/stellar-swipe/contracts/governance/src/test.rs
@@ -2402,3 +2402,274 @@ fn test_reputation_leaderboard_limit() {
     assert_eq!(res, Err(Ok(GovernanceError::IterationLimitExceeded)));
 }
 
+// ── Proposal self-withdrawal tests ──────────────────────────────────────────
+
+#[test]
+fn proposer_can_withdraw_proposal_before_voting_opens() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::ParameterChange(
+            String::from_str(&env, "liquidity_reward_bps"),
+            100,
+            120,
+        ),
+        &String::from_str(&env, "Adjust reward"),
+        &String::from_str(&env, "Increase by 20%"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // Still at t=0, well before voting_starts (t=60). Proposal is Pending.
+    let status = client.withdraw_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(status, ProposalStatus::Withdrawn);
+
+    let proposal = client.proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Withdrawn);
+}
+
+#[test]
+fn non_proposer_cannot_withdraw_others_proposal() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::SignalProposal(String::from_str(&env, "Test signal")),
+        &String::from_str(&env, "Signal vote"),
+        &String::from_str(&env, "Community signal"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // public_sale is NOT the proposer — must be rejected.
+    let result =
+        client.try_withdraw_proposal(&proposal_id, &recipients.public_sale);
+    assert_eq!(result, Err(Ok(GovernanceError::Unauthorized)));
+
+    // Original proposal must remain unchanged.
+    let proposal = client.proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+}
+
+#[test]
+fn cannot_withdraw_after_voting_has_started() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+    client.stake(&recipients.public_sale, &40_000_000i128);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::ParameterChange(
+            String::from_str(&env, "liquidity_reward_bps"),
+            100,
+            120,
+        ),
+        &String::from_str(&env, "Adjust reward"),
+        &String::from_str(&env, "Increase by 20%"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // Advance past voting_starts (t=60) and cast a vote → status becomes Active.
+    env.ledger().set_timestamp(70);
+    client.cast_vote(
+        &proposal_id,
+        &recipients.community_rewards,
+        &GovernanceVoteType::For,
+    );
+
+    // Now try to withdraw — must be rejected because status is Active.
+    let result =
+        client.try_withdraw_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalNotActive)));
+}
+
+#[test]
+fn withdrawn_proposal_refunds_deposit() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    let proposer = &recipients.community_rewards;
+    let balance_before = client.balance(proposer);
+
+    let proposal_id = client.create_proposal(
+        proposer,
+        &ProposalType::SignalProposal(String::from_str(&env, "Test")),
+        &String::from_str(&env, "Deposit test"),
+        &String::from_str(&env, "Verify deposit refund"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // Deposit was locked — balance should be reduced.
+    let balance_after_create = client.balance(proposer);
+    assert!(
+        balance_after_create < balance_before,
+        "balance must decrease after proposal creation due to deposit lock"
+    );
+
+    // Withdraw the proposal.
+    client.withdraw_proposal(&proposal_id, proposer);
+
+    // Deposit must be refunded — balance should return to original.
+    let balance_after_withdraw = client.balance(proposer);
+    assert_eq!(
+        balance_after_withdraw, balance_before,
+        "deposit must be fully refunded on self-withdrawal"
+    );
+}
+
+#[test]
+fn withdraw_proposal_emits_event() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::SignalProposal(String::from_str(&env, "Event test")),
+        &String::from_str(&env, "Event check"),
+        &String::from_str(&env, "Verify event emission"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    client.withdraw_proposal(&proposal_id, &recipients.community_rewards);
+
+    // Verify that a (gov, propwdr) event was emitted.
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
+        let t0 = topics
+            .get(0)
+            .and_then(|v| Symbol::try_from_val(&env, &v).ok());
+        let t1 = topics
+            .get(1)
+            .and_then(|v| Symbol::try_from_val(&env, &v).ok());
+        t0 == Some(Symbol::new(&env, "gov")) && t1 == Some(Symbol::new(&env, "propwdr"))
+    });
+    assert!(
+        found,
+        "withdraw_proposal must emit (gov, propwdr) event"
+    );
+}
+
+#[test]
+fn cannot_withdraw_already_withdrawn_proposal() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::SignalProposal(String::from_str(&env, "Double withdraw")),
+        &String::from_str(&env, "Double withdraw test"),
+        &String::from_str(&env, "Cannot withdraw twice"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // First withdrawal — succeeds.
+    let status = client.withdraw_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(status, ProposalStatus::Withdrawn);
+
+    // Second withdrawal — must be rejected (status is Withdrawn, not Pending).
+    let result =
+        client.try_withdraw_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalAlreadyWithdrawn)));
+}
+
+#[test]
+fn withdrawn_proposals_excluded_from_voting_eligible_listings() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    // Create two proposals.
+    let pid1 = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::SignalProposal(String::from_str(&env, "Keep this")),
+        &String::from_str(&env, "Active proposal"),
+        &String::from_str(&env, "Should remain"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+    let pid2 = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::SignalProposal(String::from_str(&env, "Withdraw this")),
+        &String::from_str(&env, "Withdrawn proposal"),
+        &String::from_str(&env, "Should be withdrawn"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // Withdraw the second proposal.
+    client.withdraw_proposal(&pid2, &recipients.community_rewards);
+
+    // get_all_proposals should still return both, but the withdrawn one
+    // has Withdrawn status (not Pending/Active) so it's excluded from
+    // voting-eligible listings by status check.
+    let all = client.proposals();
+    assert_eq!(all.len(), 2);
+    let p1 = all.get(0).unwrap();
+    let p2 = all.get(1).unwrap();
+    assert_eq!(p1.status, ProposalStatus::Pending);
+    assert_eq!(p2.status, ProposalStatus::Withdrawn);
+}
+
+#[test]
+fn cancelled_proposal_cannot_be_withdrawn() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::SignalProposal(String::from_str(&env, "Cancel test")),
+        &String::from_str(&env, "Cancel first"),
+        &String::from_str(&env, "Then try withdraw"),
+        &Bytes::new(&env),
+        &crate::proposals::ProposalCategory::General,
+        &false,
+    );
+
+    // Cancel the proposal first.
+    client.cancel_proposal(&proposal_id, &recipients.community_rewards);
+
+    // Now try to withdraw — must be rejected (status is Cancelled, not Pending).
+    let result =
+        client.try_withdraw_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalNotActive)));
+}
+


### PR DESCRIPTION
- Add Withdrawn status variant to ProposalStatus enum
- Add withdraw_proposal entrypoint with proposer-only access control
- Restrict withdrawal to Pending (pre-vote) status only
- Always refund spam-deposit on self-withdrawal (unlike failed proposals)
- Emit (gov, propwdr) event on successful withdrawal
- Add require_not_paused guard for consistency with other entrypoints
- Add ProposalAlreadyWithdrawn error for double-withdrawal attempts
- Add 8 comprehensive tests covering all acceptance criteria


Closes #748 