### PR TITLE
feat: shared multisig N-of-M approval trait with stake_vault migration

### DIFF
--- a/stellar-swipe/Cargo.lock
+++ b/stellar-swipe/Cargo.lock
@@ -804,6 +804,7 @@ name = "integration_tests"
 version = "0.0.0"
 dependencies = [
  "fee_collector",
+ "proptest",
  "signal_registry",
  "soroban-sdk",
  "stake_vault",
@@ -1713,6 +1714,7 @@ dependencies = [
 name = "trade_executor"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "shared",
  "soroban-sdk",
  "stellar_swipe_common",

--- a/stellar-swipe/contracts/integration_tests/Cargo.toml
+++ b/stellar-swipe/contracts/integration_tests/Cargo.toml
@@ -19,6 +19,7 @@ stellar_swipe_common = { path = "../common" }
 trade_executor = { path = "../trade_executor" }
 user_portfolio = { path = "../user_portfolio" }
 fee_collector = { path = "../fee_collector" }
+proptest = { version = "1", default-features = false, features = ["std"] }
 
 [[test]]
 name = "test_contract_upgrade"
@@ -43,9 +44,6 @@ path = "tests/integration/test_chaos_ordering.rs"
 [[test]]
 name = "test_arithmetic_invariants"
 path = "tests/integration/test_arithmetic_invariants.rs"
-
-[dev-dependencies]
-proptest = { version = "1", default-features = false, features = ["std"] }
 
 [lints]
 workspace = true

--- a/stellar-swipe/contracts/shared/src/lib.rs
+++ b/stellar-swipe/contracts/shared/src/lib.rs
@@ -7,6 +7,15 @@ pub use expiry::Expirable;
 pub mod access_control;
 /// Asset metadata registry (Issue #700).
 pub mod asset_registry;
+pub mod multisig;
+pub use multisig::{
+    approve as multisig_approve, get_config as multisig_get_config,
+    get_proposal as multisig_get_proposal, has_approved as multisig_has_approved,
+    is_signer as multisig_is_signer, mark_executed as multisig_mark_executed,
+    propose as multisig_propose, require_can_execute as multisig_require_can_execute,
+    set_config as multisig_set_config, validate_config as multisig_validate_config,
+    MultisigConfig, MultisigError, MultisigStorageKey, Proposal, ProposalStatus,
+};
 
 pub mod auth;
 #[allow(deprecated)]

--- a/stellar-swipe/contracts/shared/src/multisig.rs
+++ b/stellar-swipe/contracts/shared/src/multisig.rs
@@ -1,0 +1,558 @@
+//! Generic N-of-M approval trait for privileged contract actions.
+//!
+//! Any contract that adopts this module stores a [`MultisigConfig`] (list of
+//! signers, threshold, and proposal timeout). An admin proposes an opaque
+//! `Bytes` payload, then other signers approve it. Once the approval count
+//! reaches the configured threshold **and** the proposal has not expired, a
+//! caller may execute the action.
+//!
+//! # Usage
+//!
+//! 1. Call [`set_config`] during initialisation (admin-only).
+//! 2. For each privileged action add a `propose_action` entrypoint that
+//!    encodes the action into a `Bytes` payload and calls [`propose`].
+//! 3. Add `approve_action` and `execute_action` entrypoints that delegate to
+//!    [`approve`] and [`require_can_execute`] / [`mark_executed`].
+//! 4. In `execute_action` decode the payload, perform the privileged work,
+//!    then call [`mark_executed`].
+
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, Env, Vec};
+
+// ── Constants ───────────────────────────────────────────────────────────────────
+
+/// Maximum number of signers allowed in a config.
+pub const MAX_SIGNERS: u32 = 20;
+
+/// Default timeout for proposals (7 days in seconds).
+pub const DEFAULT_PROPOSAL_TIMEOUT_SECS: u64 = 604_800;
+
+// ── Errors ──────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum MultisigError {
+    /// Caller is not a registered signer.
+    Unauthorized = 1,
+    /// The requested proposal does not exist.
+    ProposalNotFound = 2,
+    /// The signer has already approved this proposal.
+    AlreadyApproved = 3,
+    /// The proposal has expired and can no longer be executed.
+    ProposalExpired = 4,
+    /// The proposal has already been executed.
+    AlreadyExecuted = 5,
+    /// The approval threshold has not yet been reached.
+    ThresholdNotMet = 6,
+    /// The config contains invalid values (threshold = 0, threshold > signers, etc.).
+    InvalidConfig = 7,
+    /// Duplicate signer addresses in the config.
+    DuplicateSigner = 8,
+}
+
+// ── Storage keys ────────────────────────────────────────────────────────────────
+
+/// Storage keys used by this module.
+///
+/// The enum discriminant is part of the serialised key, so these will **not**
+/// collide with a contract-local `StorageKey` enum that happens to have
+/// variants with the same name.
+#[contracttype]
+#[derive(Clone)]
+pub enum MultisigStorageKey {
+    Config,
+    NextId,
+    Proposal(u64),
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────────
+
+/// On-chain multi-sig configuration.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultisigConfig {
+    /// Registered signer addresses (M).
+    pub signers: Vec<Address>,
+    /// Approvals required before execution (N).
+    pub threshold: u32,
+    /// Seconds after which a proposal that hasn't reached threshold expires.
+    pub proposal_timeout_secs: u64,
+}
+
+/// Status of a proposal.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ProposalStatus {
+    /// Waiting for more approvals.
+    Pending = 0,
+    /// Executed — terminal state.
+    Executed = 1,
+}
+
+/// A generic multi-sig proposal wrapping an opaque action payload.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proposal {
+    /// Sequential proposal identifier.
+    pub id: u64,
+    /// Address that created the proposal.
+    pub proposer: Address,
+    /// Opaque action payload (contract-specific encoding).
+    pub payload: Bytes,
+    /// Current approval count.
+    pub approvals: Vec<Address>,
+    /// Current status.
+    pub status: ProposalStatus,
+    /// Ledger timestamp when the proposal was created.
+    pub created_at: u64,
+    /// Timestamp after which the proposal expires (exclusive upper bound).
+    pub expires_at: u64,
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────────────
+
+fn get_next_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&MultisigStorageKey::NextId)
+        .unwrap_or(1);
+    env.storage()
+        .instance()
+        .set(&MultisigStorageKey::NextId, &(id + 1));
+    id
+}
+
+// ── Configuration ───────────────────────────────────────────────────────────────
+
+/// Return the stored multi-sig configuration, or a sensible default.
+pub fn get_config(env: &Env) -> Option<MultisigConfig> {
+    env.storage()
+        .instance()
+        .get(&MultisigStorageKey::Config)
+}
+
+/// Persist a new multi-sig configuration.
+///
+/// # Errors
+/// - [`MultisigError::InvalidConfig`] — threshold is 0 or exceeds signer count.
+/// - [`MultisigError::DuplicateSigner`] — signers list contains a duplicate.
+pub fn set_config(env: &Env, config: &MultisigConfig) -> Result<(), MultisigError> {
+    validate_config(config)?;
+    env.storage()
+        .instance()
+        .set(&MultisigStorageKey::Config, config);
+    Ok(())
+}
+
+/// Validate that a configuration is well-formed.
+pub fn validate_config(config: &MultisigConfig) -> Result<(), MultisigError> {
+    if config.threshold == 0 || config.threshold > config.signers.len() {
+        return Err(MultisigError::InvalidConfig);
+    }
+    if config.signers.len() > MAX_SIGNERS {
+        return Err(MultisigError::InvalidConfig);
+    }
+    let mut i: u32 = 0;
+    while i < config.signers.len() {
+        let mut j: u32 = i + 1;
+        while j < config.signers.len() {
+            if config.signers.get(i).unwrap() == config.signers.get(j).unwrap() {
+                return Err(MultisigError::DuplicateSigner);
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    Ok(())
+}
+
+/// Return `true` when `address` is in the signer list.
+pub fn is_signer(config: &MultisigConfig, address: &Address) -> bool {
+    let mut i: u32 = 0;
+    while i < config.signers.len() {
+        if &config.signers.get(i).unwrap() == address {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+// ── Proposals ───────────────────────────────────────────────────────────────────
+
+/// Create a new proposal on behalf of `proposer`.
+///
+/// `proposer` **must** be a registered signer and **must** have already
+/// called `require_auth` (or `require_auth_for_args`) before calling this
+/// function.
+///
+/// Returns the newly assigned proposal ID.
+///
+/// # Errors
+/// - [`MultisigError::Unauthorized`] — proposer is not a registered signer.
+/// - [`MultisigError::InvalidConfig`] — no multi-sig config has been set.
+pub fn propose(
+    env: &Env,
+    proposer: &Address,
+    payload: Bytes,
+) -> Result<u64, MultisigError> {
+    let config = get_config(env).ok_or(MultisigError::InvalidConfig)?;
+    if !is_signer(&config, proposer) {
+        return Err(MultisigError::Unauthorized);
+    }
+
+    let now = env.ledger().timestamp();
+    let id = get_next_id(env);
+    let timeout = if config.proposal_timeout_secs > 0 {
+        config.proposal_timeout_secs
+    } else {
+        DEFAULT_PROPOSAL_TIMEOUT_SECS
+    };
+
+    let mut approvals: Vec<Address> = Vec::new(env);
+    approvals.push_back(proposer.clone());
+
+    let proposal = Proposal {
+        id,
+        proposer: proposer.clone(),
+        payload,
+        approvals,
+        status: ProposalStatus::Pending,
+        created_at: now,
+        expires_at: now.saturating_add(timeout),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&MultisigStorageKey::Proposal(id), &proposal);
+
+    Ok(id)
+}
+
+/// Record an approval from `caller` for `proposal_id`.
+///
+/// `caller` **must** have already called `require_auth` before calling this
+/// function.
+///
+/// Returns the **current** number of approvals (after recording this one).
+///
+/// # Errors
+/// - [`MultisigError::ProposalNotFound`] — no proposal with that id.
+/// - [`MultisigError::AlreadyExecuted`] — proposal has already been executed.
+/// - [`MultisigError::ProposalExpired`] — proposal has expired.
+/// - [`MultisigError::AlreadyApproved`] — caller has already approved.
+/// - [`MultisigError::Unauthorized`] — caller is not a registered signer.
+pub fn approve(env: &Env, caller: &Address, proposal_id: u64) -> Result<u32, MultisigError> {
+    let config = get_config(env).ok_or(MultisigError::InvalidConfig)?;
+    if !is_signer(&config, caller) {
+        return Err(MultisigError::Unauthorized);
+    }
+
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    if proposal.status == ProposalStatus::Executed {
+        return Err(MultisigError::AlreadyExecuted);
+    }
+    if env.ledger().timestamp() > proposal.expires_at {
+        return Err(MultisigError::ProposalExpired);
+    }
+    if has_approved(&proposal, caller) {
+        return Err(MultisigError::AlreadyApproved);
+    }
+
+    proposal.approvals.push_back(caller.clone());
+    let count = proposal.approvals.len();
+
+    env.storage()
+        .persistent()
+        .set(&MultisigStorageKey::Proposal(proposal_id), &proposal);
+
+    Ok(count as u32)
+}
+
+/// Return `true` if `signer` has already approved `proposal`.
+pub fn has_approved(proposal: &Proposal, signer: &Address) -> bool {
+    let mut i: u32 = 0;
+    while i < proposal.approvals.len() {
+        if &proposal.approvals.get(i).unwrap() == signer {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Load a proposal by id.
+pub fn get_proposal(env: &Env, proposal_id: u64) -> Result<Proposal, MultisigError> {
+    env.storage()
+        .persistent()
+        .get(&MultisigStorageKey::Proposal(proposal_id))
+        .ok_or(MultisigError::ProposalNotFound)
+}
+
+// ── Execution guard ─────────────────────────────────────────────────────────────
+
+/// Check whether `proposal` is ready to execute.
+///
+/// Returns `Ok(())` when:
+/// 1. The proposal is still `Pending` (not already executed).
+/// 2. The approval count meets or exceeds the config threshold.
+/// 3. The current ledger timestamp has not passed `expires_at`.
+///
+/// # Errors
+/// - [`MultisigError::InvalidConfig`] — no multi-sig config set.
+/// - [`MultisigError::AlreadyExecuted`] — already executed.
+/// - [`MultisigError::ThresholdNotMet`] — not enough approvals yet.
+/// - [`MultisigError::ProposalExpired`] — proposal has expired.
+pub fn require_can_execute(env: &Env, proposal: &Proposal) -> Result<(), MultisigError> {
+    let config = get_config(env).ok_or(MultisigError::InvalidConfig)?;
+
+    if proposal.status == ProposalStatus::Executed {
+        return Err(MultisigError::AlreadyExecuted);
+    }
+    if (proposal.approvals.len() as u32) < config.threshold {
+        return Err(MultisigError::ThresholdNotMet);
+    }
+    if env.ledger().timestamp() > proposal.expires_at {
+        return Err(MultisigError::ProposalExpired);
+    }
+    Ok(())
+}
+
+/// Transition the proposal to `Executed`.
+///
+/// This should be called **after** the privileged action has successfully
+/// completed.  Once marked executed the proposal cannot be run again.
+pub fn mark_executed(env: &Env, proposal_id: u64) -> Result<(), MultisigError> {
+    let mut proposal = get_proposal(env, proposal_id)?;
+    if proposal.status == ProposalStatus::Executed {
+        return Err(MultisigError::AlreadyExecuted);
+    }
+    proposal.status = ProposalStatus::Executed;
+    env.storage()
+        .persistent()
+        .set(&MultisigStorageKey::Proposal(proposal_id), &proposal);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _, Bytes, Env};
+
+    #[contract]
+    struct TestHost;
+
+    #[contractimpl]
+    impl TestHost {
+        pub fn dummy() {}
+    }
+
+    fn setup() -> (Env, Address, Vec<Address>, MultisigConfig) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TestHost, ());
+        let signer_a = Address::generate(&env);
+        let signer_b = Address::generate(&env);
+        let signer_c = Address::generate(&env);
+        let signers = soroban_sdk::vec![&env, signer_a.clone(), signer_b.clone(), signer_c.clone()];
+        let config = MultisigConfig {
+            signers: signers.clone(),
+            threshold: 2,
+            proposal_timeout_secs: 86_400, // 1 day
+        };
+        env.as_contract(&contract_id, || {
+            set_config(&env, &config).unwrap();
+        });
+        (env, contract_id, signers, config)
+    }
+
+    // ── propose ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn propose_creates_proposal_and_auto_approves_proposer() {
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let payload = Bytes::new(&env);
+
+        let id = env.as_contract(&cid, || {
+            propose(&env, &proposer, payload).unwrap()
+        });
+
+        let proposal = env.as_contract(&cid, || get_proposal(&env, id).unwrap());
+        assert_eq!(proposal.proposer, proposer);
+        assert_eq!(proposal.status, ProposalStatus::Pending);
+        assert_eq!(proposal.approvals.len(), 1);
+        assert!(has_approved(&proposal, &proposer));
+    }
+
+    #[test]
+    fn propose_by_non_signer_rejected() {
+        let (env, cid, _signers, _config) = setup();
+        let impostor = Address::generate(&env);
+        let payload = Bytes::new(&env);
+
+        let result = env.as_contract(&cid, || propose(&env, &impostor, payload));
+        assert_eq!(result, Err(MultisigError::Unauthorized));
+    }
+
+    #[test]
+    fn propose_without_config_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TestHost, ());
+        let signer = Address::generate(&env);
+        let payload = Bytes::new(&env);
+
+        let result = env.as_contract(&contract_id, || propose(&env, &signer, payload));
+        assert_eq!(result, Err(MultisigError::InvalidConfig));
+    }
+
+    // ── approve ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn approval_reaches_threshold() {
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let approver = signers.get(1).unwrap();
+        let payload = Bytes::new(&env);
+
+        let id = env.as_contract(&cid, || {
+            let id = propose(&env, &proposer, payload).unwrap();
+            let count = approve(&env, &approver, id).unwrap();
+            assert_eq!(count, 2);
+            id
+        });
+
+        let proposal = env.as_contract(&cid, || get_proposal(&env, id).unwrap());
+        assert_eq!(proposal.approvals.len(), 2);
+        assert!(require_can_execute(&env, &proposal).is_ok());
+    }
+
+    #[test]
+    fn duplicate_approval_rejected() {
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let payload = Bytes::new(&env);
+
+        let id = env.as_contract(&cid, || {
+            let id = propose(&env, &proposer, payload).unwrap();
+            // First approval by a second signer should succeed
+            let _ = approve(&env, &signers.get(1).unwrap(), id).unwrap();
+            // Proposer trying again should fail
+            let result = approve(&env, &proposer, id);
+            assert_eq!(result, Err(MultisigError::AlreadyApproved));
+            id
+        });
+    }
+
+    #[test]
+    fn unauthorized_signer_approval_rejected() {
+        let (env, cid, _signers, _config) = setup();
+        let impostor = Address::generate(&env);
+        let payload = Bytes::new(&env);
+        let proposer = Address::generate(&env);
+
+        let result = env.as_contract(&cid, || {
+            // We need to first create a valid proposal. Since impostor can't propose,
+            // let's use the existing signers from the config through a workaround.
+            // Actually we need to set up a valid proposal first.
+            let _ = set_config(
+                &env,
+                &MultisigConfig {
+                    signers: soroban_sdk::vec![&env, proposer.clone()],
+                    threshold: 1,
+                    proposal_timeout_secs: 86_400,
+                },
+            );
+            let id = propose(&env, &proposer, payload).unwrap();
+            approve(&env, &impostor, id)
+        });
+        assert_eq!(result, Err(MultisigError::Unauthorized));
+    }
+
+    // ── expiry ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn proposal_expires_and_cannot_execute() {
+        use soroban_sdk::testutils::Ledger;
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let approver = signers.get(1).unwrap();
+        let payload = Bytes::new(&env);
+
+        let id = env.as_contract(&cid, || {
+            let id = propose(&env, &proposer, payload).unwrap();
+            let _ = approve(&env, &approver, id).unwrap();
+            // Jump past expiry
+            env.ledger().with_mut(|l| l.timestamp = 86_401);
+            let proposal = get_proposal(&env, id).unwrap();
+            let result = require_can_execute(&env, &proposal);
+            assert_eq!(result, Err(MultisigError::ProposalExpired));
+            // approve should also fail
+            let result = approve(&env, &signers.get(2).unwrap(), id);
+            assert_eq!(result, Err(MultisigError::ProposalExpired));
+            id
+        });
+    }
+
+    #[test]
+    fn proposal_not_expired_at_exact_expiry_second() {
+        use soroban_sdk::testutils::Ledger;
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let approver = signers.get(1).unwrap();
+        let payload = Bytes::new(&env);
+
+        env.as_contract(&cid, || {
+            let id = propose(&env, &proposer, payload).unwrap();
+            let _ = approve(&env, &approver, id).unwrap();
+            // Jump to exactly the expiry second (exclusive upper bound)
+            env.ledger().with_mut(|l| l.timestamp = 86_400);
+            let proposal = get_proposal(&env, id).unwrap();
+            assert!(require_can_execute(&env, &proposal).is_ok());
+        });
+    }
+
+    // ── execute ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn mark_executed_and_idempotent_rejection() {
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let approver = signers.get(1).unwrap();
+        let payload = Bytes::new(&env);
+
+        env.as_contract(&cid, || {
+            let id = propose(&env, &proposer, payload).unwrap();
+            let _ = approve(&env, &approver, id).unwrap();
+            let proposal = get_proposal(&env, id).unwrap();
+            assert!(require_can_execute(&env, &proposal).is_ok());
+
+            // First execution succeeds
+            assert!(mark_executed(&env, id).is_ok());
+            // Second attempt fails
+            assert_eq!(mark_executed(&env, id), Err(MultisigError::AlreadyExecuted));
+            // The proposal should now be Executed
+            let proposal = get_proposal(&env, id).unwrap();
+            assert_eq!(proposal.status, ProposalStatus::Executed);
+        });
+    }
+
+    #[test]
+    fn execute_before_threshold_rejected() {
+        let (env, cid, signers, _config) = setup();
+        let proposer = signers.get(0).unwrap();
+        let payload = Bytes::new(&env);
+
+        env.as_contract(&cid, || {
+            let id = propose(&env, &proposer, payload).unwrap();
+            let proposal = get_proposal(&env, id).unwrap();
+            // Only 1 approval (proposer), threshold is 2
+            let result = require_can_execute(&env, &proposal);
+            assert_eq!(result, Err(MultisigError::ThresholdNotMet));
+        });
+    }
+}

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -5,10 +5,10 @@ pub mod migration;
 
 use emergency_unstake::{EmergencyMultiSigConfig, EmergencyRequest};
 use migration::{MigrationKey, StakeInfoV2};
-use shared::{initializable, pausable};
+use shared::{initializable, multisig, pausable};
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, Env, IntoVal, String,
-    Symbol, Val, Vec,
+    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, Env, IntoVal,
+    String, Symbol, Val, Vec,
 };
 
 // ── Slash severity tiers ──────────────────────────────────────────────────────
@@ -145,6 +145,12 @@ pub enum StorageKey {
     EmergencyMultiSigConfig,
     /// Per-staker pending emergency unstake request (approvals accumulate here).
     EmergencyRequest(Address),
+    // ── Issue #689: Slash appeal ─────────────────────────────────────────────────
+    SlashCounter,
+    SlashRecord(u64),
+    SlashAppeal(u64),
+    SlashedFundsHeld(u64),
+    AppealWindowSecs,
 }
 
 #[contracterror]
@@ -195,6 +201,18 @@ pub enum StakeVaultError {
     InvalidEmergencyPenalty = 23,
     /// Multi-sig required count is 0 or exceeds the number of admins.
     InvalidMultiSigConfig = 24,
+    /// The privileged action requires multi-sig approval; use propose/approve/execute.
+    RequiresMultisig = 25,
+    // ── Issue #689: Slash appeal ─────────────────────────────────────────────────
+    InvalidAppealWindow = 26,
+    AppealWindowClosed = 27,
+    SlashNotFound = 28,
+    AppealAlreadyExists = 29,
+    AppealAlreadyResolved = 30,
+    // ── Rate limiting & validation ───────────────────────────────────────────────
+    RateLimitExceeded = 31,
+    InvalidAmount = 32,
+    RemainingStakeBelowMinimum = 33,
 }
 
 /// A pending unstake request held in the FIFO queue (issue #663).
@@ -264,6 +282,44 @@ soroban_sdk::contractmeta!(
     val = env!("STELLAR_GIT_COMMIT")
 );
 
+// ── Multi-sig action discriminators ──────────────────────────────────────────
+
+/// First byte of a multi-sig action payload identifying the privileged action.
+mod action {
+    pub const PAUSE: u8 = 0;
+    pub const UNPAUSE: u8 = 1;
+    pub const SET_MINIMUM_STAKE: u8 = 2;
+    pub const SET_MINIMUM_STAKE_DURATION: u8 = 3;
+    pub const CONFIGURE_SLASH_TIERS: u8 = 4;
+    pub const SET_APPEAL_WINDOW: u8 = 5;
+}
+
+fn encode_action(env: &Env, tag: u8, data: &[u8]) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.push_back(tag);
+    for &byte in data {
+        b.push_back(byte);
+    }
+    b
+}
+
+fn encode_i128_bytes(value: i128) -> [u8; 16] {
+    let mut buf = [0u8; 16];
+    let le = value.to_le_bytes();
+    buf.copy_from_slice(&le);
+    buf
+}
+
+fn decode_i128_from_bytes(env: &Env, payload: &Bytes, offset: u32) -> i128 {
+    let mut buf = [0u8; 16];
+    let mut i = 0;
+    while i < 16 {
+        buf[i] = payload.get(offset + i as u32).unwrap_or(0);
+        i += 1;
+    }
+    i128::from_le_bytes(buf)
+}
+
 #[contract]
 pub struct StakeVaultContract;
 
@@ -297,11 +353,15 @@ impl StakeVaultContract {
 
     // ── Emergency pause (shared::pausable) ────────────────────────────────────
 
-    /// Admin: pause all stake/unstake operations.
+    /// Pause all stake/unstake operations.
     ///
-    /// Uses the shared [`pausable`] module so pause behavior and event shape
-    /// are consistent across all contracts that adopt it (Issue #561).
-    pub fn pause(env: Env) {
+    /// When multi-sig is configured this entrypoint returns
+    /// [`StakeVaultError::RequiresMultisig`]; use `propose_action` /
+    /// `approve_action` / `execute_action` instead.
+    pub fn pause(env: Env) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -309,10 +369,14 @@ impl StakeVaultContract {
             .expect("not initialized");
         admin.require_auth();
         pausable::set_paused(&env, true);
+        Ok(())
     }
 
-    /// Admin: resume operations.
-    pub fn unpause(env: Env) {
+    /// Resume operations. Behaviour mirrors [`pause`].
+    pub fn unpause(env: Env) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -320,6 +384,7 @@ impl StakeVaultContract {
             .expect("not initialized");
         admin.require_auth();
         pausable::set_paused(&env, false);
+        Ok(())
     }
 
     pub fn is_paused(env: Env) -> bool {
@@ -466,9 +531,15 @@ impl StakeVaultContract {
 
     // ── Admin: configure minimum stake duration ────────────────────────────────
 
-    /// Admin: set the minimum duration (in seconds) that newly staked funds
+    /// Set the minimum duration (in seconds) that newly staked funds
     /// must remain locked before counting toward voting power.
+    ///
+    /// When multi-sig is configured use `execute_action` with action
+    /// [`action::SET_MINIMUM_STAKE_DURATION`] instead.
     pub fn set_minimum_stake_duration(env: Env, duration_secs: u64) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -506,7 +577,10 @@ impl StakeVaultContract {
 
     // ── Minimum stake ──────────────────────────────────────────────────────────
 
-    pub fn set_minimum_stake(env: Env, minimum: i128) {
+    pub fn set_minimum_stake(env: Env, minimum: i128) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -516,6 +590,7 @@ impl StakeVaultContract {
         env.storage()
             .instance()
             .set(&StorageKey::MinimumStake, &minimum);
+        Ok(())
     }
 
     pub fn get_minimum_stake(env: Env) -> i128 {
@@ -523,6 +598,176 @@ impl StakeVaultContract {
             .instance()
             .get(&StorageKey::MinimumStake)
             .unwrap_or(0)
+    }
+
+    // ── Multi-sig approval flow ────────────────────────────────────────────────
+
+    /// Admin: configure the N-of-M multi-sig parameters for privileged actions.
+    ///
+    /// Once configured, single-admin-gated entrypoints such as
+    /// [`set_minimum_stake`] will return [`StakeVaultError::RequiresMultisig`]
+    /// and must instead be invoked via `propose_action` / `approve_action` /
+    /// `execute_action`.
+    ///
+    /// Pass `None` to clear the config and restore single-admin behaviour.
+    pub fn set_multisig_config(
+        env: Env,
+        caller: Address,
+        config: Option<multisig::MultisigConfig>,
+    ) -> Result<(), StakeVaultError> {
+        caller.require_auth();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(StakeVaultError::NotInitialized)?;
+        if caller != admin {
+            return Err(StakeVaultError::Unauthorized);
+        }
+        if let Some(cfg) = config {
+            multisig::set_config(&env, &cfg)
+                .map_err(|_| StakeVaultError::InvalidMultiSigConfig)?;
+        } else {
+            env.storage()
+                .instance()
+                .remove(&multisig::MultisigStorageKey::Config);
+        }
+        Ok(())
+    }
+
+    /// Propose a privileged action. `caller` must be a registered signer.
+    /// Returns the proposal ID.
+    pub fn propose_action(
+        env: Env,
+        caller: Address,
+        payload: Bytes,
+    ) -> Result<u64, StakeVaultError> {
+        caller.require_auth();
+        multisig::propose(&env, &caller, payload)
+            .map_err(|_| StakeVaultError::Unauthorized)
+    }
+
+    /// Approve a pending proposal. `caller` must be a registered signer.
+    /// Returns the current number of approvals.
+    pub fn approve_action(
+        env: Env,
+        caller: Address,
+        proposal_id: u64,
+    ) -> Result<u32, StakeVaultError> {
+        caller.require_auth();
+        multisig::approve(&env, &caller, proposal_id)
+            .map_err(|e| -> StakeVaultError {
+                match e {
+                    multisig::MultisigError::ProposalNotFound => {
+                        StakeVaultError::EmergencyRequestNotFound
+                    }
+                    multisig::MultisigError::AlreadyApproved => StakeVaultError::AlreadyApproved,
+                    multisig::MultisigError::ProposalExpired => {
+                        StakeVaultError::EmergencyRequestExpired
+                    }
+                    _ => StakeVaultError::Unauthorized,
+                }
+            })
+    }
+
+    /// Execute an approved proposal. Decodes the action payload and performs
+    /// the privileged action, then marks the proposal as executed.
+    pub fn execute_action(
+        env: Env,
+        caller: Address,
+        proposal_id: u64,
+    ) -> Result<(), StakeVaultError> {
+        caller.require_auth();
+        let proposal = multisig::get_proposal(&env, proposal_id)
+            .map_err(|_| StakeVaultError::EmergencyRequestNotFound)?;
+        multisig::require_can_execute(&env, &proposal)
+            .map_err(|e| -> StakeVaultError {
+                match e {
+                    multisig::MultisigError::AlreadyExecuted => {
+                        StakeVaultError::EmergencyRequestNotFound
+                    }
+                    multisig::MultisigError::ThresholdNotMet => {
+                        StakeVaultError::Unauthorized
+                    }
+                    multisig::MultisigError::ProposalExpired => {
+                        StakeVaultError::EmergencyRequestExpired
+                    }
+                    _ => StakeVaultError::Unauthorized,
+                }
+            })?;
+
+        let payload = proposal.payload;
+        let tag = payload.get(0).ok_or(StakeVaultError::Unauthorized)?;
+        match tag {
+            action::PAUSE => Self::do_pause(&env)?,
+            action::UNPAUSE => Self::do_unpause(&env)?,
+            action::SET_MINIMUM_STAKE => {
+                let minimum = decode_i128_from_bytes(&env, &payload, 1);
+                env.storage()
+                    .instance()
+                    .set(&StorageKey::MinimumStake, &minimum);
+            }
+            action::SET_MINIMUM_STAKE_DURATION => {
+                let mut buf = [0u8; 8];
+                let mut i = 0;
+                while i < 8 {
+                    buf[i] = payload.get(1 + i as u32).unwrap_or(0);
+                    i += 1;
+                }
+                let duration = u64::from_le_bytes(buf);
+                env.storage()
+                    .instance()
+                    .set(&StorageKey::MinimumStakeDuration, &duration);
+            }
+            action::CONFIGURE_SLASH_TIERS => {
+                let minor = decode_i128_from_bytes(&env, &payload, 1) as u32;
+                let major = decode_i128_from_bytes(&env, &payload, 17) as u32;
+                let critical = decode_i128_from_bytes(&env, &payload, 33) as u32;
+                if minor > 10_000 || major > 10_000 || critical > 10_000 {
+                    return Err(StakeVaultError::InvalidSlashTier);
+                }
+                let cfg = SlashTierConfig {
+                    minor_bps: minor,
+                    major_bps: major,
+                    critical_bps: critical,
+                };
+                env.storage()
+                    .instance()
+                    .set(&StorageKey::SlashTierConfig, &cfg);
+            }
+            action::SET_APPEAL_WINDOW => {
+                let mut buf = [0u8; 8];
+                let mut i = 0;
+                while i < 8 {
+                    buf[i] = payload.get(1 + i as u32).unwrap_or(0);
+                    i += 1;
+                }
+                let window = u64::from_le_bytes(buf);
+                if window > 2_592_000 {
+                    return Err(StakeVaultError::InvalidAppealWindow);
+                }
+                env.storage()
+                    .instance()
+                    .set(&StorageKey::AppealWindowSecs, &window);
+            }
+            _ => return Err(StakeVaultError::Unauthorized),
+        }
+
+        multisig::mark_executed(&env, proposal_id)
+            .map_err(|_| StakeVaultError::Unauthorized)?;
+        Ok(())
+    }
+
+    // ── Internal execution helpers ────────────────────────────────────────────
+
+    fn do_pause(env: &Env) -> Result<(), StakeVaultError> {
+        pausable::set_paused(env, true);
+        Ok(())
+    }
+
+    fn do_unpause(env: &Env) -> Result<(), StakeVaultError> {
+        pausable::set_paused(env, false);
+        Ok(())
     }
 
     pub fn notify_stake_below_minimum(env: Env, provider: Address) {
@@ -968,14 +1213,20 @@ impl StakeVaultContract {
 
     // ── Slash ──────────────────────────────────────────────────────────────────
 
-    /// Admin: configure the slash percentage for each severity tier (in basis points).
+    /// Configure the slash percentage for each severity tier (in basis points).
     /// `minor_bps`, `major_bps`, `critical_bps` must all be <= 10_000.
+    ///
+    /// When multi-sig is configured use `execute_action` with action
+    /// [`action::CONFIGURE_SLASH_TIERS`] instead.
     pub fn configure_slash_tiers(
         env: Env,
         minor_bps: u32,
         major_bps: u32,
         critical_bps: u32,
     ) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -1179,10 +1430,16 @@ impl StakeVaultContract {
 
     // ── Issue #689: Slash appeal window ────────────────────────────────────────
 
-    /// Admin: set the window (in seconds) after a slash during which the
+    /// Set the window (in seconds) after a slash during which the
     /// affected provider may submit an evidence appeal.
     /// Set to 0 to disable appeals entirely.
+    ///
+    /// When multi-sig is configured use `execute_action` with action
+    /// [`action::SET_APPEAL_WINDOW`] instead.
     pub fn set_appeal_window(env: Env, window_secs: u64) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -2,11 +2,13 @@
 
 use crate::{
     migration::{MigrationKey, StakeInfoV2},
-    SlashSeverity, StakeVaultContract, StakeVaultContractClient, StakeVaultError,
+    action, encode_action, encode_i128_bytes, SlashSeverity, StakeVaultContract,
+    StakeVaultContractClient, StakeVaultError,
 };
+use shared::multisig::MultisigConfig;
 use soroban_sdk::{
-    contract, contractimpl, testutils::Address as _, token::StellarAssetClient, Address, Env, Map,
-    MuxedAddress, Symbol,
+    contract, contractimpl, testutils::Address as _, token::StellarAssetClient, Address, Bytes, Env,
+    Map, MuxedAddress, Symbol, Vec,
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -1425,12 +1427,14 @@ mod slash_severity_tests {
 mod slash_appeal_tests {
     use crate::{
         migration::{MigrationKey, StakeInfoV2},
-        AppealStatus, SlashSeverity, StakeVaultContract, StakeVaultContractClient, StakeVaultError,
+        action, encode_action, encode_i128_bytes, AppealStatus, SlashSeverity,
+        StakeVaultContract, StakeVaultContractClient, StakeVaultError,
     };
+    use shared::multisig::MultisigConfig;
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
         token::StellarAssetClient,
-        Address, Env, Map, String, Symbol,
+        Address, Bytes, Env, Map, String, Symbol, Vec,
     };
 
     fn sac_token(env: &Env, admin: &Address) -> Address {
@@ -1924,5 +1928,177 @@ mod slash_appeal_tests {
 
         assert_eq!(client.get_slash_record(&0u64).unwrap().provider, p1);
         assert_eq!(client.get_slash_record(&1u64).unwrap().provider, p2);
+    }
+
+    // ── Multi-sig approval flow tests ─────────────────────────────────────────
+
+    fn multisig_env() -> (Env, Address, Address, Vec<Address>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let sig_reg = Address::generate(&env);
+        let token = sac_token(&env, &admin);
+        let vault_id = env.register(StakeVaultContract, ());
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        client.initialize(&admin, &token, &sig_reg);
+
+        let signer_a = Address::generate(&env);
+        let signer_b = Address::generate(&env);
+        let signer_c = Address::generate(&env);
+        let signers = soroban_sdk::vec![&env, signer_a.clone(), signer_b.clone(), signer_c.clone()];
+        let cfg = MultisigConfig {
+            signers: signers.clone(),
+            threshold: 2,
+            proposal_timeout_secs: 86_400,
+        };
+        client.set_multisig_config(&admin, &Some(cfg));
+        (env, vault_id, admin, signers)
+    }
+
+    #[test]
+    fn set_minimum_stake_returns_requires_multisig_when_configured() {
+        let (env, vault_id, _admin, _signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let result = client.try_set_minimum_stake(&1_000_000i128);
+        assert_eq!(result, Err(Ok(StakeVaultError::RequiresMultisig)));
+    }
+
+    #[test]
+    fn pause_returns_requires_multisig_when_configured() {
+        let (env, vault_id, _admin, _signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let result = client.try_pause();
+        assert_eq!(result, Err(Ok(StakeVaultError::RequiresMultisig)));
+    }
+
+    #[test]
+    fn propose_approve_execute_set_minimum_stake() {
+        let (env, vault_id, _admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        // Proposer encodes the action
+        let payload = {
+            let e = &env;
+            encode_action(e, action::SET_MINIMUM_STAKE, &encode_i128_bytes(500_000i128))
+        };
+
+        // Propose by signer A
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+
+        // Approve by signer B (threshold = 2, so this reaches threshold)
+        let count = client.approve_action(&signers.get(1).unwrap(), &id);
+        assert_eq!(count, 2);
+
+        // Execute (auto-unwraps in mock auth mode)
+        client.execute_action(&signers.get(0).unwrap(), &id);
+
+        // Verify the state change
+        assert_eq!(client.get_minimum_stake(), 500_000);
+    }
+
+    #[test]
+    fn propose_approve_execute_pause() {
+        let (env, vault_id, _admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        let payload = {
+            let e = &env;
+            encode_action(e, action::PAUSE, &[])
+        };
+
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        let _ = client.approve_action(&signers.get(1).unwrap(), &id);
+        client.execute_action(&signers.get(0).unwrap(), &id);
+        assert!(client.is_paused());
+    }
+
+    #[test]
+    fn execute_before_threshold_rejected() {
+        let (env, vault_id, _admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        let payload = {
+            let e = &env;
+            encode_action(e, action::PAUSE, &[])
+        };
+
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        // Only 1 approval, threshold is 2
+        let result = client.try_execute_action(&signers.get(0).unwrap(), &id);
+        assert_eq!(result, Err(Ok(StakeVaultError::Unauthorized)));
+    }
+
+    #[test]
+    fn duplicate_approval_rejected() {
+        let (env, vault_id, _admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        let payload = {
+            let e = &env;
+            encode_action(e, action::SET_MINIMUM_STAKE, &encode_i128_bytes(100_000i128))
+        };
+
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        // Second signer approves
+        let _ = client.approve_action(&signers.get(1).unwrap(), &id);
+        // First signer tries to approve again — fails
+        let result = client.try_approve_action(&signers.get(0).unwrap(), &id);
+        assert_eq!(result, Err(Ok(StakeVaultError::AlreadyApproved)));
+    }
+
+    #[test]
+    fn unauthorized_signer_approval_rejected() {
+        let (env, vault_id, _admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let impostor = Address::generate(&env);
+
+        let payload = {
+            let e = &env;
+            encode_action(e, action::PAUSE, &[])
+        };
+
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        let result = client.try_approve_action(&impostor, &id);
+        assert_eq!(result, Err(Ok(StakeVaultError::Unauthorized)));
+    }
+
+    #[test]
+    fn proposal_expiry_blocks_execution() {
+        use soroban_sdk::testutils::Ledger;
+        let (env, vault_id, _admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        let payload = {
+            let e = &env;
+            encode_action(e, action::PAUSE, &[])
+        };
+
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        let _ = client.approve_action(&signers.get(1).unwrap(), &id);
+
+        // Jump past the 1-day expiry
+        env.ledger().with_mut(|l| l.timestamp = 86_401);
+
+        let result = client.try_execute_action(&signers.get(0).unwrap(), &id);
+        assert_eq!(result, Err(Ok(StakeVaultError::EmergencyRequestExpired)));
+    }
+
+    #[test]
+    fn clear_multisig_restores_direct_admin() {
+        let (env, vault_id, admin, signers) = multisig_env();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        // With multisig configured, direct call fails
+        assert_eq!(
+            client.try_set_minimum_stake(&1_000_000i128),
+            Err(Ok(StakeVaultError::RequiresMultisig))
+        );
+
+        // Admin clears the multisig config
+        client.set_multisig_config(&admin, &None);
+
+        // Now direct admin call succeeds again (auto-unwraps in mock auth)
+        client.set_minimum_stake(&1_000_000i128);
+        assert_eq!(client.get_minimum_stake(), 1_000_000);
     }
 }

--- a/stellar-swipe/contracts/stake_vault/src/tests_emergency.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests_emergency.rs
@@ -4,7 +4,7 @@
 
 use crate::{StakeVaultContract, StakeVaultContractClient, StakeVaultError};
 use soroban_sdk::{
-    testutils::Address as _, token::StellarAssetClient, vec, Address, Env, Vec,
+    testutils::{Address as _, Ledger}, token::StellarAssetClient, vec, Address, Env, Vec,
 };
 
 fn setup(env: &Env) -> (Address, Address, Address) {
@@ -26,7 +26,7 @@ fn fund_staker(env: &Env, token: &Address, admin: &Address, staker: &Address, am
 
 fn do_stake(env: &Env, contract_id: &Address, staker: &Address, amount: i128) {
     let client = StakeVaultContractClient::new(env, contract_id);
-    client.deposit_stake(staker, &amount).unwrap();
+    client.deposit_stake(staker, &amount);
 }
 
 /// Happy path: request approved by enough signers, executes with penalty, funds transferred.
@@ -42,28 +42,22 @@ fn test_approved_within_threshold_executes_with_penalty() {
 
     // Configure 2-of-2 multi-sig, 10% penalty, 3600 s timeout.
     let admins: Vec<Address> = vec![&env, signer1.clone(), signer2.clone()];
-    client
-        .configure_emergency_multisig(&admin, &admins, &2u32, &1_000u32, &3600u64)
-        .unwrap();
+    client.configure_emergency_multisig(&admin, &admins, &2u32, &1_000u32, &3600u64);
 
     // Stake some tokens.
     fund_staker(&env, &token, &admin, &staker, 1_000_000);
     do_stake(&env, &id, &staker, 1_000_000);
 
     // Staker requests emergency unstake.
-    client.request_emergency_unstake(&staker).unwrap();
+    client.request_emergency_unstake(&staker);
     assert!(client.get_emergency_request(&staker).is_some());
 
     // First approval — not yet at threshold.
-    client
-        .approve_emergency_unstake(&signer1, &staker)
-        .unwrap();
+    client.approve_emergency_unstake(&signer1, &staker);
     assert!(client.get_emergency_request(&staker).is_some());
 
     // Second approval — threshold reached, executes.
-    client
-        .approve_emergency_unstake(&signer2, &staker)
-        .unwrap();
+    client.approve_emergency_unstake(&signer2, &staker);
 
     // Request should be consumed.
     assert!(client.get_emergency_request(&staker).is_none());
@@ -84,18 +78,14 @@ fn test_insufficient_approvals_does_not_execute() {
     let staker = Address::generate(&env);
 
     let admins: Vec<Address> = vec![&env, signer1.clone(), signer2.clone()];
-    client
-        .configure_emergency_multisig(&admin, &admins, &2u32, &1_000u32, &3600u64)
-        .unwrap();
+    client.configure_emergency_multisig(&admin, &admins, &2u32, &1_000u32, &3600u64);
 
     fund_staker(&env, &token, &admin, &staker, 500_000);
     do_stake(&env, &id, &staker, 500_000);
 
-    client.request_emergency_unstake(&staker).unwrap();
+    client.request_emergency_unstake(&staker);
     // Only one approval out of two required.
-    client
-        .approve_emergency_unstake(&signer1, &staker)
-        .unwrap();
+    client.approve_emergency_unstake(&signer1, &staker);
 
     // Funds still locked.
     assert_eq!(client.get_stake(&staker), 500_000);
@@ -118,21 +108,19 @@ fn test_request_expiry_without_threshold() {
     // Use valid 1-of-1 but with short timeout and check expiry before approval.
     let admins2: Vec<Address> = vec![&env, signer.clone()];
     let timeout_secs: u64 = 60;
-    client
-        .configure_emergency_multisig(&admin, &admins2, &1u32, &0u32, &timeout_secs)
-        .unwrap();
+    client.configure_emergency_multisig(&admin, &admins2, &1u32, &0u32, &timeout_secs);
 
     fund_staker(&env, &token, &admin, &staker, 200_000);
     do_stake(&env, &id, &staker, 200_000);
 
     env.ledger().with_mut(|l| l.timestamp = 1_000);
-    client.request_emergency_unstake(&staker).unwrap();
+    client.request_emergency_unstake(&staker);
 
     // Advance time past the timeout.
     env.ledger().with_mut(|l| l.timestamp = 1_000 + timeout_secs + 1);
 
     // expire_request should succeed and remove the stale request.
-    client.expire_emergency_request(&staker).unwrap();
+    client.expire_emergency_request(&staker);
     assert!(client.get_emergency_request(&staker).is_none());
 
     // approve should now return EmergencyRequestNotFound.


### PR DESCRIPTION
## Summary

Adds a shared multi-sig N-of-M approval trait (`shared/src/multisig.rs`) and migrates the `stake_vault` contract's privileged admin functions to use it. When a `MultisigConfig` is set, single-admin gated functions (`pause`, `unpause`, `set_minimum_stake`, etc.) return `RequiresMultisig` and must go through a propose → approve → execute flow with N-of-M signer approvals.

## Changes

### New file
- **`contracts/shared/src/multisig.rs`** — Shared multisig module with:
  - `MultisigConfig` (signers, threshold, proposal timeout), `Proposal`, `ProposalStatus` types
  - `MultisigStorageKey` + `MultisigError` (Soroban `#[contracttype]`)
  - Functions: `set_config`, `validate_config`, `is_signer`, `propose`, `approve`, `get_proposal`, `has_approved`, `require_can_execute`, `mark_executed`
  - Unit tests covering all core paths (threshold execution, expiry, duplicate/unauthorized rejection, idempotent execution)

### Modified files

- **`contracts/shared/src/lib.rs`** — Added `pub mod multisig` + re-exports

- **`contracts/stake_vault/src/lib.rs`**
  - Added `mod action` with discriminator constants for 6 privileged actions
  - Added `encode_action`, `encode_i128_bytes`, `decode_i128_from_bytes` helpers
  - Added entrypoints: `set_multisig_config`, `propose_action`, `approve_action`, `execute_action`
  - Migrated `pause`, `unpause`, `set_minimum_stake`, `set_minimum_stake_duration`, `configure_slash_tiers`, `set_appeal_window` — each checks for multisig config and returns `RequiresMultisig` when configured
  - Added missing `StorageKey` and `StakeVaultError` variants referenced by pre-existing code (unblocks compilation)

- **`contracts/stake_vault/src/tests.rs`** — 9 new multisig integration tests (propose→approve→execute flow, error cases)
- **`contracts/stake_vault/src/tests_emergency.rs`** — Fixed `.unwrap()` on auto-unwrapped Soroban client methods

- **`contracts/integration_tests/Cargo.toml`** — Fixed duplicate `[dev-dependencies]` section

### Test results

- **stake_vault**: 92/94 pass (2 pre-existing event assertion failures, unrelated)
- **shared**: `cargo check` passes (test compilation blocked by pre-existing `asset_registry.rs` issues)

## Design

- Module-based approach (not a trait), consistent with existing `pausable.rs` pattern
- `Optional<MultisigConfig>` storage — `None` = single-admin fallback, `Some` = multisig required
- Actions encoded as `Bytes` payloads with discriminator byte + data; dispatch by first byte
- Proposals use Soroban `Expirable`-style exclusive upper-bound timeout
- Dedicated `MultisigStorageKey` enum avoids collision with contract-local `StorageKey`

### Closes #749