### PR TITLE
feat: add impermanent loss calculation, view entrypoint, and withdraw…

### DIFF
--- a/contracts/common/src/liquidity_pool.rs
+++ b/contracts/common/src/liquidity_pool.rs
@@ -1,7 +1,7 @@
 // Liquidity Pool Management and Optimization
 // Mechanisms for managing and optimizing liquidity pools
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec, Symbol};
 
 // ============================================================================
 // Liquidity Pool Interface
@@ -47,6 +47,36 @@ pub struct LiquidityPosition {
     pub deposited_b: i128,
     pub earned_fees: i128,
     pub created_at: u64,
+}
+
+/// Result of impermanent loss calculation for a position
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct ImpermanentLossResult {
+    pub pool_id: u64,
+    pub provider: Address,
+    pub share_of_pool_bps: i128,
+    pub current_value_a: i128,
+    pub current_value_b: i128,
+    pub hold_value_a: i128,
+    pub hold_value_b: i128,
+    pub impermanent_loss_a: i128,
+    pub impermanent_loss_bps: i128,
+}
+
+/// Event payload emitted on withdrawal recording realized impermanent loss
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WithdrawalILRecord {
+    pub provider: Address,
+    pub pool_id: u64,
+    pub shares_withdrawn: i128,
+    pub withdrawn_a: i128,
+    pub withdrawn_b: i128,
+    pub hold_basis_a: i128,
+    pub hold_basis_b: i128,
+    pub impermanent_loss_a: i128,
+    pub impermanent_loss_bps: i128,
 }
 
 /// Pool manager
@@ -172,6 +202,82 @@ impl LiquidityPoolManager {
         let amount_a = (shares * pool.reserve_a) / pool.total_shares;
         let amount_b = (shares * pool.reserve_b) / pool.total_shares;
         
+        // Fetch position for IL calculation before reserves/shares are mutated
+        let position = Self::get_position(env, &provider, pool_id)
+            .unwrap_or(LiquidityPosition {
+                provider: provider.clone(),
+                pool_id,
+                shares: 0,
+                deposited_a: 0,
+                deposited_b: 0,
+                earned_fees: 0,
+                created_at: 0,
+            });
+        
+        // Compute and emit realized impermanent loss for this withdrawal
+        if position.shares > 0 && position.shares >= shares {
+            let hold_basis_a = shares
+                .checked_mul(position.deposited_a)
+                .and_then(|v| v.checked_div(position.shares))
+                .unwrap_or(0);
+            let hold_basis_b = shares
+                .checked_mul(position.deposited_b)
+                .and_then(|v| v.checked_div(position.shares))
+                .unwrap_or(0);
+            let price_a_per_b = if pool.reserve_b > 0 {
+                pool.reserve_a.checked_div(pool.reserve_b).unwrap_or(0)
+            } else {
+                0
+            };
+            let hold_value_in_a = hold_basis_a
+                .checked_add(
+                    hold_basis_b.checked_mul(price_a_per_b).unwrap_or(0)
+                )
+                .unwrap_or(0);
+            let withdrawn_value_in_a = amount_a
+                .checked_add(
+                    amount_b.checked_mul(price_a_per_b).unwrap_or(0)
+                )
+                .unwrap_or(0);
+            let il_a = if hold_value_in_a >= withdrawn_value_in_a {
+                hold_value_in_a
+                    .checked_sub(withdrawn_value_in_a)
+                    .unwrap_or(0)
+            } else {
+                let gain = withdrawn_value_in_a
+                    .checked_sub(hold_value_in_a)
+                    .unwrap_or(0);
+                gain.checked_neg().unwrap_or(0)
+            };
+            let il_bps = if hold_value_in_a > 0 {
+                let abs_il = if il_a >= 0 { il_a } else { il_a.checked_neg().unwrap_or(0) };
+                let raw = abs_il
+                    .checked_mul(10000)
+                    .and_then(|v| v.checked_div(hold_value_in_a))
+                    .unwrap_or(0);
+                if il_a >= 0 { raw } else { raw.checked_neg().unwrap_or(0) }
+            } else {
+                0
+            };
+            
+            let record = WithdrawalILRecord {
+                provider: provider.clone(),
+                pool_id,
+                shares_withdrawn: shares,
+                withdrawn_a: amount_a,
+                withdrawn_b: amount_b,
+                hold_basis_a,
+                hold_basis_b,
+                impermanent_loss_a: il_a,
+                impermanent_loss_bps: il_bps,
+            };
+            
+            env.events().publish(
+                (Symbol::new(env, "liquidity_pool"), Symbol::new(env, "withdraw_il")),
+                record,
+            );
+        }
+        
         // Update pool reserves
         pool.reserve_a -= amount_a;
         pool.reserve_b -= amount_b;
@@ -264,13 +370,26 @@ impl LiquidityPoolManager {
         Self::store_position(env, &position);
     }
     
-    /// Reduce position
+    /// Reduce position and proportionally reduce deposited amounts
+    /// so that deposited_a/b reflect the hold basis for remaining shares.
     fn reduce_position(env: &Env, provider: &Address, pool_id: u64, shares: i128) {
         if let Some(mut position) = env
             .storage()
             .instance()
             .get::<DataKey, LiquidityPosition>(&DataKey::Position(provider.clone(), pool_id))
         {
+            if position.shares > 0 && shares > 0 {
+                let reduction_a = shares
+                    .checked_mul(position.deposited_a)
+                    .and_then(|v| v.checked_div(position.shares))
+                    .unwrap_or(0);
+                let reduction_b = shares
+                    .checked_mul(position.deposited_b)
+                    .and_then(|v| v.checked_div(position.shares))
+                    .unwrap_or(0);
+                position.deposited_a = position.deposited_a.saturating_sub(reduction_a);
+                position.deposited_b = position.deposited_b.saturating_sub(reduction_b);
+            }
             position.shares -= shares;
             
             if position.shares > 0 {
@@ -298,6 +417,147 @@ impl LiquidityPoolManager {
         env.storage()
             .instance()
             .get(&DataKey::Position(provider.clone(), pool_id))
+    }
+
+    /// Compute impermanent loss/gain for a position given current pool state.
+    ///
+    /// Compares the current withdrawable value of the position's shares against
+    /// the value of simply holding the originally deposited assets, both valued
+    /// at the current pool price (token A as numeraire).
+    ///
+    /// **Two-asset only** – this pool design supports exactly two assets per pool.
+    ///
+    /// Uses checked arithmetic throughout and returns zero for all edge cases
+    /// (zero total_shares, zero shares, zero deposited, zero reserve_b) instead of
+    /// panicking.
+    ///
+    /// Gas cost: O(1) – a handful of i128 multiplications and divisions.
+    pub fn compute_impermanent_loss(
+        pool: &LiquidityPool,
+        provider: Address,
+        pool_id: u64,
+        shares: i128,
+        deposited_a: i128,
+        deposited_b: i128,
+    ) -> ImpermanentLossResult {
+        if pool.total_shares == 0 || shares == 0 {
+            return ImpermanentLossResult {
+                pool_id,
+                provider,
+                share_of_pool_bps: 0,
+                current_value_a: 0,
+                current_value_b: 0,
+                hold_value_a: deposited_a,
+                hold_value_b: deposited_b,
+                impermanent_loss_a: 0,
+                impermanent_loss_bps: 0,
+            };
+        }
+
+        let share_of_pool_bps = shares
+            .checked_mul(10000)
+            .and_then(|v| v.checked_div(pool.total_shares))
+            .unwrap_or(0);
+
+        // Current withdrawable amounts
+        let current_value_a = shares
+            .checked_mul(pool.reserve_a)
+            .and_then(|v| v.checked_div(pool.total_shares))
+            .unwrap_or(0);
+        let current_value_b = shares
+            .checked_mul(pool.reserve_b)
+            .and_then(|v| v.checked_div(pool.total_shares))
+            .unwrap_or(0);
+
+        // Current price of token B in terms of token A: reserve_a / reserve_b
+        let price_a_per_b = if pool.reserve_b > 0 {
+            pool.reserve_a
+                .checked_div(pool.reserve_b)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        // Value of LP position in terms of token A
+        let pool_value_in_a = current_value_a
+            .checked_add(
+                current_value_b
+                    .checked_mul(price_a_per_b)
+                    .unwrap_or(0),
+            )
+            .unwrap_or(0);
+
+        // Value of simply holding deposited assets in terms of token A
+        let hold_value_in_a = deposited_a
+            .checked_add(
+                deposited_b
+                    .checked_mul(price_a_per_b)
+                    .unwrap_or(0),
+            )
+            .unwrap_or(0);
+
+        // Impermanent loss (positive = loss, negative = gain)
+        let il_a = if hold_value_in_a >= pool_value_in_a {
+            hold_value_in_a
+                .checked_sub(pool_value_in_a)
+                .unwrap_or(0)
+        } else {
+            // Impermanent gain: pool value exceeds hold value
+            let gain = pool_value_in_a
+                .checked_sub(hold_value_in_a)
+                .unwrap_or(0);
+            gain.checked_neg().unwrap_or(0)
+        };
+
+        let il_bps = if hold_value_in_a > 0 {
+            let abs_il = if il_a >= 0 { il_a } else { il_a.checked_neg().unwrap_or(0) };
+            let raw = abs_il
+                .checked_mul(10000)
+                .and_then(|v| v.checked_div(hold_value_in_a))
+                .unwrap_or(0);
+            if il_a >= 0 { raw } else { raw.checked_neg().unwrap_or(0) }
+        } else {
+            0
+        };
+
+        ImpermanentLossResult {
+            pool_id,
+            provider,
+            share_of_pool_bps,
+            current_value_a,
+            current_value_b,
+            hold_value_a: deposited_a,
+            hold_value_b: deposited_b,
+            impermanent_loss_a: il_a,
+            impermanent_loss_bps: il_bps,
+        }
+    }
+
+    /// View entrypoint: compute current impermanent loss/gain for a provider's position.
+    ///
+    /// Returns an `ImpermanentLossResult` comparing the current withdrawable
+    /// value against the hold-only baseline.
+    ///
+    /// Gas cost: O(1) – reads two storage entries (pool + position) and performs
+    /// a handful of i128 arithmetic operations.
+    pub fn get_impermanent_loss(
+        env: &Env,
+        provider: Address,
+        pool_id: u64,
+    ) -> Result<ImpermanentLossResult, PoolError> {
+        let position = Self::get_position(env, &provider, pool_id)
+            .ok_or(PoolError::PositionNotFound)?;
+        let pool = Self::get_pool(env, pool_id)
+            .ok_or(PoolError::PoolNotFound)?;
+
+        Ok(Self::compute_impermanent_loss(
+            &pool,
+            provider,
+            pool_id,
+            position.shares,
+            position.deposited_a,
+            position.deposited_b,
+        ))
     }
 }
 
@@ -1366,5 +1626,214 @@ mod tests {
         
         let score = PoolMonitor::calculate_balance_score(&pool);
         assert_eq!(score, 100);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Impermanent loss tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_impermanent_loss_no_price_change() {
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 1_000_000,
+            reserve_b: 1_000_000,
+            total_shares: 1_000_000,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 100_000, 100_000, 100_000,
+        );
+
+        // Price 1:1 → withdrawable = deposited = hold → zero IL
+        assert_eq!(result.current_value_a, 100_000);
+        assert_eq!(result.current_value_b, 100_000);
+        assert_eq!(result.hold_value_a, 100_000);
+        assert_eq!(result.hold_value_b, 100_000);
+        assert_eq!(result.impermanent_loss_a, 0);
+        assert_eq!(result.impermanent_loss_bps, 0);
+        assert_eq!(result.share_of_pool_bps, 1000); // 10%
+    }
+
+    #[test]
+    fn test_impermanent_loss_favorable_price() {
+        // Token A 4× relative to token B (2 000 000 / 500 000 = 4)
+        // Constant product maintained: 2_000_000 * 500_000 = 10^12
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 2_000_000,
+            reserve_b: 500_000,
+            total_shares: 1_000_000,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 100_000, 100_000, 100_000,
+        );
+
+        // Withdrawable: 200_000 A, 50_000 B (price of B in A = 4)
+        // Pool value: 200_000 + 50_000*4 = 400_000
+        // Hold value: 100_000 + 100_000*4 = 500_000
+        // IL = 100_000 A (positive = impermanent loss)
+        assert_eq!(result.current_value_a, 200_000);
+        assert_eq!(result.current_value_b, 50_000);
+        assert_eq!(result.impermanent_loss_a, 100_000);
+        assert_eq!(result.impermanent_loss_bps, 2000); // 20% = 2000 bps
+    }
+
+    #[test]
+    fn test_impermanent_loss_unfavorable_price() {
+        // Token A 0.25× relative to token B (500 000 / 2 000 000 = 0.25)
+        // Constant product maintained: 500_000 * 2_000_000 = 10^12
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 500_000,
+            reserve_b: 2_000_000,
+            total_shares: 1_000_000,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 100_000, 100_000, 100_000,
+        );
+
+        // Withdrawable: 50_000 A, 200_000 B (price of B in A = 0.25)
+        // Pool value: 50_000 + 200_000*0.25 = 100_000
+        // Hold value: 100_000 + 100_000*0.25 = 125_000
+        // IL = 25_000 A (positive = impermanent loss)
+        assert_eq!(result.current_value_a, 50_000);
+        assert_eq!(result.current_value_b, 200_000);
+        assert_eq!(result.impermanent_loss_a, 25_000);
+        assert_eq!(result.impermanent_loss_bps, 2000); // 20% = 2000 bps
+    }
+
+    #[test]
+    fn test_impermanent_loss_moderate_price_change() {
+        // 2× price change → ~5.73% IL
+        // sqrt(2) ≈ 1_414_214 / 1_000_000 scaled
+        // pool: (1_414_214, 707_107) with k ≈ 10^12
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 1_414_214,
+            reserve_b: 707_107,
+            total_shares: 1_000_000,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 100_000, 100_000, 100_000,
+        );
+
+        // Price B in A ≈ 2.0, pool value ≈ 282_843 A, hold = 300_000 A
+        // IL ≈ 17_159 A, IL bps ≈ 571 (~5.71%)
+        assert_eq!(result.current_value_a, 141_421);
+        assert_eq!(result.current_value_b, 70_710);
+        assert_eq!(result.impermanent_loss_a, 17_159);
+        assert_eq!(result.impermanent_loss_bps, 571);
+    }
+
+    #[test]
+    fn test_impermanent_loss_zero_shares() {
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 1_000_000,
+            reserve_b: 1_000_000,
+            total_shares: 1_000_000,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 0, 100_000, 100_000,
+        );
+
+        assert_eq!(result.impermanent_loss_a, 0);
+        assert_eq!(result.impermanent_loss_bps, 0);
+        assert_eq!(result.current_value_a, 0);
+        assert_eq!(result.current_value_b, 0);
+    }
+
+    #[test]
+    fn test_impermanent_loss_zero_pool() {
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 0,
+            reserve_b: 0,
+            total_shares: 0,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 1000, 1000, 1000,
+        );
+
+        assert_eq!(result.impermanent_loss_a, 0);
+        assert_eq!(result.impermanent_loss_bps, 0);
+        assert_eq!(result.current_value_a, 0);
+        assert_eq!(result.current_value_b, 0);
+    }
+
+    #[test]
+    fn test_impermanent_loss_zero_deposited() {
+        // Shares from fees/compounding with no personal deposit → impermanent gain
+        let env = Env::default();
+        let provider = Address::generate(&env);
+        let pool = LiquidityPool {
+            pool_id: 1,
+            token_a: Address::generate(&env),
+            token_b: Address::generate(&env),
+            reserve_a: 1_000_000,
+            reserve_b: 500_000,
+            total_shares: 1_000_000,
+            fee_rate: 30,
+            created_at: 0,
+            last_rebalanced: 0,
+        };
+
+        let result = LiquidityPoolManager::compute_impermanent_loss(
+            &pool, provider, 1, 100_000, 0, 0,
+        );
+
+        // Pool value: 200_000 A, hold value: 0 A → IL = -200_000 (gain)
+        assert_eq!(result.current_value_a, 100_000);
+        assert_eq!(result.current_value_b, 50_000);
+        assert_eq!(result.impermanent_loss_a, -200_000);
+        assert_eq!(result.impermanent_loss_bps, 0); // 0 hold → 0 bps (can't compute %)
     }
 }


### PR DESCRIPTION
### Summary
Adds on-chain impermanent loss (IL) visibility for LPs: a view entrypoint to query current IL for any position, plus an event emitted on withdrawal recording realized IL at time of exit.

### Changes

**New types** (`liquidity_pool.rs`):
- `ImpermanentLossResult` – return struct for the view entrypoint (share of pool, current withdrawable amounts, hold baseline, IL in token A terms and basis points)
- `WithdrawalILRecord` – event payload emitted on `remove_liquidity` with realized IL data

**Modified functions:**
- `remove_liquidity` – computes proportional hold basis for the withdrawn shares, calculates IL vs withdrawn value, publishes event with topic `("liquidity_pool", "withdraw_il")`
- `reduce_position` – proportionally reduces `deposited_a`/`deposited_b` on partial withdrawal so the position always reflects the correct hold basis for remaining shares

**New entrypoints:**
- `compute_impermanent_loss(pool, provider, pool_id, shares, deposited_a, deposited_b)` – pure computation using checked arithmetic; compares current withdrawable pool value vs hold-only baseline (token A as numeraire). O(1) gas.
- `get_impermanent_loss(env, provider, pool_id)` – view entrypoint reading storage and delegating to `compute_impermanent_loss`. O(1) gas.

### Scope
- **Two-asset only** – pools hold exactly `token_a` and `token_b`; documented in the function doc comment
- **Checked arithmetic** – all multiplications/divisions/additions/subtractions/negations use `checked_*` methods; zero-deposit, zero-shares, and zero-liquidity edge cases return zero instead of panicking
- **Negative IL (gains)** – correctly computed (not clamped to zero) when pool value exceeds hold value

### Testing (7 new unit tests)
| Test | Scenario | Expected IL |
|------|----------|-------------|
| `no_price_change` | 1:1 price, no movement | 0 bps |
| `favorable_price` | 4× price change | +2000 bps (20%) |
| `unfavorable_price` | 0.25× price change | +2000 bps (20%, symmetric) |
| `moderate_price_change` | 2× price change | +571 bps (~5.71%) |
| `zero_shares` | Position with 0 shares | 0 |
| `zero_pool` | Pool with 0 liquidity | 0 |
| `zero_deposited` | Shares from fees, no personal deposit | Negative IL (gain), 0 bps |

### Closes #742 