### PR TITLE
fix(collaboration): correct reward distribution rounding and remove dead code

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/collaboration.rs
+++ b/stellar-swipe/contracts/signal_registry/src/collaboration.rs
@@ -1,5 +1,9 @@
 use crate::errors::AdminError;
 use crate::types::{Signal, SignalAction};
+use crate::collaboration::{
+    self, Author, CollaborationStatus, get_collaborative_signal,
+    is_collaborative_signal, distribute_collaborative_rewards,
+};
 use soroban_sdk::{contracttype, Address, Env, Map, Vec};
 
 #[contracttype]
@@ -112,16 +116,30 @@ pub fn distribute_collaborative_rewards(
     total_roi: i128,
 ) -> Vec<(Address, i128, i128)> {
     let mut distributions = Vec::new(env);
+    let mut fee_sum = 0i128;
+    let mut roi_sum = 0i128;
 
+    // First pass: compute floor shares
     for i in 0..authors.len() {
         let author = authors.get(i).unwrap();
         let fee_share = (total_fees * author.contribution_pct as i128) / 10000;
         let roi_share = (total_roi * author.contribution_pct as i128) / 10000;
-        distributions.push_back((author.address, fee_share, roi_share));
+        fee_sum += fee_share;
+        roi_sum += roi_share;
+        distributions.push_back((author.address.clone(), fee_share, roi_share));
+    }
+
+    // Adjust the last entry to absorb any rounding remainder
+    if let Some(last) = distributions.last_mut() {
+        let fee_rem = total_fees - fee_sum;
+        let roi_rem = total_roi - roi_sum;
+        last.1 += fee_rem;
+        last.2 += roi_rem;
     }
 
     distributions
 }
+
 
 fn store_collaborative_signal(env: &Env, signal_id: u64, authors: &Vec<Author>) {
     let mut map: Map<u64, Vec<Author>> = env
@@ -147,16 +165,3 @@ pub fn is_collaborative_signal(env: &Env, signal_id: u64) -> bool {
     get_collaborative_signal(env, signal_id).is_some()
 }
 
-/// Helper to distribute provider fees among co-authors
-/// Takes the provider_fee portion and splits it according to contribution percentages
-pub fn split_provider_fee(authors: &Vec<Author>, provider_fee: i128) -> Vec<(u32, i128)> {
-    let mut splits = Vec::new(&authors.env());
-
-    for i in 0..authors.len() {
-        let author = authors.get(i).unwrap();
-        let author_share = (provider_fee * author.contribution_pct as i128) / 10000;
-        splits.push_back((i, author_share));
-    }
-
-    splits
-}


### PR DESCRIPTION

- Ensure distribute_collaborative_rewards adjusts the last author's share to absorb any rounding remainder, guaranteeing that the sum of distributed fee/ROI equals the total.
- Remove unused split_provider_fee helper (which had a compilation error due to authors.env()) to avoid dead code and potential future misuse.

Closes https://github.com/AgesEmpire/StellarSwipe-Contract/issues/783