### PR TITLE
 Title: feat: paginated signal expiry pruning to prevent instance storage bloat 

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/analytics.rs
+++ b/stellar-swipe/contracts/signal_registry/src/analytics.rs
@@ -516,8 +516,7 @@ pub fn calculate_global_analytics_paginated(
             if let Some(signal) = signals_map.get(key) {
                 if signal.timestamp >= cutoff {
                     acc.total_signals_24h = acc.total_signals_24h.saturating_add(1);
-                    acc.total_volume_24h =
-                        acc.total_volume_24h.saturating_add(signal.total_volume);
+                    acc.total_volume_24h = acc.total_volume_24h.saturating_add(signal.total_volume);
                 }
                 if matches!(
                     signal.status,
@@ -623,14 +622,24 @@ mod pagination_tests {
             env.ledger().with_mut(|l| l.timestamp = 1_000_000);
             let map = make_map(env, 5, 999_000);
 
-            let paged =
-                calculate_global_analytics_paginated(env, &map, None, GlobalAnalyticsAccumulator::new());
+            let paged = calculate_global_analytics_paginated(
+                env,
+                &map,
+                None,
+                GlobalAnalyticsAccumulator::new(),
+            );
             assert_eq!(paged.cursor, None);
 
             let direct = calculate_global_analytics(env, &map);
-            assert_eq!(paged.accumulator.total_signals_24h, direct.total_signals_24h);
+            assert_eq!(
+                paged.accumulator.total_signals_24h,
+                direct.total_signals_24h
+            );
             assert_eq!(paged.accumulator.total_volume_24h, direct.total_volume_24h);
-            assert_eq!(paged.accumulator.avg_success_rate(), direct.avg_success_rate);
+            assert_eq!(
+                paged.accumulator.avg_success_rate(),
+                direct.avg_success_rate
+            );
         });
     }
 
@@ -661,7 +670,10 @@ mod pagination_tests {
                 }
                 assert!(pages < 10_000, "pagination did not terminate");
             }
-            assert!(pages > 1, "expected pagination to span multiple pages, got {pages}");
+            assert!(
+                pages > 1,
+                "expected pagination to span multiple pages, got {pages}"
+            );
 
             let direct = calculate_global_analytics(env, &map);
             assert_eq!(acc.total_signals_24h, direct.total_signals_24h);

--- a/stellar-swipe/contracts/signal_registry/src/churn_risk.rs
+++ b/stellar-swipe/contracts/signal_registry/src/churn_risk.rs
@@ -74,10 +74,7 @@ pub fn set_churn_threshold(env: &Env, threshold: u32) {
 
 // ─── Snapshot management ──────────────────────────────────────────────────────
 
-pub fn get_provider_churn_snapshot(
-    env: &Env,
-    provider: &Address,
-) -> Option<ProviderChurnSnapshot> {
+pub fn get_provider_churn_snapshot(env: &Env, provider: &Address) -> Option<ProviderChurnSnapshot> {
     env.storage()
         .persistent()
         .get(&ChurnStorageKey::ProviderSnapshot(provider.clone()))
@@ -112,9 +109,10 @@ pub fn update_provider_churn_snapshot(
         snapshot_at: now,
     };
 
-    env.storage()
-        .persistent()
-        .set(&ChurnStorageKey::ProviderSnapshot(provider.clone()), &snapshot);
+    env.storage().persistent().set(
+        &ChurnStorageKey::ProviderSnapshot(provider.clone()),
+        &snapshot,
+    );
 }
 
 // ─── Core scoring ─────────────────────────────────────────────────────────────
@@ -253,11 +251,9 @@ fn emit_churn_risk_elevated(
     composite_score: u32,
     level: ChurnRiskLevel,
 ) {
-    let topics = (
-        Symbol::new(env, "churn_risk_elevated"),
-        provider.clone(),
-    );
-    env.events().publish(topics, (composite_score, level as u32));
+    let topics = (Symbol::new(env, "churn_risk_elevated"), provider.clone());
+    env.events()
+        .publish(topics, (composite_score, level as u32));
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -265,8 +261,8 @@ fn emit_churn_risk_elevated(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Signal, SignalAction, SignalStatus};
     use crate::categories::{RiskLevel, SignalCategory};
+    use crate::types::{Signal, SignalAction, SignalStatus};
     use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::{vec, Env, Map, String, Vec};
 
@@ -353,7 +349,11 @@ mod tests {
             let score = get_provider_churn_risk(&env, &provider, &signals, Some(&stats));
 
             assert_eq!(score.level, ChurnRiskLevel::Low);
-            assert!(score.composite_score < 34, "score={}", score.composite_score);
+            assert!(
+                score.composite_score < 34,
+                "score={}",
+                score.composite_score
+            );
         });
     }
 
@@ -430,7 +430,11 @@ mod tests {
             let score = get_provider_churn_risk(&env, &provider, &signals, Some(&stats));
 
             assert_eq!(score.level, ChurnRiskLevel::High);
-            assert!(score.composite_score >= 67, "score={}", score.composite_score);
+            assert!(
+                score.composite_score >= 67,
+                "score={}",
+                score.composite_score
+            );
         });
     }
 

--- a/stellar-swipe/contracts/signal_registry/src/cohort_retention.rs
+++ b/stellar-swipe/contracts/signal_registry/src/cohort_retention.rs
@@ -122,7 +122,11 @@ pub fn record_activity(env: &Env, provider: &Address, user: &Address) {
 }
 
 /// Read-only: return cohort retention summary for `(provider, week_slot)`.
-pub fn get_cohort_retention(env: &Env, provider: &Address, cohort_week_slot: u64) -> CohortRetention {
+pub fn get_cohort_retention(
+    env: &Env,
+    provider: &Address,
+    cohort_week_slot: u64,
+) -> CohortRetention {
     let data = load_cohort(env, provider, cohort_week_slot);
     let total = data.total_followers;
 
@@ -148,7 +152,10 @@ pub fn get_cohort_retention(env: &Env, provider: &Address, cohort_week_slot: u64
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Env,
+    };
 
     fn setup() -> (Env, Address, Address, Address) {
         let env = Env::default();
@@ -162,7 +169,8 @@ mod tests {
     #[test]
     fn test_new_follower_joins_cohort() {
         let (env, provider, user1, _) = setup();
-        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 5);
+        env.ledger()
+            .with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 5);
 
         record_follow(&env, &provider, &user1);
 
@@ -174,11 +182,13 @@ mod tests {
     #[test]
     fn test_activity_at_week_1_recorded() {
         let (env, provider, user1, _) = setup();
-        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 10);
+        env.ledger()
+            .with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 10);
         record_follow(&env, &provider, &user1);
 
         // Advance 1 week
-        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 11);
+        env.ledger()
+            .with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 11);
         record_activity(&env, &provider, &user1);
 
         let retention = get_cohort_retention(&env, &provider, 10);
@@ -191,11 +201,13 @@ mod tests {
     #[test]
     fn test_activity_at_week_12_fills_all_buckets() {
         let (env, provider, user1, _) = setup();
-        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 0);
+        env.ledger()
+            .with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 0);
         record_follow(&env, &provider, &user1);
 
         // Advance 12 weeks
-        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 12);
+        env.ledger()
+            .with_mut(|l| l.timestamp = SECONDS_PER_WEEK * 12);
         record_activity(&env, &provider, &user1);
 
         let retention = get_cohort_retention(&env, &provider, 0);
@@ -217,7 +229,8 @@ mod tests {
         record_follow(&env, &provider, &user2);
 
         // user1 is active at week 1 (relative to their cohort)
-        env.ledger().with_mut(|l| l.timestamp = SECONDS_PER_WEEK + 1);
+        env.ledger()
+            .with_mut(|l| l.timestamp = SECONDS_PER_WEEK + 1);
         record_activity(&env, &provider, &user1);
 
         // cohort 0: user1 joined, 100% at week 1

--- a/stellar-swipe/contracts/signal_registry/src/contests.rs
+++ b/stellar-swipe/contracts/signal_registry/src/contests.rs
@@ -265,8 +265,7 @@ fn derive_tiebreak_nonce(env: &Env, random_seed: u64, ledger_sequence: u32) -> u
     let hash = env.crypto().sha256(&preimage);
     let bytes = hash.to_array();
     u64::from_be_bytes([
-        bytes[0], bytes[1], bytes[2], bytes[3],
-        bytes[4], bytes[5], bytes[6], bytes[7],
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
     ])
 }
 
@@ -326,7 +325,11 @@ pub fn finalize_contest(env: &Env, contest_id: u64) -> Result<Vec<Address>, Cont
 
     env.events().publish(
         (Symbol::new(env, "contest_randomness"), contest_id),
-        (contest.random_seed, contest.finalize_after_ledger, current_ledger),
+        (
+            contest.random_seed,
+            contest.finalize_after_ledger,
+            current_ledger,
+        ),
     );
 
     let mut qualified_entries: Vec<ContestEntry> = Vec::new(env);

--- a/stellar-swipe/contracts/signal_registry/src/events.rs
+++ b/stellar-swipe/contracts/signal_registry/src/events.rs
@@ -105,6 +105,14 @@ pub fn emit_signal_expired(env: &Env, signal_id: u64, provider: Address, expired
         .publish(topics, (signal_id, provider, expired_at_ledger));
 }
 
+/// Emitted when expired signals are permanently removed from storage
+/// (issue #779). `ledger` is the ledger sequence at prune time so off-chain
+/// indexers can track storage health over time.
+pub fn emit_signals_pruned(env: &Env, count: u32, ledger: u32) {
+    let topics = (Symbol::new(env, "signals_pruned"),);
+    env.events().publish(topics, (count, ledger));
+}
+
 pub fn emit_trade_executed(env: &Env, signal_id: u64, executor: Address, roi: i128, volume: i128) {
     let topics = (Symbol::new(env, "trade_executed"),);
     env.events()

--- a/stellar-swipe/contracts/signal_registry/src/expiry.rs
+++ b/stellar-swipe/contracts/signal_registry/src/expiry.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{Address, Env, Map, Vec};
 use stellar_swipe_common::{SECONDS_PER_30_DAY_MONTH, SECONDS_PER_DAY};
 
-use crate::events::emit_signal_expired;
+use crate::events::{emit_signal_expired, emit_signals_pruned};
 use crate::types::{Signal, SignalStatus};
 
 use shared::Expirable;
@@ -209,6 +209,72 @@ pub fn cleanup_expired_signals(
         signals_processed,
         signals_expired,
     }
+}
+
+/// Permanently remove up to `max_entries` signals whose expiry timestamp has
+/// passed (issue #779).
+///
+/// Unlike [`cleanup_expired_signals`], which only flips signal status, this
+/// deletes entries from the signals map to reclaim instance storage. Uses the
+/// same expiry boundary as [`is_expired`] (a signal at exactly its expiry
+/// second is still live). Emits a single `signals_pruned` event when at least
+/// one signal is removed.
+///
+/// Returns the pruned signals so callers can update secondary indexes.
+/// `max_entries == 0` is a no-op and returns an empty Vec.
+pub fn prune_expired_signals(
+    env: &Env,
+    signals_map: &Map<u64, Signal>,
+    max_entries: u32,
+) -> Vec<Signal> {
+    let mut pruned = Vec::new(env);
+    if max_entries == 0 {
+        return pruned;
+    }
+
+    let mut updated_map = signals_map.clone();
+    let keys = signals_map.keys();
+    for i in 0..keys.len() {
+        if pruned.len() >= max_entries {
+            break;
+        }
+        let signal_id = keys.get(i).unwrap();
+        if let Some(signal) = signals_map.get(signal_id) {
+            if is_expired(env, &signal) {
+                updated_map.remove(signal_id);
+                pruned.push_back(signal);
+            }
+        }
+    }
+
+    if !pruned.is_empty() {
+        env.storage()
+            .instance()
+            .set(&crate::StorageKey::Signals, &updated_map);
+        emit_signals_pruned(env, pruned.len(), env.ledger().sequence());
+    }
+
+    pruned
+}
+
+/// Count signals whose expiry timestamp has passed, regardless of status —
+/// i.e. what [`prune_expired_signals`] would remove given a large enough
+/// budget. Surfaced through `health_check` (issue #779).
+pub fn count_prunable_signals(env: &Env, signals_map: &Map<u64, Signal>) -> u32 {
+    let current_time = env.ledger().timestamp();
+    let mut count = 0u32;
+
+    let keys = signals_map.keys();
+    for i in 0..keys.len() {
+        let key = keys.get(i).unwrap();
+        if let Some(signal) = signals_map.get(key) {
+            if signal.is_expired(current_time) {
+                count += 1;
+            }
+        }
+    }
+
+    count
 }
 
 /// Archive old expired signals (optional - removes from active storage)
@@ -448,6 +514,60 @@ mod tests {
         // Active signal (never archive)
         let active = create_test_signal(&env, 3, current_time + 1000);
         assert!(!should_archive(&env, &active));
+    }
+
+    #[test]
+    fn test_prune_expired_signals() {
+        let env = Env::default();
+        env.ledger().set_timestamp(10000);
+        let current_time = env.ledger().timestamp();
+
+        #[allow(deprecated)]
+        let contract_id = env.register_contract(None, crate::SignalRegistry);
+        env.as_contract(&contract_id, || {
+            let mut signals = Map::new(&env);
+
+            // 3 expired, 2 active
+            for i in 0..3 {
+                signals.set(i, create_test_signal(&env, i, current_time - 1000));
+            }
+            for i in 3..5 {
+                signals.set(i, create_test_signal(&env, i, current_time + 1000));
+            }
+
+            // max_entries = 0 is a no-op
+            assert_eq!(prune_expired_signals(&env, &signals, 0).len(), 0);
+
+            // Partial prune: budget smaller than expired count
+            assert_eq!(prune_expired_signals(&env, &signals, 2).len(), 2);
+
+            // Full prune: budget larger than expired count
+            assert_eq!(prune_expired_signals(&env, &signals, 100).len(), 3);
+
+            // A signal at exactly its expiry second is still live — not pruned
+            let mut boundary = Map::new(&env);
+            boundary.set(1, create_test_signal(&env, 1, current_time));
+            assert_eq!(prune_expired_signals(&env, &boundary, 100).len(), 0);
+        });
+    }
+
+    #[test]
+    fn test_count_prunable_signals() {
+        let env = Env::default();
+        env.ledger().set_timestamp(10000);
+        let current_time = env.ledger().timestamp();
+        let mut signals = Map::new(&env);
+
+        // 2 past expiry (one already marked Expired, one still Active)
+        signals.set(0, create_test_signal(&env, 0, current_time - 1000));
+        let mut marked = create_test_signal(&env, 1, current_time - 1000);
+        marked.status = SignalStatus::Expired;
+        signals.set(1, marked);
+
+        // 1 active in the future
+        signals.set(2, create_test_signal(&env, 2, current_time + 1000));
+
+        assert_eq!(count_prunable_signals(&env, &signals), 2);
     }
 
     #[test]

--- a/stellar-swipe/contracts/signal_registry/src/leaderboard.rs
+++ b/stellar-swipe/contracts/signal_registry/src/leaderboard.rs
@@ -526,7 +526,12 @@ mod tests {
     // ── Tie-breaking tests (#611) ─────────────────────────────────────────────
 
     /// Helper: build an IndexEntry directly so `registered_at` can be controlled.
-    fn make_entry(env: &Env, provider: Address, success_rate: u32, registered_at: u64) -> IndexEntry {
+    fn make_entry(
+        env: &Env,
+        provider: Address,
+        success_rate: u32,
+        registered_at: u64,
+    ) -> IndexEntry {
         IndexEntry {
             provider,
             closed_signals: 10,
@@ -552,8 +557,18 @@ mod tests {
             let score = 7500u32;
             let mut idx = Vec::new(&env);
             // Insert later-registered first, then earlier-registered
-            upsert_sorted(&env, &mut idx, make_entry(&env, p_late.clone(), score, 2000), |e| e.success_rate as i128);
-            upsert_sorted(&env, &mut idx, make_entry(&env, p_early.clone(), score, 1000), |e| e.success_rate as i128);
+            upsert_sorted(
+                &env,
+                &mut idx,
+                make_entry(&env, p_late.clone(), score, 2000),
+                |e| e.success_rate as i128,
+            );
+            upsert_sorted(
+                &env,
+                &mut idx,
+                make_entry(&env, p_early.clone(), score, 1000),
+                |e| e.success_rate as i128,
+            );
 
             // Earlier registration (t=1000) should rank first
             assert_eq!(idx.get(0).unwrap().provider, p_early);
@@ -602,8 +617,18 @@ mod tests {
             let mut idx = Vec::new(&env);
             // p_high has score 9000, p_low has score 6000
             // p_high registered later — tie-break would put p_low first if primary score didn't dominate
-            upsert_sorted(&env, &mut idx, make_entry(&env, p_high.clone(), 9000, 5000), |e| e.success_rate as i128);
-            upsert_sorted(&env, &mut idx, make_entry(&env, p_low.clone(), 6000, 1000), |e| e.success_rate as i128);
+            upsert_sorted(
+                &env,
+                &mut idx,
+                make_entry(&env, p_high.clone(), 9000, 5000),
+                |e| e.success_rate as i128,
+            );
+            upsert_sorted(
+                &env,
+                &mut idx,
+                make_entry(&env, p_low.clone(), 6000, 1000),
+                |e| e.success_rate as i128,
+            );
 
             // Higher primary score must still win regardless of registration time
             assert_eq!(idx.get(0).unwrap().provider, p_high);

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -33,20 +33,20 @@ mod scheduling;
 mod scoring;
 mod social;
 mod stake;
+/// Storage-layout XDR snapshot regression tests (Issue #580).
+#[cfg(test)]
+mod storage_layout_tests;
 mod storage_monitor;
 mod submission;
 mod template_presets;
 mod templates;
 mod test_reputation;
-mod types;
-mod validation;
-mod versioning;
-/// Storage-layout XDR snapshot regression tests (Issue #580).
-#[cfg(test)]
-mod storage_layout_tests;
 /// Provider submission cooldown tests (Issue #661).
 #[cfg(test)]
 mod test_submission_cooldown;
+mod types;
+mod validation;
+mod versioning;
 
 pub use categories::{RiskLevel, SignalCategory};
 pub use multisig_approvals::CriticalActionPayload;
@@ -90,7 +90,7 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Bytes, Env, IntoVal, Map, String, Symbol, Val,
     Vec,
 };
-use stellar_swipe_common::{health_uninitialized, placeholder_admin, HealthStatus};
+use stellar_swipe_common::placeholder_admin;
 use stellar_swipe_common::{validate_asset_pair as validate_asset_pair_common, AssetPairError};
 use stellar_swipe_common::{ApprovalProposal, MultisigTimelockConfig, ProposalStatus};
 pub use template_presets::{SignalTemplateOverrides, SignalTemplatePreset, StoredSignalTemplate};
@@ -98,26 +98,20 @@ pub use templates::SignalTemplate;
 use templates::DEFAULT_TEMPLATE_EXPIRY_HOURS;
 use types::{
     AddressMapping, Asset, CrossChainSignal, ImportResultView, ProviderMonthlyReport,
-    RecurrencePattern, Signal, SignalDataV2, SignalEditInput, SignalPerformanceView, SignalSummary,
-    SortOption, SyncStatus, TradeExecution,
+    RecurrencePattern, RegistryHealthStatus, Signal, SignalDataV2, SignalEditInput,
+    SignalPerformanceView, SignalSummary, SortOption, SyncStatus, TradeExecution,
 };
 // SignalData is a type alias for SignalDataV2; keep the alias re-export for
 // any external clients compiled against the old name (Issue #568).
+pub use cohort_retention::{get_cohort_retention as cohort_retention_get, CohortRetention};
 pub use types::SignalData;
-pub use cohort_retention::{CohortRetention, get_cohort_retention as cohort_retention_get};
 use versioning::{CopyRecord, SignalVersion};
 
 const MAX_EXPIRY_SECONDS: u64 = SECONDS_PER_30_DAY_MONTH;
 const WARNING_WINDOW_LEDGERS: u64 = 720;
 
-soroban_sdk::contractmeta!(
-    key = "SourceHash",
-    val = env!("STELLAR_SOURCE_HASH")
-);
-soroban_sdk::contractmeta!(
-    key = "GitCommit",
-    val = env!("STELLAR_GIT_COMMIT")
-);
+soroban_sdk::contractmeta!(key = "SourceHash", val = env!("STELLAR_SOURCE_HASH"));
+soroban_sdk::contractmeta!(key = "GitCommit", val = env!("STELLAR_GIT_COMMIT"));
 
 #[contract]
 pub struct SignalRegistry;
@@ -171,6 +165,9 @@ pub enum StorageKey {
     SubmissionCooldown,
     /// Timestamp of a provider's most recent successful signal submission (issue #661).
     ProviderLastSignal(Address),
+    /// Keeper addresses allowlisted (by the admin) to call
+    /// `prune_expired_signals` alongside the admin (issue #779).
+    PruneKeepers,
 }
 #[contractimpl]
 impl SignalRegistry {
@@ -521,25 +518,138 @@ impl SignalRegistry {
     /// is never unexpectedly archived.  Open to any caller.
     pub fn bump_signals_ttl(env: Env) {
         stellar_swipe_common::ttl_manager::force_bump_persistent(&env, &StorageKey::Signals);
-        stellar_swipe_common::ttl_manager::force_bump_persistent(&env, &StorageKey::ActiveSignalsByCategory);
+        stellar_swipe_common::ttl_manager::force_bump_persistent(
+            &env,
+            &StorageKey::ActiveSignalsByCategory,
+        );
     }
 
     /// Read-only health probe for monitoring and front-ends (no auth).
-    pub fn health_check(env: Env) -> HealthStatus {
+    ///
+    /// `expired_signal_count` reports how many stored signals are past their
+    /// expiry timestamp and thus reclaimable via `prune_expired_signals`
+    /// (issue #779).
+    pub fn health_check(env: Env) -> RegistryHealthStatus {
         let version = String::from_str(&env, env!("CARGO_PKG_VERSION"));
+        let signals = Self::get_signals_map(&env);
+        let expired_signal_count = expiry::count_prunable_signals(&env, &signals);
         if !admin::has_admin(&env) {
-            return health_uninitialized(&env, version);
+            return RegistryHealthStatus {
+                is_initialized: false,
+                is_paused: false,
+                version,
+                admin: placeholder_admin(&env),
+                expired_signal_count,
+            };
         }
         let admin_addr = match get_admin(&env) {
             Ok(a) => a,
             Err(_) => placeholder_admin(&env),
         };
-        HealthStatus {
+        RegistryHealthStatus {
             is_initialized: true,
             is_paused: is_trading_paused(&env),
             version,
             admin: admin_addr,
+            expired_signal_count,
         }
+    }
+
+    /// Permanently remove up to `max_entries` expired signals from instance
+    /// storage to bound rent costs and keep `get_active_signals` scans cheap
+    /// (issue #779). Only the admin or an allowlisted keeper may call this.
+    ///
+    /// Pruned signal ids are also dropped from the per-category index.
+    /// Returns the number of signals removed; `max_entries == 0` is a no-op
+    /// that returns 0.
+    ///
+    /// # Errors
+    /// - [`AdminError::Unauthorized`] if `caller` is neither admin nor an
+    ///   allowlisted keeper.
+    pub fn prune_expired_signals(
+        env: Env,
+        caller: Address,
+        max_entries: u32,
+    ) -> Result<u32, AdminError> {
+        caller.require_auth();
+        if admin::require_admin(&env, &caller).is_err() && !Self::is_prune_keeper(&env, &caller) {
+            return Err(AdminError::Unauthorized);
+        }
+        if max_entries == 0 {
+            return Ok(0);
+        }
+
+        let signals = Self::get_signals_map(&env);
+        let pruned = expiry::prune_expired_signals(&env, &signals, max_entries);
+
+        if !pruned.is_empty() {
+            let mut cat_map = Self::get_category_index_map(&env);
+            for signal in pruned.iter() {
+                let old_list = cat_map
+                    .get(signal.category.clone())
+                    .unwrap_or(Vec::new(&env));
+                let mut new_list = Vec::new(&env);
+                for j in 0..old_list.len() {
+                    let sid = old_list.get(j).unwrap();
+                    if sid != signal.id {
+                        new_list.push_back(sid);
+                    }
+                }
+                cat_map.set(signal.category.clone(), new_list);
+            }
+            Self::save_category_index_map(&env, &cat_map);
+        }
+
+        Ok(pruned.len())
+    }
+
+    /// Allowlist a keeper address permitted to call `prune_expired_signals`
+    /// (admin only). Adding an already-listed keeper is a no-op.
+    pub fn add_prune_keeper(env: Env, caller: Address, keeper: Address) -> Result<(), AdminError> {
+        admin::require_admin(&env, &caller)?;
+        caller.require_auth();
+        let mut keepers = Self::get_prune_keepers(env.clone());
+        if !keepers.contains(&keeper) {
+            keepers.push_back(keeper);
+            env.storage()
+                .instance()
+                .set(&StorageKey::PruneKeepers, &keepers);
+        }
+        Ok(())
+    }
+
+    /// Remove a keeper address from the prune allowlist (admin only).
+    pub fn remove_prune_keeper(
+        env: Env,
+        caller: Address,
+        keeper: Address,
+    ) -> Result<(), AdminError> {
+        admin::require_admin(&env, &caller)?;
+        caller.require_auth();
+        let keepers = Self::get_prune_keepers(env.clone());
+        let mut remaining = Vec::new(&env);
+        for i in 0..keepers.len() {
+            let addr = keepers.get(i).unwrap();
+            if addr != keeper {
+                remaining.push_back(addr);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&StorageKey::PruneKeepers, &remaining);
+        Ok(())
+    }
+
+    /// Current prune-keeper allowlist (read-only).
+    pub fn get_prune_keepers(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::PruneKeepers)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    fn is_prune_keeper(env: &Env, caller: &Address) -> bool {
+        Self::get_prune_keepers(env.clone()).contains(caller)
     }
 
     pub fn set_circuit_breaker_config(
@@ -919,9 +1029,7 @@ impl SignalRegistry {
                     .persistent()
                     .get(&StorageKey::ProviderLastSignal(provider.clone()))
                     .unwrap_or(0u64);
-                if last_signal_time > 0
-                    && env.ledger().timestamp() < last_signal_time + cooldown
-                {
+                if last_signal_time > 0 && env.ledger().timestamp() < last_signal_time + cooldown {
                     return Err(AdminError::CooldownNotElapsed);
                 }
             }
@@ -1270,10 +1378,7 @@ impl SignalRegistry {
 
     /// Retrieve the full version history for a signal (audit trail, Issue #686).
     /// Returns all stored versions in chronological order.
-    pub fn get_signal_version_history(
-        env: Env,
-        signal_id: u64,
-    ) -> Vec<versioning::SignalVersion> {
+    pub fn get_signal_version_history(env: Env, signal_id: u64) -> Vec<versioning::SignalVersion> {
         versioning::get_signal_history(&env, signal_id)
     }
 
@@ -1370,9 +1475,7 @@ impl SignalRegistry {
         provider.require_auth();
 
         let mut signals = Self::get_signals_map(&env);
-        let mut signal = signals
-            .get(signal_id)
-            .ok_or(SignalCancelError::NotFound)?;
+        let mut signal = signals.get(signal_id).ok_or(SignalCancelError::NotFound)?;
 
         if signal.provider != provider {
             return Err(SignalCancelError::NotOwner);
@@ -2248,10 +2351,7 @@ impl SignalRegistry {
     /// rate (30 %), and performance trend (30 %) into a composite 0–100 score.
     /// Emits `churn_risk_elevated` when the composite score meets or exceeds the
     /// admin-configured threshold.
-    pub fn get_provider_churn_risk(
-        env: Env,
-        provider: Address,
-    ) -> churn_risk::ChurnRiskScore {
+    pub fn get_provider_churn_risk(env: Env, provider: Address) -> churn_risk::ChurnRiskScore {
         let signals = Self::get_signals_map(&env);
         let stats_map = Self::get_provider_stats_map(&env);
         let stats = stats_map.get(provider.clone());
@@ -2458,7 +2558,9 @@ impl SignalRegistry {
                 break;
             }
             let id = ids.get(i).unwrap();
-            let Some(signal) = signals_map.get(id) else { continue };
+            let Some(signal) = signals_map.get(id) else {
+                continue;
+            };
             if signal.status != SignalStatus::Active || signal.expiry <= now {
                 continue;
             }
@@ -3211,18 +3313,21 @@ mod test;
 mod test_admin_transfer;
 #[cfg(test)]
 mod test_adoption;
+/// Signal categorization query tests (Issue #660).
+#[cfg(test)]
+mod test_categorization;
 #[cfg(test)]
 mod test_emergency;
 #[cfg(test)]
 mod test_health;
 #[cfg(test)]
 mod test_multisig_approval;
+/// Paginated signal expiry pruning tests (Issue #779).
+#[cfg(test)]
+mod test_prune_expiry;
 #[cfg(test)]
 mod test_scheduling;
 #[cfg(test)]
 mod test_signal_issues;
-/// Signal categorization query tests (Issue #660).
-#[cfg(test)]
-mod test_categorization;
 #[cfg(test)]
 mod tests;

--- a/stellar-swipe/contracts/signal_registry/src/migration.rs
+++ b/stellar-swipe/contracts/signal_registry/src/migration.rs
@@ -184,7 +184,11 @@ fn snapshot_v2(v2: &Map<u64, Signal>, max_id: u64) -> MigrationSnapshot {
 /// of the same scope and reports whether they reconcile.
 fn reconcile(pre: MigrationSnapshot, post: MigrationSnapshot) -> MigrationVerification {
     let verified = pre == post;
-    MigrationVerification { verified, pre, post }
+    MigrationVerification {
+        verified,
+        pre,
+        post,
+    }
 }
 
 fn get_migration_pre_snapshot(env: &Env) -> Option<MigrationSnapshot> {
@@ -429,10 +433,16 @@ mod migration_invariant_tests {
             }
 
             let verification = get_migration_verification(env).expect("verification recorded");
-            assert!(verification.verified, "expected clean migration to reconcile: {verification:?}");
+            assert!(
+                verification.verified,
+                "expected clean migration to reconcile: {verification:?}"
+            );
             assert_eq!(verification.pre.record_count, 37);
             assert_eq!(verification.post.record_count, 37);
-            assert_eq!(verification.pre.total_volume_sum, verification.post.total_volume_sum);
+            assert_eq!(
+                verification.pre.total_volume_sum,
+                verification.post.total_volume_sum
+            );
             // Sum of (i * 100) for i in 1..=37
             let expected_sum: i128 = (1..=37i128).map(|i| i * 100).sum();
             assert_eq!(verification.pre.total_volume_sum, expected_sum);
@@ -473,11 +483,16 @@ mod migration_invariant_tests {
             }
 
             let verification = get_migration_verification(env).expect("verification recorded");
-            assert!(!verification.verified, "expected corrupted migration to be flagged as mismatched");
-            assert_eq!(verification.pre.record_count, verification.post.record_count);
+            assert!(
+                !verification.verified,
+                "expected corrupted migration to be flagged as mismatched"
+            );
+            assert_eq!(
+                verification.pre.record_count,
+                verification.post.record_count
+            );
             assert_ne!(
-                verification.pre.total_volume_sum,
-                verification.post.total_volume_sum,
+                verification.pre.total_volume_sum, verification.post.total_volume_sum,
                 "corruption should have shifted the total_volume sum"
             );
             assert_eq!(

--- a/stellar-swipe/contracts/signal_registry/src/providers.rs
+++ b/stellar-swipe/contracts/signal_registry/src/providers.rs
@@ -389,11 +389,7 @@ pub fn check_verification_eligibility(
 /// Set the specialization tags for a provider (self-selected).
 /// Replaces any existing tags for this provider.
 /// Validates that all tags are in the admin-defined set and within count limits.
-pub fn set_provider_specializations(
-    env: &Env,
-    provider: &Address,
-    tags: soroban_sdk::Vec<String>,
-) {
+pub fn set_provider_specializations(env: &Env, provider: &Address, tags: soroban_sdk::Vec<String>) {
     provider.require_auth();
 
     if tags.len() > MAX_SPECIALIZATION_TAGS_PER_PROVIDER {
@@ -486,13 +482,12 @@ pub fn set_provider_specializations(
 }
 
 /// Returns the specialization tags for a given provider.
-pub fn get_provider_specializations(
-    env: &Env,
-    provider: &Address,
-) -> soroban_sdk::Vec<String> {
+pub fn get_provider_specializations(env: &Env, provider: &Address) -> soroban_sdk::Vec<String> {
     env.storage()
         .persistent()
-        .get(&SpecializationStorageKey::ProviderSpecializations(provider.clone()))
+        .get(&SpecializationStorageKey::ProviderSpecializations(
+            provider.clone(),
+        ))
         .unwrap_or_else(|| soroban_sdk::Vec::new(env))
 }
 
@@ -890,7 +885,8 @@ mod tests {
             set_provider_specializations(env, &provider2, p2_tags);
 
             // List by tag
-            let defi_providers = list_providers_by_specialization(env, String::from_str(env, "DeFi"));
+            let defi_providers =
+                list_providers_by_specialization(env, String::from_str(env, "DeFi"));
             assert_eq!(defi_providers.len(), 1);
             assert_eq!(defi_providers.get(0).unwrap(), provider1);
         });
@@ -966,7 +962,8 @@ mod tests {
             assert_eq!(stored2.get(0).unwrap(), String::from_str(env, "Forex"));
 
             // Old tag should no longer list the provider
-            let defi_providers = list_providers_by_specialization(env, String::from_str(env, "DeFi"));
+            let defi_providers =
+                list_providers_by_specialization(env, String::from_str(env, "DeFi"));
             assert_eq!(defi_providers.len(), 0);
         });
     }

--- a/stellar-swipe/contracts/signal_registry/src/scheduling.rs
+++ b/stellar-swipe/contracts/signal_registry/src/scheduling.rs
@@ -99,7 +99,12 @@ pub fn publish_scheduled_signals(env: Env) -> Vec<u64> {
                 if scheduled.recurrence.is_recurring && scheduled.recurrence.repeat_count > 0 {
                     // Upgrade V1 → V2 on first publish of a recurring schedule.
                     let resolved = scheduled.signal_data.clone().resolve();
-                    schedule_next_occurrence(&env, &scheduled, scheduled.recurrence.clone(), resolved);
+                    schedule_next_occurrence(
+                        &env,
+                        &scheduled,
+                        scheduled.recurrence.clone(),
+                        resolved,
+                    );
                 }
 
                 env.storage()

--- a/stellar-swipe/contracts/signal_registry/src/storage_layout_tests.rs
+++ b/stellar-swipe/contracts/signal_registry/src/storage_layout_tests.rs
@@ -43,7 +43,10 @@ use soroban_sdk::{Address, Bytes, Env, String, Vec};
 
 /// Compute the hex-encoded XDR bytes of `val` using the Soroban host.
 /// Uses the `ToXdr` trait from soroban-sdk (available in testutils build).
-fn xdr_hex<T: soroban_sdk::IntoVal<Env, soroban_sdk::Val>>(env: &Env, val: T) -> std::string::String {
+fn xdr_hex<T: soroban_sdk::IntoVal<Env, soroban_sdk::Val>>(
+    env: &Env,
+    val: T,
+) -> std::string::String {
     let xdr: Bytes = val.to_xdr(env);
     let mut out = std::string::String::with_capacity(xdr.len() as usize * 2);
     for byte in xdr.iter() {
@@ -144,8 +147,13 @@ fn snapshot_signal_data_v1_layout() {
         };
 
         // Store → read-back to confirm the host accepts this layout.
-        env.storage().persistent().set(&StorageKey::MigrationCursor, &val);
-        let _: SignalDataV1 = env.storage().persistent().get(&StorageKey::MigrationCursor)
+        env.storage()
+            .persistent()
+            .set(&StorageKey::MigrationCursor, &val);
+        let _: SignalDataV1 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::MigrationCursor)
             .expect("round-trip must succeed");
 
         let hex = xdr_hex(env, val);
@@ -166,8 +174,13 @@ fn snapshot_signal_data_v2_layout() {
             risk_level: RiskLevel::Medium,
         };
 
-        env.storage().persistent().set(&StorageKey::MigrationCursor, &val);
-        let _: SignalDataV2 = env.storage().persistent().get(&StorageKey::MigrationCursor)
+        env.storage()
+            .persistent()
+            .set(&StorageKey::MigrationCursor, &val);
+        let _: SignalDataV2 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::MigrationCursor)
             .expect("round-trip must succeed");
 
         let hex = xdr_hex(env, val);
@@ -205,7 +218,8 @@ fn snapshot_scheduled_signal_layout() {
         env.storage()
             .persistent()
             .set(&ScheduleDataKey::Schedule(1u64), &val);
-        let _: ScheduledSignal = env.storage()
+        let _: ScheduledSignal = env
+            .storage()
             .persistent()
             .get(&ScheduleDataKey::Schedule(1u64))
             .expect("round-trip must succeed");
@@ -231,7 +245,9 @@ fn snapshot_mechanism_detects_field_order_sensitivity() {
             price: 3_000i128,
             rationale: String::from_str(env, "canary"),
         };
-        env.storage().persistent().set(&StorageKey::MigrationCursor, &original);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::MigrationCursor, &original);
         let decoded: SignalDataV1 = env
             .storage()
             .persistent()
@@ -239,7 +255,13 @@ fn snapshot_mechanism_detects_field_order_sensitivity() {
             .expect("must decode");
 
         // Confirm each field round-trips correctly in position order.
-        assert_eq!(decoded.price, 3_000i128, "price field must be in expected position");
-        assert_eq!(decoded.rationale, original.rationale, "rationale field must be in expected position");
+        assert_eq!(
+            decoded.price, 3_000i128,
+            "price field must be in expected position"
+        );
+        assert_eq!(
+            decoded.rationale, original.rationale,
+            "rationale field must be in expected position"
+        );
     });
 }

--- a/stellar-swipe/contracts/signal_registry/src/test_categorization.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_categorization.rs
@@ -15,7 +15,12 @@ fn setup(env: &Env) -> (Address, SignalRegistryClient) {
     (admin, client)
 }
 
-fn add_signal(env: &Env, client: &SignalRegistryClient, provider: &Address, category: SignalCategory) -> u64 {
+fn add_signal(
+    env: &Env,
+    client: &SignalRegistryClient,
+    provider: &Address,
+    category: SignalCategory,
+) -> u64 {
     client.create_signal(
         provider,
         &String::from_str(env, "XLM/USDC"),
@@ -87,8 +92,12 @@ fn pagination_offset_skips_signals() {
     // All three IDs present across pages (no duplicates)
     let ids: soroban_sdk::Vec<u64> = {
         let mut v = soroban_sdk::Vec::new(&env);
-        for i in 0..page1.len() { v.push_back(page1.get(i).unwrap().id); }
-        for i in 0..page2.len() { v.push_back(page2.get(i).unwrap().id); }
+        for i in 0..page1.len() {
+            v.push_back(page1.get(i).unwrap().id);
+        }
+        for i in 0..page2.len() {
+            v.push_back(page2.get(i).unwrap().id);
+        }
         v
     };
     assert!(ids.contains(id1));

--- a/stellar-swipe/contracts/signal_registry/src/test_health.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_health.rs
@@ -12,6 +12,7 @@ fn health_uninitialized_contract() {
     let h = client.health_check();
     assert!(!h.is_initialized);
     assert!(!h.is_paused);
+    assert_eq!(h.expired_signal_count, 0);
 }
 
 #[test]

--- a/stellar-swipe/contracts/signal_registry/src/test_prune_expiry.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_prune_expiry.rs
@@ -1,0 +1,215 @@
+//! Tests for admin/keeper-gated pruning of expired signals (Issue #779).
+
+#![cfg(test)]
+
+use super::*;
+use crate::types::SignalStatus;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, Map, String,
+};
+
+const NOW: u64 = 100_000;
+
+fn make_signal(env: &Env, id: u64, provider: &Address, expiry: u64) -> Signal {
+    Signal {
+        id,
+        provider: provider.clone(),
+        asset_pair: String::from_str(env, "XLM/USDC"),
+        action: SignalAction::Buy,
+        price: 100_000,
+        rationale: String::from_str(env, "Test signal"),
+        timestamp: env.ledger().timestamp(),
+        expiry,
+        status: SignalStatus::Active,
+        executions: 0,
+        successful_executions: 0,
+        total_volume: 0,
+        total_roi: 0,
+        category: SignalCategory::SWING,
+        risk_level: RiskLevel::Medium,
+        is_collaborative: false,
+        tags: Vec::new(env),
+        submitted_at: env.ledger().timestamp(),
+        rationale_hash: String::from_str(env, "Test signal"),
+        confidence: 50,
+        adoption_count: 0,
+        ai_validation_score: None,
+        avg_copier_roi_bps: 0,
+        copier_closed_count: 0,
+        warning_emitted: false,
+        benchmark_return_bps: None,
+        alpha_bps: None,
+    }
+}
+
+/// Seed the signals map (and per-category index) with `expired_count` signals
+/// past expiry followed by `active_count` live ones. Ids start at 1.
+fn seed_signals(env: &Env, contract_id: &Address, expired_count: u64, active_count: u64) {
+    let provider = Address::generate(env);
+    env.as_contract(contract_id, || {
+        let mut map = Map::new(env);
+        let mut ids = Vec::new(env);
+        for id in 1..=expired_count {
+            map.set(id, make_signal(env, id, &provider, NOW - 1_000));
+            ids.push_back(id);
+        }
+        for id in (expired_count + 1)..=(expired_count + active_count) {
+            map.set(id, make_signal(env, id, &provider, NOW + 1_000));
+            ids.push_back(id);
+        }
+        env.storage().instance().set(&StorageKey::Signals, &map);
+
+        let mut cat_map: Map<SignalCategory, Vec<u64>> = Map::new(env);
+        cat_map.set(SignalCategory::SWING, ids);
+        env.storage()
+            .instance()
+            .set(&StorageKey::ActiveSignalsByCategory, &cat_map);
+    });
+}
+
+fn signals_len(env: &Env, contract_id: &Address) -> u32 {
+    env.as_contract(contract_id, || {
+        let map: Map<u64, Signal> = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Signals)
+            .unwrap_or(Map::new(env));
+        map.len()
+    })
+}
+
+fn setup() -> (Env, Address, SignalRegistryClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(NOW);
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, SignalRegistry);
+    let client = SignalRegistryClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, contract_id, client, admin)
+}
+
+#[test]
+fn prune_with_no_expired_signals_returns_zero() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 0, 3);
+
+    assert_eq!(client.prune_expired_signals(&admin, &10), 0);
+    assert_eq!(signals_len(&env, &contract_id), 3);
+}
+
+#[test]
+fn prune_zero_max_entries_is_noop() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 4, 1);
+
+    assert_eq!(client.prune_expired_signals(&admin, &0), 0);
+    assert_eq!(signals_len(&env, &contract_id), 5);
+}
+
+#[test]
+fn prune_fewer_expired_than_max_entries() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 2, 3);
+
+    assert_eq!(client.prune_expired_signals(&admin, &10), 2);
+    assert_eq!(signals_len(&env, &contract_id), 3);
+
+    // Only the live signals remain
+    let active = client.get_active_signals(&0, &10, &SortOption::RecencyDesc, &None, &None);
+    assert_eq!(active.len(), 3);
+}
+
+#[test]
+fn prune_more_expired_than_max_entries_partial() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 5, 2);
+
+    // First pass prunes only up to the budget
+    assert_eq!(client.prune_expired_signals(&admin, &2), 2);
+    assert_eq!(signals_len(&env, &contract_id), 5);
+
+    // Second pass drains the rest
+    assert_eq!(client.prune_expired_signals(&admin, &10), 3);
+    assert_eq!(signals_len(&env, &contract_id), 2);
+}
+
+#[test]
+fn prune_unauthorized_caller_rejected() {
+    let (env, contract_id, client, _admin) = setup();
+    seed_signals(&env, &contract_id, 2, 0);
+
+    let stranger = Address::generate(&env);
+    let result = client.try_prune_expired_signals(&stranger, &10);
+    assert_eq!(result, Err(Ok(AdminError::Unauthorized)));
+    assert_eq!(signals_len(&env, &contract_id), 2);
+}
+
+#[test]
+fn prune_allowlisted_keeper_may_call() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 3, 1);
+
+    let keeper = Address::generate(&env);
+    client.add_prune_keeper(&admin, &keeper);
+    assert_eq!(client.get_prune_keepers().len(), 1);
+
+    assert_eq!(client.prune_expired_signals(&keeper, &10), 3);
+    assert_eq!(signals_len(&env, &contract_id), 1);
+
+    // Removed keepers lose access again
+    client.remove_prune_keeper(&admin, &keeper);
+    let result = client.try_prune_expired_signals(&keeper, &10);
+    assert_eq!(result, Err(Ok(AdminError::Unauthorized)));
+}
+
+#[test]
+fn only_admin_may_manage_keepers() {
+    let (env, _contract_id, client, _admin) = setup();
+
+    let stranger = Address::generate(&env);
+    let keeper = Address::generate(&env);
+    assert_eq!(
+        client.try_add_prune_keeper(&stranger, &keeper),
+        Err(Ok(AdminError::Unauthorized))
+    );
+    assert_eq!(
+        client.try_remove_prune_keeper(&stranger, &keeper),
+        Err(Ok(AdminError::Unauthorized))
+    );
+}
+
+#[test]
+fn prune_updates_category_index() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 2, 1);
+
+    client.prune_expired_signals(&admin, &10);
+
+    env.as_contract(&contract_id, || {
+        let cat_map: Map<SignalCategory, Vec<u64>> = env
+            .storage()
+            .instance()
+            .get(&StorageKey::ActiveSignalsByCategory)
+            .unwrap();
+        let ids = cat_map.get(SignalCategory::SWING).unwrap();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids.get(0).unwrap(), 3); // only the live signal's id remains
+    });
+}
+
+#[test]
+fn health_check_reports_expired_signal_count() {
+    let (env, contract_id, client, admin) = setup();
+    seed_signals(&env, &contract_id, 2, 1);
+
+    let h = client.health_check();
+    assert!(h.is_initialized);
+    assert_eq!(h.expired_signal_count, 2);
+
+    client.prune_expired_signals(&admin, &10);
+    let h = client.health_check();
+    assert_eq!(h.expired_signal_count, 0);
+}

--- a/stellar-swipe/contracts/signal_registry/src/test_scheduling.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_scheduling.rs
@@ -136,8 +136,7 @@ fn test_v1_signal_data_upgrades_on_read() {
             .set(&ScheduleDataKey::NextScheduleId, &1u64);
 
         // Read back and resolve — should yield V2 with default confidence/risk.
-        let (record, resolved) = get_scheduled_signal_data(&env, 0)
-            .expect("record must exist");
+        let (record, resolved) = get_scheduled_signal_data(&env, 0).expect("record must exist");
 
         // Verify the raw stored variant is still V1.
         assert!(
@@ -201,8 +200,7 @@ fn test_v2_signal_data_roundtrips() {
             .instance()
             .set(&ScheduleDataKey::NextScheduleId, &2u64);
 
-        let (_record, resolved) = get_scheduled_signal_data(&env, 1)
-            .expect("record must exist");
+        let (_record, resolved) = get_scheduled_signal_data(&env, 1).expect("record must exist");
 
         // V2 resolve is a no-op — all fields preserved exactly.
         assert_eq!(resolved.asset_pair, v2_data.asset_pair);

--- a/stellar-swipe/contracts/signal_registry/src/test_submission_cooldown.rs
+++ b/stellar-swipe/contracts/signal_registry/src/test_submission_cooldown.rs
@@ -5,7 +5,9 @@ extern crate std;
 use super::*;
 use crate::categories::{RiskLevel, SignalCategory};
 use crate::errors::AdminError;
-use soroban_sdk::{testutils::Address as _, testutils::Ledger, vec, Address, Env, InvokeError, String};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Ledger, vec, Address, Env, InvokeError, String,
+};
 
 fn setup(env: &Env) -> (Address, SignalRegistryClient) {
     env.mock_all_auths();

--- a/stellar-swipe/contracts/signal_registry/src/tests/test_signal_lifecycle.rs
+++ b/stellar-swipe/contracts/signal_registry/src/tests/test_signal_lifecycle.rs
@@ -363,8 +363,7 @@ fn cancel_before_min_lifetime_rejected() {
     let id = create_signal(&env, &client, &provider, 86_400);
 
     // Advance only 1 800 seconds — half the required lifetime.
-    env.ledger()
-        .set_timestamp(env.ledger().timestamp() + 1_800);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 1_800);
 
     let result = client.try_cancel_signal(&provider, &id);
     assert_eq!(result, Err(Ok(SignalCancelError::LifetimeNotElapsed)));
@@ -384,8 +383,7 @@ fn cancel_at_min_lifetime_boundary_succeeds() {
     client.set_min_signal_lifetime(&admin, &3_600u64);
     let id = create_signal(&env, &client, &provider, 86_400);
 
-    env.ledger()
-        .set_timestamp(env.ledger().timestamp() + 3_600);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 3_600);
 
     client.cancel_signal(&provider, &id);
     assert_eq!(
@@ -403,8 +401,7 @@ fn cancel_after_min_lifetime_succeeds() {
     client.set_min_signal_lifetime(&admin, &3_600u64);
     let id = create_signal(&env, &client, &provider, 86_400);
 
-    env.ledger()
-        .set_timestamp(env.ledger().timestamp() + 7_200);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 7_200);
 
     client.cancel_signal(&provider, &id);
     assert_eq!(

--- a/stellar-swipe/contracts/signal_registry/src/types.rs
+++ b/stellar-swipe/contracts/signal_registry/src/types.rs
@@ -1,6 +1,21 @@
 use crate::categories::{RiskLevel, SignalCategory};
 use soroban_sdk::{contracttype, Address, String, Symbol, Vec};
 
+/// Health probe response for the signal registry. Extends the shared
+/// `HealthStatus` shape with `expired_signal_count` so monitoring dashboards
+/// can surface storage-bloat pressure from expired signals (issue #779).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RegistryHealthStatus {
+    pub is_initialized: bool,
+    pub is_paused: bool,
+    pub version: String,
+    pub admin: Address,
+    /// Signals past their expiry timestamp still occupying instance storage —
+    /// what `prune_expired_signals` would remove given a large enough budget.
+    pub expired_signal_count: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SortOption {

--- a/stellar-swipe/contracts/signal_registry/src/versioning.rs
+++ b/stellar-swipe/contracts/signal_registry/src/versioning.rs
@@ -220,9 +220,7 @@ pub fn edit_signal_with_audit(
     }
 
     // Update version metadata
-    env.storage()
-        .persistent()
-        .set(&version_key, &new_version);
+    env.storage().persistent().set(&version_key, &new_version);
 
     // Emit event
     events::emit_signal_updated(env, signal_id, new_version, updater.clone());


### PR DESCRIPTION





## Summary

Closes #779.

Expired signals previously stayed in instance storage forever — `expiry.rs` only
flipped their status on read. This PR adds an on-chain pruning mechanism so the
protocol can reclaim storage, keep TTL bump costs bounded, and stay within the
64 KB instance storage limit.

## Changes

- **`prune_expired_signals(caller, max_entries) -> u32`** — new contract entry
  point. Permanently removes up to `max_entries` signals whose expiry timestamp
  has passed (same exclusive boundary as `is_expired`) and returns the count
  removed. `max_entries == 0` is a no-op returning 0. Pruned ids are also
  dropped from the `ActiveSignalsByCategory` index so it doesn't accumulate
  stale entries.
- **Authorization** — callable only by the admin or an allowlisted keeper;
  anyone else gets `AdminError::Unauthorized`. Keeper management via new
  admin-only `add_prune_keeper` / `remove_prune_keeper` entry points and a
  `get_prune_keepers` view, backed by a new `StorageKey::PruneKeepers`.
- **`signals_pruned` event** — emitted once per prune with
  `(count, ledger_sequence)` so off-chain indexers can track storage health.
- **`health_check()` now reports `expired_signal_count`** — returns a new
  `RegistryHealthStatus` type: the same four fields as the shared
  `HealthStatus` plus `expired_signal_count: u32`. A registry-specific type was
  needed because five other contracts construct the shared struct. Note this
  changes the entry point's return ABI; consumers reading the original fields
  by name are unaffected.

## Tests

17 tests pass covering the acceptance criteria:

- `test_prune_expiry.rs` (9 entry-point tests): no expired signals, zero-budget
  no-op, fewer expired than budget, partial prune across two calls,
  unauthorized caller rejected, keeper add/use/remove, keeper management is
  admin-only, category-index cleanup, health metric before/after prune.
- `expiry.rs` unit tests: prune budget/boundary behavior (signal at exactly its
  expiry second is not pruned), prunable count.
- `test_health.rs`: extended to assert `expired_signal_count`.