### PR TITLE
feat: enforce maximum concurrent open positions per user in trade_executor (#791)

### DIFF
--- a/stellar-swipe/contracts/trade_executor/src/errors.rs
+++ b/stellar-swipe/contracts/trade_executor/src/errors.rs
@@ -45,7 +45,6 @@ pub enum ContractError {
     DCAPlanAlreadyExists = 17,
     SignalExpired = 18,
     IntervalNotDue = 19,
-    ConfirmationDepthNotReached = 26,
     /// Transient: the network is congested. Caller should read `NetworkErrorDetail`
     /// via [`crate::TradeExecutorContract::get_network_error_detail`] and retry
     /// after `retry_after_ledger`.
@@ -68,6 +67,10 @@ pub enum ContractError {
     NotTradeOwner = 28,
     /// A queued trade exceeded the maximum retry limit and was moved to the dead-letter queue.
     MaxRetriesExceeded = 29,
+    /// Trade executed but the confirmation depth has not yet been reached.
+    ConfirmationDepthNotReached = 30,
+    /// The user already holds the maximum number of concurrent open positions.
+    TooManyOpenPositions = 31,
 }
 
 /// Populated when [`ContractError::InsufficientLiquidity`] is returned.

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -5,20 +5,20 @@ mod errors;
 pub mod feature_flags;
 pub mod keeper;
 mod oracle;
-pub mod risk_gates;
 pub mod priority;
+pub mod risk_gates;
 pub mod sdex;
 pub mod triggers;
 mod wire;
 
 use errors::{ContractError, InsufficientBalanceDetail, NetworkErrorDetail};
-use shared::math::normalize_amount;
 use risk_gates::{
     check_user_balance, resolve_trade_amount, validate_and_record_position,
     validate_min_trade_size, DEFAULT_ESTIMATED_COPY_TRADE_FEE, DEFAULT_MIN_TRADE_SIZE,
     MAX_BATCH_SIZE,
 };
 use sdex::{execute_sdex_swap, min_received_from_slippage};
+use shared::math::normalize_amount;
 use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, IntoVal, String, Symbol,
     Val, Vec,
@@ -87,6 +87,12 @@ pub enum StorageKey {
     DeadLetterIds(Address),
     /// Priority-lane configuration (PriorityConfig).
     PriorityConfig,
+    /// The most recent trade order awaiting confirmation-depth finalization.
+    PendingTradeConfirmation,
+    /// Maximum concurrent open positions per user (absent = [`DEFAULT_MAX_OPEN_POSITIONS`]).
+    MaxOpenPositions,
+    /// Number of currently open copy-trade positions for `user` (persistent storage).
+    UserPositionCount(Address),
     /// Consecutive priority-only batch counter for fairness fallback.
     PriorityBatchCounter,
     /// SHA-256 receipt hash for a completed trade, keyed by monotonic receipt ID.
@@ -242,14 +248,8 @@ pub struct PendingLimitOrder {
     pub expires_at_ledger: u32,
 }
 
-soroban_sdk::contractmeta!(
-    key = "SourceHash",
-    val = env!("STELLAR_SOURCE_HASH")
-);
-soroban_sdk::contractmeta!(
-    key = "GitCommit",
-    val = env!("STELLAR_GIT_COMMIT")
-);
+soroban_sdk::contractmeta!(key = "SourceHash", val = env!("STELLAR_SOURCE_HASH"));
+soroban_sdk::contractmeta!(key = "GitCommit", val = env!("STELLAR_GIT_COMMIT"));
 
 #[contract]
 pub struct TradeExecutorContract;
@@ -263,7 +263,7 @@ fn effective_estimated_fee(env: &Env) -> i128 {
 
 fn require_admin(env: &Env) -> Result<Address, ContractError> {
     oracle::require_admin(env)
-} 
+}
 fn get_confirmation_depth(env: &Env) -> u32 {
     env.storage()
         .instance()
@@ -398,6 +398,51 @@ fn decrease_open_interest(env: &Env, pair: &Address, amount: i128) {
     env.storage().instance().set(&key, &next);
 }
 
+// ── Per-user open-position cap (Issue #791) ──────────────────────────────────
+
+/// Default maximum concurrent open positions per user.
+pub const DEFAULT_MAX_OPEN_POSITIONS: u32 = 50;
+
+/// Effective per-user position cap (admin override, or [`DEFAULT_MAX_OPEN_POSITIONS`]).
+fn effective_max_open_positions(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&StorageKey::MaxOpenPositions)
+        .unwrap_or(DEFAULT_MAX_OPEN_POSITIONS)
+}
+
+fn user_position_count(env: &Env, user: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::UserPositionCount(user.clone()))
+        .unwrap_or(0)
+}
+
+fn increment_user_position_count(env: &Env, user: &Address) {
+    let key = StorageKey::UserPositionCount(user.clone());
+    let next = user_position_count(env, user).saturating_add(1);
+    env.storage().persistent().set(&key, &next);
+}
+
+/// Saturating decrement so the count can never go negative, even if a close
+/// path runs for a position opened before this counter existed.
+pub(crate) fn decrement_user_position_count(env: &Env, user: &Address) {
+    let key = StorageKey::UserPositionCount(user.clone());
+    let next = user_position_count(env, user).saturating_sub(1);
+    env.storage().persistent().set(&key, &next);
+}
+
+/// Reject a new position when a non-exempt user is already at the cap.
+fn check_position_cap(env: &Env, user: &Address, exempt: bool) -> Result<(), ContractError> {
+    if exempt {
+        return Ok(());
+    }
+    if user_position_count(env, user) >= effective_max_open_positions(env) {
+        return Err(ContractError::TooManyOpenPositions);
+    }
+    Ok(())
+}
+
 /// Compute the SHA-256 trade receipt hash over `(user, asset, amount, price, timestamp)`.
 pub fn compute_trade_hash(
     env: &Env,
@@ -413,12 +458,16 @@ pub fn compute_trade_hash(
     payload.append(&asset.to_xdr(env));
     payload.append(&soroban_sdk::Bytes::from_slice(env, &amount.to_be_bytes()));
     payload.append(&soroban_sdk::Bytes::from_slice(env, &price.to_be_bytes()));
-    payload.append(&soroban_sdk::Bytes::from_slice(env, &timestamp.to_be_bytes()));
+    payload.append(&soroban_sdk::Bytes::from_slice(
+        env,
+        &timestamp.to_be_bytes(),
+    ));
     env.crypto().sha256(&payload).into()
 }
 
 /// Store a SHA-256 receipt hash for a completed trade and emit a `trade_receipt` event.
-fn record_trade_receipt(env: &Env, user: &Address, token: &Address, amount: i128) {
+/// Returns the monotonic receipt ID assigned to this trade.
+fn record_trade_receipt(env: &Env, user: &Address, token: &Address, amount: i128) -> u64 {
     use soroban_sdk::xdr::ToXdr;
     let price: i128 = env
         .storage()
@@ -439,21 +488,33 @@ fn record_trade_receipt(env: &Env, user: &Address, token: &Address, amount: i128
     payload.append(&token.to_xdr(env));
     payload.append(&soroban_sdk::Bytes::from_slice(env, &amount.to_be_bytes()));
     payload.append(&soroban_sdk::Bytes::from_slice(env, &price.to_be_bytes()));
-    payload.append(&soroban_sdk::Bytes::from_slice(env, &timestamp.to_be_bytes()));
-    payload.append(&soroban_sdk::Bytes::from_slice(env, &receipt_id.to_be_bytes()));
+    payload.append(&soroban_sdk::Bytes::from_slice(
+        env,
+        &timestamp.to_be_bytes(),
+    ));
+    payload.append(&soroban_sdk::Bytes::from_slice(
+        env,
+        &receipt_id.to_be_bytes(),
+    ));
     let hash: BytesN<32> = env.crypto().sha256(&payload).into();
 
     env.storage()
         .instance()
         .set(&StorageKey::TradeReceiptHash(receipt_id), &hash);
-    env.storage()
-        .instance()
-        .set(&StorageKey::NextTradeReceiptId, &receipt_id.saturating_add(1));
+    env.storage().instance().set(
+        &StorageKey::NextTradeReceiptId,
+        &receipt_id.saturating_add(1),
+    );
 
     env.events().publish(
-        (Symbol::new(env, "trade_executor"), Symbol::new(env, "trade_receipt")),
+        (
+            Symbol::new(env, "trade_executor"),
+            Symbol::new(env, "trade_receipt"),
+        ),
         (receipt_id, hash),
     );
+
+    receipt_id
 }
 
 fn execute_market_copy_trade(
@@ -537,6 +598,12 @@ fn execute_market_copy_trade(
         env.storage().instance().get(&key).unwrap_or(false)
     };
 
+    // ── Per-user open-position cap (Issue #791) ────────────────────────────
+    if let Err(e) = check_position_cap(env, &user, exempt) {
+        env.storage().temporary().remove(&lock_key);
+        return Err(e);
+    }
+
     // ── Resolve effective amount (portfolio % or explicit) ─────────────────
     let oracle: Option<Address> = env.storage().instance().get(&Symbol::new(env, ORACLE_KEY));
     let effective_amount =
@@ -583,6 +650,7 @@ fn execute_market_copy_trade(
     }
 
     increase_open_interest(env, &token, amount);
+    increment_user_position_count(env, &user);
 
     // If fallback was used, emit the FeeDeductedFromReceived event.
     // The trade_id is the current position count (used as a proxy identifier).
@@ -608,13 +676,22 @@ fn execute_market_copy_trade(
         );
     }
 
-    record_trade_receipt(env, &user, &token, effective_amount);
+    let receipt_id = record_trade_receipt(env, &user, &token, effective_amount);
 
     let pending_order = wire::TradeOrder {
-        status: wire::TradeStatus::ExecutedAwaitingConfirmation,
         execution_ledger: env.ledger().sequence(),
+        trade_id: receipt_id,
+        user: user.clone(),
+        amount: effective_amount,
+        expires_at_ledger: env
+            .ledger()
+            .sequence()
+            .saturating_add(TRADE_TIMEOUT_LEDGERS),
+        status: wire::TradeStatus::ExecutedAwaitingConfirmation,
     };
-    env.storage().instance().set(&StorageKey::UserPortfolio, &pending_order);
+    env.storage()
+        .instance()
+        .set(&StorageKey::PendingTradeConfirmation, &pending_order);
 
     env.storage().temporary().remove(&lock_key);
     Ok(())
@@ -760,36 +837,52 @@ impl TradeExecutorContract {
     ///
     /// # Parameters
     pub fn set_depth(env: Env, depth: u32) -> Result<(), ContractError> {
-        Self::require_admin(&env)?;
+        require_admin(&env)?;
         set_confirmation_depth(&env, depth);
         Ok(())
     }
+
+    /// Mark the pending trade order as `Filled` once the configured
+    /// confirmation depth has elapsed since its execution ledger.
+    ///
+    /// Note: finalization confirms the fill — the position remains open (and
+    /// counted against the per-user cap) until it is closed via
+    /// [`Self::cancel_copy_trade`] or a stop-loss/take-profit trigger.
     pub fn finalize_trade(env: Env) -> Result<(), ContractError> {
-        let mut order: wire::TradeOrder = env.storage()
+        let mut order: wire::TradeOrder = env
+            .storage()
             .instance()
-            .get(&StorageKey::UserPortfolio)
-            .ok_or(ContractError::AutoTradeError(AutoTradeError::SignalNotFound))?;
+            .get(&StorageKey::PendingTradeConfirmation)
+            .ok_or(ContractError::TradeNotFound)?;
 
         if order.status != wire::TradeStatus::ExecutedAwaitingConfirmation {
-            return Err(ContractError::AutoTradeError(AutoTradeError::Unauthorized));
+            return Err(ContractError::Unauthorized);
         }
 
         let depth = get_confirmation_depth(&env);
         let current_ledger = env.ledger().sequence();
-        
+
         if current_ledger.saturating_sub(order.execution_ledger) < depth {
-            return Err(ContractError::AutoTradeError(AutoTradeError::ConfirmationDepthNotReached));
+            return Err(ContractError::ConfirmationDepthNotReached);
         }
 
         order.status = wire::TradeStatus::Filled;
-        env.storage().instance().set(&StorageKey::UserPortfolio, &order);
+        env.storage()
+            .instance()
+            .set(&StorageKey::PendingTradeConfirmation, &order);
 
         Ok(())
     }
     pub fn get_build_info(env: Env) -> soroban_sdk::Map<soroban_sdk::String, soroban_sdk::String> {
         let mut m = soroban_sdk::Map::new(&env);
-        m.set(soroban_sdk::String::from_str(&env, "version"), soroban_sdk::String::from_str(&env, env!("CARGO_PKG_VERSION")));
-        m.set(soroban_sdk::String::from_str(&env, "git_commit"), soroban_sdk::String::from_str(&env, env!("GIT_COMMIT_HASH")));
+        m.set(
+            soroban_sdk::String::from_str(&env, "version"),
+            soroban_sdk::String::from_str(&env, env!("CARGO_PKG_VERSION")),
+        );
+        m.set(
+            soroban_sdk::String::from_str(&env, "git_commit"),
+            soroban_sdk::String::from_str(&env, env!("GIT_COMMIT_HASH")),
+        );
         m
     }
 
@@ -892,6 +985,33 @@ impl TradeExecutorContract {
     pub fn is_position_limit_exempt(env: Env, user: Address) -> bool {
         let key = StorageKey::PositionLimitExempt(user);
         env.storage().instance().get(&key).unwrap_or(false)
+    }
+
+    /// Admin: set the maximum concurrent open positions per user (Issue #791).
+    /// Exempt users (see [`Self::set_position_limit_exempt`]) bypass this cap.
+    pub fn set_max_open_positions(env: Env, max: u32) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        if max == 0 {
+            panic!("max must be positive");
+        }
+        env.storage()
+            .instance()
+            .set(&StorageKey::MaxOpenPositions, &max);
+    }
+
+    /// Effective per-user position cap ([`DEFAULT_MAX_OPEN_POSITIONS`] unless overridden).
+    pub fn get_max_open_positions(env: Env) -> u32 {
+        effective_max_open_positions(&env)
+    }
+
+    /// Number of open copy-trade positions currently counted for `user`.
+    pub fn get_user_position_count(env: Env, user: Address) -> u32 {
+        user_position_count(&env, &user)
     }
 
     // ── Stop-loss / take-profit configuration ─────────────────────────────────
@@ -1328,6 +1448,17 @@ impl TradeExecutorContract {
         portfolio_pct_bps: Option<u32>,
     ) -> Result<u64, ContractError> {
         user.require_auth();
+
+        // Fail fast if the user is already at the position cap (Issue #791).
+        // The cap is re-checked at execution time, when queued positions may
+        // have been freed by intervening closes.
+        let exempt = env
+            .storage()
+            .instance()
+            .get(&StorageKey::PositionLimitExempt(user.clone()))
+            .unwrap_or(false);
+        check_position_cap(&env, &user, exempt)?;
+
         let queued_trade_id = next_queued_trade_id(&env);
         let trade = QueuedTrade {
             queued_trade_id,
@@ -1405,14 +1536,11 @@ impl TradeExecutorContract {
 
         for i in 0..ids.len() {
             let id = ids.get(i).unwrap();
-            let trade: QueuedTrade = match env
-                .storage()
-                .instance()
-                .get(&StorageKey::QueuedTrade(id))
-            {
-                Some(t) => t,
-                None => continue,
-            };
+            let trade: QueuedTrade =
+                match env.storage().instance().get(&StorageKey::QueuedTrade(id)) {
+                    Some(t) => t,
+                    None => continue,
+                };
 
             if grace_period_elapsed(&env, trade.queued_at_ledger) {
                 let result = execute_market_copy_trade(
@@ -1611,6 +1739,7 @@ impl TradeExecutorContract {
         close_args.push_back(realized_pnl.into_val(&env));
         env.invoke_contract::<()>(&portfolio, &close_sym, close_args);
         decrease_open_interest(&env, &from_token, amount);
+        decrement_user_position_count(&env, &user);
 
         shared::events::emit_trade_cancelled(
             &env,
@@ -1790,10 +1919,7 @@ impl TradeExecutorContract {
 
     /// Re-queue a dead-lettered trade, resetting its retry count.
     /// The trade re-enters the grace-period queue as a fresh attempt.
-    pub fn requeue_dead_lettered_trade(
-        env: Env,
-        trade_id: u64,
-    ) -> Result<(), ContractError> {
+    pub fn requeue_dead_lettered_trade(env: Env, trade_id: u64) -> Result<(), ContractError> {
         require_admin(&env)?;
         let failed: FailedTrade = env
             .storage()
@@ -1837,10 +1963,7 @@ impl TradeExecutorContract {
     }
 
     /// Permanently discard a dead-lettered trade (no requeue).
-    pub fn discard_dead_lettered_trade(
-        env: Env,
-        trade_id: u64,
-    ) -> Result<(), ContractError> {
+    pub fn discard_dead_lettered_trade(env: Env, trade_id: u64) -> Result<(), ContractError> {
         require_admin(&env)?;
         let failed: FailedTrade = env
             .storage()
@@ -1877,11 +2000,7 @@ impl TradeExecutorContract {
     /// Emits a `feat_flag / changed` event for transparency.
     /// Toggling a flag only affects entrypoints that explicitly check it;
     /// all other entrypoints remain unaffected.
-    pub fn set_feature_flag(
-        env: Env,
-        name: String,
-        enabled: bool,
-    ) -> Result<(), ContractError> {
+    pub fn set_feature_flag(env: Env, name: String, enabled: bool) -> Result<(), ContractError> {
         require_admin(&env)?;
         feature_flags::set_flag(&env, name, enabled);
         Ok(())

--- a/stellar-swipe/contracts/trade_executor/src/priority.rs
+++ b/stellar-swipe/contracts/trade_executor/src/priority.rs
@@ -229,9 +229,7 @@ mod tests {
     use super::*;
     use crate::BatchTradeInput;
     use soroban_sdk::{
-        contract, contractimpl, contracttype,
-        testutils::Address as _,
-        Address, Env,
+        contract, contractimpl, contracttype, testutils::Address as _, Address, Env,
     };
 
     #[contract]
@@ -261,9 +259,7 @@ mod tests {
         }
 
         pub fn set_stake(env: Env, user: Address, amount: i128) {
-            env.storage()
-                .instance()
-                .set(&MockKey::Stake(user), &amount);
+            env.storage().instance().set(&MockKey::Stake(user), &amount);
         }
 
         pub fn set_account_age(env: Env, user: Address, age: u64) {
@@ -284,7 +280,11 @@ mod tests {
 
     fn make_trade_input(env: &Env, user: Address, amount: i128) -> BatchTradeInput {
         let token = Address::generate(env);
-        BatchTradeInput { user, token, amount }
+        BatchTradeInput {
+            user,
+            token,
+            amount,
+        }
     }
 
     // --- Priority config ---

--- a/stellar-swipe/contracts/trade_executor/src/test.rs
+++ b/stellar-swipe/contracts/trade_executor/src/test.rs
@@ -76,7 +76,6 @@ impl MockUserPortfolio {
 
 const TRADE_AMOUNT: i128 = 1_000_000;
 
-
 fn test_tx_hash(env: &Env, seed: u8) -> soroban_sdk::Bytes {
     let mut arr = [0u8; 32];
     arr[0] = seed;
@@ -208,8 +207,7 @@ fn check_user_balance_more_than_sufficient() {
 
 #[test]
 fn execute_copy_trade_below_default_minimum_is_rejected() {
-    let (env, exec_id, portfolio_id, user, _admin, token) =
-        setup_with_balance(1_000_000_000);
+    let (env, exec_id, portfolio_id, user, _admin, token) = setup_with_balance(1_000_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
     let below_default_min = crate::risk_gates::DEFAULT_MIN_TRADE_SIZE - 1;
@@ -235,8 +233,7 @@ fn execute_copy_trade_below_default_minimum_is_rejected() {
 
 #[test]
 fn execute_copy_trade_below_per_asset_minimum_is_rejected() {
-    let (env, exec_id, _portfolio_id, user, _admin, token) =
-        setup_with_balance(1_000_000_000);
+    let (env, exec_id, _portfolio_id, user, _admin, token) = setup_with_balance(1_000_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
     exec.set_min_trade_size(&token, &10_000_000);
 
@@ -256,8 +253,7 @@ fn execute_copy_trade_below_per_asset_minimum_is_rejected() {
 
 #[test]
 fn execute_copy_trade_exactly_at_minimum_is_accepted() {
-    let (env, exec_id, portfolio_id, user, _admin, token) =
-        setup_with_balance(1_000_000_000);
+    let (env, exec_id, portfolio_id, user, _admin, token) = setup_with_balance(1_000_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
     exec.set_min_trade_size(&token, &10_000_000);
 
@@ -281,8 +277,7 @@ fn execute_copy_trade_exactly_at_minimum_is_accepted() {
 
 #[test]
 fn execute_copy_trade_above_minimum_is_accepted() {
-    let (env, exec_id, portfolio_id, user, _admin, token) =
-        setup_with_balance(1_000_000_000);
+    let (env, exec_id, portfolio_id, user, _admin, token) = setup_with_balance(1_000_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
     exec.set_min_trade_size(&token, &10_000_000);
 
@@ -306,8 +301,7 @@ fn execute_copy_trade_above_minimum_is_accepted() {
 
 #[test]
 fn admin_can_update_min_trade_size_for_asset() {
-    let (env, exec_id, _portfolio_id, _user, _admin, token) =
-        setup_with_balance(1_000_000_000);
+    let (env, exec_id, _portfolio_id, _user, _admin, token) = setup_with_balance(1_000_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
     assert_eq!(
@@ -321,8 +315,7 @@ fn admin_can_update_min_trade_size_for_asset() {
 
 #[test]
 fn limit_order_below_minimum_trade_size_is_rejected() {
-    let (env, exec_id, _portfolio_id, user, _admin, token) =
-        setup_with_balance(1_000_000_000);
+    let (env, exec_id, _portfolio_id, user, _admin, token) = setup_with_balance(1_000_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
     exec.set_min_trade_size(&token, &10_000_000);
 
@@ -387,7 +380,9 @@ fn execute_copy_trade_sufficient_balance_invokes_portfolio() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
     assert!(exec.get_insufficient_balance_detail(&user).is_none());
     assert_eq!(
@@ -423,7 +418,8 @@ fn twenty_first_copy_trade_fails_until_one_closed() {
         setup_with_balance(per * 30 + 1_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
-    for _ in 0..MAX_POSITIONS_PER_USER {
+    for n in 0..MAX_POSITIONS_PER_USER {
+        let nonce = (n + 1) as u64;
         exec.execute_copy_trade(
             &user,
             &token,
@@ -431,10 +427,14 @@ fn twenty_first_copy_trade_fails_until_one_closed() {
             &None::<u32>,
             &OrderType::Market,
             &None,
-            &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+            &nonce,
+            &test_tx_hash(&env, nonce as u8),
+            &far_future(&env),
         );
     }
 
+    // A failed call rolls back its nonce commit, so the retry reuses the nonce.
+    let next_nonce = (MAX_POSITIONS_PER_USER + 1) as u64;
     let err = exec.try_execute_copy_trade(
         &user,
         &token,
@@ -442,7 +442,9 @@ fn twenty_first_copy_trade_fails_until_one_closed() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &next_nonce,
+        &test_tx_hash(&env, next_nonce as u8),
+        &far_future(&env),
     );
     assert_eq!(err, Err(Ok(ContractError::PositionLimitReached)));
 
@@ -454,7 +456,9 @@ fn twenty_first_copy_trade_fails_until_one_closed() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &next_nonce,
+        &test_tx_hash(&env, next_nonce as u8),
+        &far_future(&env),
     );
 
     assert_eq!(
@@ -470,7 +474,8 @@ fn whitelisted_user_bypasses_position_limit() {
         setup_with_balance(per * 35 + 1_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
-    for _ in 0..MAX_POSITIONS_PER_USER {
+    for n in 0..MAX_POSITIONS_PER_USER {
+        let nonce = (n + 1) as u64;
         exec.execute_copy_trade(
             &user,
             &token,
@@ -478,10 +483,14 @@ fn whitelisted_user_bypasses_position_limit() {
             &None::<u32>,
             &OrderType::Market,
             &None,
-            &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+            &nonce,
+            &test_tx_hash(&env, nonce as u8),
+            &far_future(&env),
         );
     }
 
+    // A failed call rolls back its nonce commit, so the retry reuses the nonce.
+    let next_nonce = (MAX_POSITIONS_PER_USER + 1) as u64;
     let err = exec.try_execute_copy_trade(
         &user,
         &token,
@@ -489,7 +498,9 @@ fn whitelisted_user_bypasses_position_limit() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &next_nonce,
+        &test_tx_hash(&env, next_nonce as u8),
+        &far_future(&env),
     );
     assert_eq!(err, Err(Ok(ContractError::PositionLimitReached)));
 
@@ -503,7 +514,9 @@ fn whitelisted_user_bypasses_position_limit() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &next_nonce,
+        &test_tx_hash(&env, next_nonce as u8),
+        &far_future(&env),
     );
     assert_eq!(
         MockUserPortfolioClient::new(&env, &portfolio_id).get_open_position_count(&user),
@@ -513,6 +526,7 @@ fn whitelisted_user_bypasses_position_limit() {
     exec.set_position_limit_exempt(&user, &false);
     assert!(!exec.is_position_limit_exempt(&user));
 
+    let after_nonce = next_nonce + 1;
     let err2 = exec.try_execute_copy_trade(
         &user,
         &token,
@@ -520,7 +534,9 @@ fn whitelisted_user_bypasses_position_limit() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &after_nonce,
+        &test_tx_hash(&env, after_nonce as u8),
+        &far_future(&env),
     );
     assert_eq!(err2, Err(Ok(ContractError::PositionLimitReached)));
 }
@@ -606,7 +622,9 @@ fn reentrant_call_returns_reentrancy_detected() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
     assert!(
         ReentrantPortfolioClient::new(&env, &portfolio_id).was_blocked(),
@@ -640,7 +658,9 @@ fn lock_cleared_after_successful_execution() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &far_future(&env),
     );
     exec.execute_copy_trade(
         &user,
@@ -649,7 +669,9 @@ fn lock_cleared_after_successful_execution() {
         &None::<u32>,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &2u64,
+        &test_tx_hash(&env, 2),
+        &far_future(&env),
     );
 
     assert_eq!(
@@ -918,9 +940,7 @@ impl MockPortfolioWithPositions {
         env.storage()
             .instance()
             .set(&PortfolioKey::LastClosed, &trade_id);
-        env.storage()
-            .instance()
-            .set(&PortfolioKey::LastPnl, &pnl);
+        env.storage().instance().set(&PortfolioKey::LastPnl, &pnl);
     }
     pub fn last_closed(env: Env) -> Option<u64> {
         env.storage().instance().get(&PortfolioKey::LastClosed)
@@ -966,11 +986,24 @@ fn cancel_copy_trade_success() {
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
     MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
-        &user, &1u64, &10_000_000i128,
+        &user,
+        &1u64,
+        &10_000_000i128,
     );
     exec.cancel_copy_trade(
-        &user, &user, &1u64, &token_a, &token_b, &1_000_000, &900_000, &10_000_000,
-        &ReplayParams { nonce: 1, tx_hash: test_tx_hash(&env, 0), expiry_ts: far_future(&env) },
+        &user,
+        &user,
+        &1u64,
+        &token_a,
+        &token_b,
+        &1_000_000,
+        &900_000,
+        &10_000_000,
+        &ReplayParams {
+            nonce: 1,
+            tx_hash: test_tx_hash(&env, 0),
+            expiry_ts: far_future(&env),
+        },
     );
 
     assert_eq!(
@@ -986,7 +1019,9 @@ fn cancel_copy_trade_unauthorized() {
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
     MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
-        &user, &1u64, &10_000_000i128,
+        &user,
+        &1u64,
+        &10_000_000i128,
     );
 
     let err = env.as_contract(&exec_id, || {
@@ -1050,8 +1085,19 @@ fn cancel_copy_trade_pnl_calculation() {
     let portfolio = MockPortfolioWithPositionsClient::new(&env, &portfolio_id);
     portfolio.add_position_with_entry_price(&user, &2u64, &9_500_000i128);
     exec.cancel_copy_trade(
-        &user, &user, &2u64, &token_a, &token_b, &1_000_000, &900_000, &9_500_000,
-        &ReplayParams { nonce: 1, tx_hash: test_tx_hash(&env, 0), expiry_ts: far_future(&env) },
+        &user,
+        &user,
+        &2u64,
+        &token_a,
+        &token_b,
+        &1_000_000,
+        &900_000,
+        &9_500_000,
+        &ReplayParams {
+            nonce: 1,
+            tx_hash: test_tx_hash(&env, 0),
+            expiry_ts: far_future(&env),
+        },
     );
 
     // Verify the close_position was called with the correct realized_pnl.
@@ -1070,7 +1116,9 @@ fn cancel_copy_trade_third_party_rejected() {
     let third_party = Address::generate(&env);
 
     MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
-        &user, &5u64, &10_000_000i128,
+        &user,
+        &5u64,
+        &10_000_000i128,
     );
 
     let err = env.as_contract(&exec_id, || {
@@ -1094,18 +1142,30 @@ fn cancel_copy_trade_third_party_rejected() {
     assert_eq!(err, Err(ContractError::Unauthorized));
 }
 
-
 #[test]
 fn cancel_copy_trade_replay_nonce_rejected() {
     let (env, exec_id, portfolio_id, user, token_a, token_b, _) = setup_cancel(1_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
     MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
-        &user, &1u64, &10_000_000i128,
+        &user,
+        &1u64,
+        &10_000_000i128,
     );
     exec.cancel_copy_trade(
-        &user, &user, &1u64, &token_a, &token_b, &1_000_000, &900_000, &10_000_000,
-        &ReplayParams { nonce: 1, tx_hash: test_tx_hash(&env, 1), expiry_ts: far_future(&env) },
+        &user,
+        &user,
+        &1u64,
+        &token_a,
+        &token_b,
+        &1_000_000,
+        &900_000,
+        &10_000_000,
+        &ReplayParams {
+            nonce: 1,
+            tx_hash: test_tx_hash(&env, 1),
+            expiry_ts: far_future(&env),
+        },
     );
 
     let err = env.as_contract(&exec_id, || {
@@ -1147,11 +1207,24 @@ fn trade_cancelled_event_has_two_topic_format() {
     let (env, exec_id, portfolio_id, user, token_a, token_b, _) = setup_cancel(1_100_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
     MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
-        &user, &1u64, &10_000_000i128,
+        &user,
+        &1u64,
+        &10_000_000i128,
     );
     exec.cancel_copy_trade(
-        &user, &user, &1u64, &token_a, &token_b, &1_000_000, &900_000, &10_000_000,
-        &ReplayParams { nonce: 1, tx_hash: test_tx_hash(&env, 0), expiry_ts: far_future(&env) },
+        &user,
+        &user,
+        &1u64,
+        &token_a,
+        &token_b,
+        &1_000_000,
+        &900_000,
+        &10_000_000,
+        &ReplayParams {
+            nonce: 1,
+            tx_hash: test_tx_hash(&env, 0),
+            expiry_ts: far_future(&env),
+        },
     );
     let (contract, event) = last_event_topics(&env);
     assert_eq!(contract, soroban_sdk::Symbol::new(&env, "trade_executor"));
@@ -1180,7 +1253,9 @@ fn volume_limit_zero_means_no_restriction() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
 }
 
@@ -1196,7 +1271,9 @@ fn volume_under_limit_succeeds() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
 }
 
@@ -1212,7 +1289,9 @@ fn volume_at_limit_succeeds() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
 }
 
@@ -1228,7 +1307,9 @@ fn volume_over_limit_returns_error() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
     assert_eq!(result, Err(Ok(ContractError::DailyVolumeLimitExceeded)));
 }
@@ -1248,7 +1329,9 @@ fn volume_resets_on_new_day() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &far_future(&env),
     );
 
     // Advance to day 1.
@@ -1262,7 +1345,9 @@ fn volume_resets_on_new_day() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &2u64,
+        &test_tx_hash(&env, 2),
+        &far_future(&env),
     );
 }
 
@@ -1290,8 +1375,17 @@ fn primary_fee_deduction_succeeds_with_sufficient_balance() {
     exec.set_user_portfolio(&portfolio_id);
 
     // Should succeed — no fallback needed.
-    let result =
-        exec.try_execute_copy_trade(&user, &token, &amount, &None, &OrderType::Market, &None, &1u64, &test_tx_hash(&env, 0), &far_future(&env));
+    let result = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &amount,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
+    );
     assert!(result.is_ok(), "primary fee deduction should succeed");
 
     // No fee_from_received event should be emitted.
@@ -1334,8 +1428,17 @@ fn fee_fallback_activates_when_only_amount_available() {
     exec.set_copy_trade_estimated_fee(&1_000i128);
 
     // Trade should still succeed via fallback.
-    let result =
-        exec.try_execute_copy_trade(&user, &token, &amount, &None, &OrderType::Market, &None, &1u64, &test_tx_hash(&env, 0), &far_future(&env));
+    let result = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &amount,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
+    );
     assert!(result.is_ok(), "trade should succeed via fee fallback");
 
     // fee_from_received event must be emitted.
@@ -1381,7 +1484,9 @@ fn trade_fails_when_balance_below_amount() {
         &None,
         &OrderType::Market,
         &None,
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
     assert_eq!(result, Err(Ok(ContractError::InsufficientBalance)));
 }
@@ -1404,7 +1509,9 @@ fn test_limit_order_execution() {
         &None,
         &OrderType::Limit,
         &Some(10_000i128),
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
 
     // Verify order is stored
@@ -1452,7 +1559,9 @@ fn test_limit_order_expiration() {
         &None,
         &OrderType::Limit,
         &Some(10_000i128),
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 0),
+        &far_future(&env),
     );
 
     let order_ids = exec.get_pending_limit_order_ids();
@@ -1497,7 +1606,9 @@ fn test_limit_order_persistence() {
         &None,
         &OrderType::Limit,
         &Some(10_000i128),
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &far_future(&env),
     );
     exec.execute_copy_trade(
         &user,
@@ -1506,7 +1617,9 @@ fn test_limit_order_persistence() {
         &None,
         &OrderType::Limit,
         &Some(9_000i128),
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &2u64,
+        &test_tx_hash(&env, 2),
+        &far_future(&env),
     );
     exec.execute_copy_trade(
         &user,
@@ -1515,7 +1628,9 @@ fn test_limit_order_persistence() {
         &None,
         &OrderType::Limit,
         &Some(8_000i128),
-        &1u64, &test_tx_hash(&env, 0), &far_future(&env),
+        &3u64,
+        &test_tx_hash(&env, 3),
+        &far_future(&env),
     );
 
     let initial_ids = exec.get_pending_limit_order_ids();
@@ -1562,7 +1677,10 @@ fn trade_receipt_hash_is_stored_after_execute_copy_trade() {
     );
 
     let receipt = exec.get_trade_receipt(&1u64);
-    assert!(receipt.is_some(), "receipt hash must be stored after a trade");
+    assert!(
+        receipt.is_some(),
+        "receipt hash must be stored after a trade"
+    );
     let hash = receipt.unwrap();
     assert_ne!(hash, soroban_sdk::BytesN::from_array(&env, &[0u8; 32]));
 }
@@ -1666,4 +1784,196 @@ fn get_trade_receipt_returns_none_for_unknown_id() {
     let (env, exec_id, _, _, _, _) = setup_with_balance(1_000_000);
     let exec = TradeExecutorContractClient::new(&env, &exec_id);
     assert!(exec.get_trade_receipt(&999u64).is_none());
+}
+
+// ── Per-user open-position cap tests (Issue #791) ─────────────────────────────
+
+fn execute_trade(
+    env: &Env,
+    exec: &TradeExecutorContractClient,
+    user: &Address,
+    token: &Address,
+    nonce: u64,
+) {
+    exec.execute_copy_trade(
+        user,
+        token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &nonce,
+        &test_tx_hash(env, nonce as u8),
+        &far_future(env),
+    );
+}
+
+#[test]
+fn max_open_positions_defaults_to_50() {
+    let (env, exec_id, _, _, _, _) = setup_with_balance(1_000_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    assert_eq!(
+        exec.get_max_open_positions(),
+        crate::DEFAULT_MAX_OPEN_POSITIONS
+    );
+    assert_eq!(crate::DEFAULT_MAX_OPEN_POSITIONS, 50);
+}
+
+#[test]
+#[should_panic(expected = "max must be positive")]
+fn set_max_open_positions_rejects_zero() {
+    let (env, exec_id, _, _, _, _) = setup_with_balance(1_000_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.set_max_open_positions(&0);
+}
+
+#[test]
+fn open_below_cap_succeeds_and_increments_count() {
+    let (env, exec_id, _, user, _, token) = setup_with_balance(1_000_000_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.set_max_open_positions(&3);
+
+    execute_trade(&env, &exec, &user, &token, 1);
+    assert_eq!(exec.get_user_position_count(&user), 1);
+
+    execute_trade(&env, &exec, &user, &token, 2);
+    assert_eq!(exec.get_user_position_count(&user), 2);
+}
+
+#[test]
+fn open_at_exactly_cap_is_rejected() {
+    let (env, exec_id, _, user, _, token) = setup_with_balance(1_000_000_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.set_max_open_positions(&2);
+
+    execute_trade(&env, &exec, &user, &token, 1);
+    execute_trade(&env, &exec, &user, &token, 2);
+    assert_eq!(exec.get_user_position_count(&user), 2);
+
+    let err = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &3u64,
+        &test_tx_hash(&env, 3),
+        &far_future(&env),
+    );
+    assert_eq!(err, Err(Ok(ContractError::TooManyOpenPositions)));
+    assert_eq!(exec.get_user_position_count(&user), 2);
+}
+
+#[test]
+fn queue_copy_trade_rejected_at_cap() {
+    let (env, exec_id, _, user, _, token) = setup_with_balance(1_000_000_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.set_max_open_positions(&1);
+
+    execute_trade(&env, &exec, &user, &token, 1);
+
+    let err = exec.try_queue_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
+    assert_eq!(err, Err(Ok(ContractError::TooManyOpenPositions)));
+}
+
+#[test]
+fn exempt_user_ignores_cap() {
+    let (env, exec_id, _, user, _, token) = setup_with_balance(1_000_000_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.set_max_open_positions(&1);
+    exec.set_position_limit_exempt(&user, &true);
+
+    for nonce in 1u64..=3 {
+        execute_trade(&env, &exec, &user, &token, nonce);
+    }
+    // Exempt users are still counted, just not capped.
+    assert_eq!(exec.get_user_position_count(&user), 3);
+
+    // Queueing is also uncapped for exempt users.
+    exec.queue_copy_trade(&user, &token, &TRADE_AMOUNT, &None);
+}
+
+#[test]
+fn close_frees_a_slot() {
+    let (env, exec_id, portfolio_id, user, token_a, token_b, _) = setup_cancel(1_100_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    StellarAssetClient::new(&env, &token_a).mint(&user, &1_000_000_000);
+    exec.set_max_open_positions(&1);
+
+    execute_trade(&env, &exec, &user, &token_a, 1);
+    assert_eq!(exec.get_user_position_count(&user), 1);
+
+    // Cap of 1 reached — next open is rejected.
+    let err = exec.try_execute_copy_trade(
+        &user,
+        &token_a,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &2u64,
+        &test_tx_hash(&env, 2),
+        &far_future(&env),
+    );
+    assert_eq!(err, Err(Ok(ContractError::TooManyOpenPositions)));
+
+    // Close the position; the slot is freed. (The rejected call above rolled
+    // back its nonce commit, so the next sequential nonce is 2.)
+    MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
+        &user,
+        &1u64,
+        &10_000_000i128,
+    );
+    exec.cancel_copy_trade(
+        &user,
+        &user,
+        &1u64,
+        &token_a,
+        &token_b,
+        &1_000_000,
+        &900_000,
+        &10_000_000,
+        &ReplayParams {
+            nonce: 2,
+            tx_hash: test_tx_hash(&env, 20),
+            expiry_ts: far_future(&env),
+        },
+    );
+    assert_eq!(exec.get_user_position_count(&user), 0);
+
+    // A new position can be opened again.
+    execute_trade(&env, &exec, &user, &token_a, 3);
+    assert_eq!(exec.get_user_position_count(&user), 1);
+}
+
+#[test]
+fn count_never_goes_negative_on_close() {
+    let (env, exec_id, portfolio_id, user, token_a, token_b, _) = setup_cancel(1_100_000);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    // Close a position that was never counted (pre-existing position):
+    // the saturating decrement must leave the count at zero, not underflow.
+    MockPortfolioWithPositionsClient::new(&env, &portfolio_id).add_position_with_entry_price(
+        &user,
+        &7u64,
+        &10_000_000i128,
+    );
+    assert_eq!(exec.get_user_position_count(&user), 0);
+    exec.cancel_copy_trade(
+        &user,
+        &user,
+        &7u64,
+        &token_a,
+        &token_b,
+        &1_000_000,
+        &900_000,
+        &10_000_000,
+        &ReplayParams {
+            nonce: 1,
+            tx_hash: test_tx_hash(&env, 1),
+            expiry_ts: far_future(&env),
+        },
+    );
+    assert_eq!(exec.get_user_position_count(&user), 0);
 }

--- a/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
@@ -1,6 +1,6 @@
 pub mod test_batch_execute;
-pub mod test_dead_letter;
 pub mod test_dca;
+pub mod test_dead_letter;
 pub mod test_feature_flags;
 pub mod test_grace_period;
 pub mod test_market_simulation;

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_dead_letter.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_dead_letter.rs
@@ -12,8 +12,7 @@
 //! - Successful trade is not dead-lettered
 
 use crate::{
-    errors::ContractError,
-    FailedTrade, TradeExecutorContract, TradeExecutorContractClient,
+    errors::ContractError, FailedTrade, TradeExecutorContract, TradeExecutorContractClient,
     DEFAULT_MAX_RETRY_COUNT,
 };
 use soroban_sdk::{
@@ -116,16 +115,28 @@ fn failed_trade_dead_lettered_after_max_retries() {
     // First two calls: trade is retried (not yet dead-lettered).
     exec.execute_queued_trades();
     let dl_after_1 = exec.get_dead_letter_trades(&user);
-    assert_eq!(dl_after_1.len(), 0, "should not be dead-lettered after attempt 1");
+    assert_eq!(
+        dl_after_1.len(),
+        0,
+        "should not be dead-lettered after attempt 1"
+    );
 
     exec.execute_queued_trades();
     let dl_after_2 = exec.get_dead_letter_trades(&user);
-    assert_eq!(dl_after_2.len(), 0, "should not be dead-lettered after attempt 2");
+    assert_eq!(
+        dl_after_2.len(),
+        0,
+        "should not be dead-lettered after attempt 2"
+    );
 
     // Third call: max retries reached → dead-lettered.
     exec.execute_queued_trades();
     let dl_after_3 = exec.get_dead_letter_trades(&user);
-    assert_eq!(dl_after_3.len(), 1, "should be dead-lettered after attempt 3");
+    assert_eq!(
+        dl_after_3.len(),
+        1,
+        "should be dead-lettered after attempt 3"
+    );
 }
 
 /// `get_dead_letter_trades` returns the correct FailedTrade fields.
@@ -151,7 +162,10 @@ fn dead_letter_trade_has_correct_fields() {
     assert_eq!(ft.token, token);
     assert_eq!(ft.amount, AMOUNT);
     assert_eq!(ft.retry_count, DEFAULT_MAX_RETRY_COUNT);
-    assert!(ft.failure_code > 0, "failure_code should be a non-zero error discriminant");
+    assert!(
+        ft.failure_code > 0,
+        "failure_code should be a non-zero error discriminant"
+    );
 }
 
 /// A successful trade is never dead-lettered.
@@ -173,7 +187,11 @@ fn successful_trade_not_dead_lettered() {
     assert_eq!(count, 1, "trade should succeed");
 
     let dl = exec.get_dead_letter_trades(&user);
-    assert_eq!(dl.len(), 0, "successful trade must not appear in dead-letter queue");
+    assert_eq!(
+        dl.len(),
+        0,
+        "successful trade must not appear in dead-letter queue"
+    );
 }
 
 /// `get_dead_letter_trades` returns empty vec for a user with no failures.
@@ -206,7 +224,11 @@ fn admin_can_requeue_dead_lettered_trade() {
     exec.requeue_dead_lettered_trade(&queued_id);
 
     // Dead-letter queue should now be empty for this user.
-    assert_eq!(exec.get_dead_letter_trades(&user).len(), 0, "after requeue, dead-letter should be cleared");
+    assert_eq!(
+        exec.get_dead_letter_trades(&user).len(),
+        0,
+        "after requeue, dead-letter should be cleared"
+    );
 }
 
 /// Admin can permanently discard a dead-lettered trade.
@@ -226,7 +248,11 @@ fn admin_can_discard_dead_lettered_trade() {
     assert_eq!(exec.get_dead_letter_trades(&user).len(), 1);
 
     exec.discard_dead_lettered_trade(&queued_id);
-    assert_eq!(exec.get_dead_letter_trades(&user).len(), 0, "after discard, dead-letter should be cleared");
+    assert_eq!(
+        exec.get_dead_letter_trades(&user).len(),
+        0,
+        "after discard, dead-letter should be cleared"
+    );
 }
 
 /// Multiple users' dead-letter queues are isolated — one user's failures don't

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_feature_flags.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_feature_flags.rs
@@ -3,10 +3,7 @@
 
 extern crate std;
 
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env, String,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 use crate::{
     errors::ContractError,
@@ -114,10 +111,7 @@ fn execute_copy_trade_blocked_when_flag_disabled() {
         &soroban_sdk::Bytes::from_array(&env, &[0u8; 32]),
         &(env.ledger().timestamp() + 86_400),
     );
-    assert_eq!(
-        result,
-        Err(Ok(ContractError::FeatureDisabled))
-    );
+    assert_eq!(result, Err(Ok(ContractError::FeatureDisabled)));
 }
 
 // ── execute_dca_interval blocked when flag disabled ───────────────────────────
@@ -133,8 +127,5 @@ fn execute_dca_interval_blocked_when_flag_disabled() {
     let user = Address::generate(&env);
 
     let result = client.try_execute_dca_interval(&user, &1u64);
-    assert_eq!(
-        result,
-        Err(Ok(ContractError::FeatureDisabled))
-    );
+    assert_eq!(result, Err(Ok(ContractError::FeatureDisabled)));
 }

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_grace_period.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_grace_period.rs
@@ -10,9 +10,8 @@
 //! - Grace period of 0 (trades eligible immediately)
 
 use crate::{
-    errors::ContractError,
-    TradeExecutorContract, TradeExecutorContractClient,
-    QueuedTrade, DEFAULT_GRACE_PERIOD_LEDGERS,
+    errors::ContractError, QueuedTrade, TradeExecutorContract, TradeExecutorContractClient,
+    DEFAULT_GRACE_PERIOD_LEDGERS,
 };
 use soroban_sdk::{
     contract, contractimpl, contracttype,
@@ -37,14 +36,19 @@ impl MockPortfolio {
     pub fn validate_and_record(env: Env, user: Address, max_positions: u32) -> u32 {
         let key = PortfolioKey::Count(user.clone());
         let count: u32 = env.storage().instance().get(&key).unwrap_or(0);
-        if count >= max_positions { panic!("position limit reached"); }
+        if count >= max_positions {
+            panic!("position limit reached");
+        }
         let new_count = count + 1;
         env.storage().instance().set(&key, &new_count);
         new_count
     }
 
     pub fn get_open_position_count(env: Env, user: Address) -> u32 {
-        env.storage().instance().get(&PortfolioKey::Count(user)).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&PortfolioKey::Count(user))
+            .unwrap_or(0)
     }
 }
 
@@ -116,7 +120,10 @@ fn cancel_queued_trade_within_grace_period_succeeds() {
 
     env.ledger().with_mut(|l| l.sequence_number = 5);
     let result = exec.try_cancel_queued_trade(&user, &queued_id);
-    assert!(result.is_ok(), "cancellation within grace period should succeed");
+    assert!(
+        result.is_ok(),
+        "cancellation within grace period should succeed"
+    );
 }
 
 /// Cancel after the grace period has elapsed should fail.
@@ -130,83 +137,87 @@ fn cancel_after_grace_period_elapsed_fails() {
     env.ledger().with_mut(|l| l.sequence_number = 0);
     let queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
 
-/// Execute queued trades after grace period — only eligible ones execute.
-#[test]
-fn execute_queued_trades_after_grace_period() {
-    let (env, exec_id, _) = setup();
-    let token = sac(&env);
-    let user = funded_user(&env, &token);
-    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    /// Execute queued trades after grace period — only eligible ones execute.
+    #[test]
+    fn execute_queued_trades_after_grace_period() {
+        let (env, exec_id, _) = setup();
+        let token = sac(&env);
+        let user = funded_user(&env, &token);
+        let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
-    env.ledger().with_mut(|l| l.sequence_number = 0);
-    let _queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
+        env.ledger().with_mut(|l| l.sequence_number = 0);
+        let _queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
 
-    // Not yet eligible
-    env.ledger().with_mut(|l| l.sequence_number = 5);
-    let count = exec.execute_queued_trades();
-    assert_eq!(count, 0, "no trades before grace period elapses");
+        // Not yet eligible
+        env.ledger().with_mut(|l| l.sequence_number = 5);
+        let count = exec.execute_queued_trades();
+        assert_eq!(count, 0, "no trades before grace period elapses");
 
-    // Eligible now
-    env.ledger().with_mut(|l| l.sequence_number = 15);
-    let count = exec.execute_queued_trades();
-    assert_eq!(count, 1, "trade executes after grace period");
-}
+        // Eligible now
+        env.ledger().with_mut(|l| l.sequence_number = 15);
+        let count = exec.execute_queued_trades();
+        assert_eq!(count, 1, "trade executes after grace period");
+    }
 
-/// Multiple queued trades — only those past the grace period execute.
-#[test]
-fn multiple_queued_trades_partial_execution() {
-    let (env, exec_id, _) = setup();
-    let token = sac(&env);
-    let user1 = funded_user(&env, &token);
-    let user2 = funded_user(&env, &token);
-    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    /// Multiple queued trades — only those past the grace period execute.
+    #[test]
+    fn multiple_queued_trades_partial_execution() {
+        let (env, exec_id, _) = setup();
+        let token = sac(&env);
+        let user1 = funded_user(&env, &token);
+        let user2 = funded_user(&env, &token);
+        let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
-    env.ledger().with_mut(|l| l.sequence_number = 0);
-    exec.queue_copy_trade(&user1, &token, &AMOUNT, &None);
+        env.ledger().with_mut(|l| l.sequence_number = 0);
+        exec.queue_copy_trade(&user1, &token, &AMOUNT, &None);
 
-    env.ledger().with_mut(|l| l.sequence_number = 8);
-    exec.queue_copy_trade(&user2, &token, &AMOUNT, &None);
+        env.ledger().with_mut(|l| l.sequence_number = 8);
+        exec.queue_copy_trade(&user2, &token, &AMOUNT, &None);
 
-    // Only trade 1 eligible (12-0 >= 10)
-    env.ledger().with_mut(|l| l.sequence_number = 12);
-    assert_eq!(exec.execute_queued_trades(), 1);
+        // Only trade 1 eligible (12-0 >= 10)
+        env.ledger().with_mut(|l| l.sequence_number = 12);
+        assert_eq!(exec.execute_queued_trades(), 1);
 
-    // Trade 2 eligible now
-    env.ledger().with_mut(|l| l.sequence_number = 20);
-    assert_eq!(exec.execute_queued_trades(), 1);
-}
+        // Trade 2 eligible now
+        env.ledger().with_mut(|l| l.sequence_number = 20);
+        assert_eq!(exec.execute_queued_trades(), 1);
+    }
 
-/// Grace period of 0 means trades are immediately eligible.
-#[test]
-fn zero_grace_period_executes_immediately() {
-    let (env, exec_id, _) = setup();
-    let token = sac(&env);
-    let user = funded_user(&env, &token);
-    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    /// Grace period of 0 means trades are immediately eligible.
+    #[test]
+    fn zero_grace_period_executes_immediately() {
+        let (env, exec_id, _) = setup();
+        let token = sac(&env);
+        let user = funded_user(&env, &token);
+        let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
-    exec.set_trade_grace_period(&0);
-    env.ledger().with_mut(|l| l.sequence_number = 5);
-    let _queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
-    assert_eq!(exec.execute_queued_trades(), 1, "immediate with grace 0");
-}
+        exec.set_trade_grace_period(&0);
+        env.ledger().with_mut(|l| l.sequence_number = 5);
+        let _queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
+        assert_eq!(exec.execute_queued_trades(), 1, "immediate with grace 0");
+    }
 
-/// Cancelled trade is not executed.
-#[test]
-fn cancelled_trade_not_executed() {
-    let (env, exec_id, _) = setup();
-    let token = sac(&env);
-    let user = funded_user(&env, &token);
-    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    /// Cancelled trade is not executed.
+    #[test]
+    fn cancelled_trade_not_executed() {
+        let (env, exec_id, _) = setup();
+        let token = sac(&env);
+        let user = funded_user(&env, &token);
+        let exec = TradeExecutorContractClient::new(&env, &exec_id);
 
-    env.ledger().with_mut(|l| l.sequence_number = 0);
-    let queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
+        env.ledger().with_mut(|l| l.sequence_number = 0);
+        let queued_id = exec.queue_copy_trade(&user, &token, &AMOUNT, &None);
 
-    env.ledger().with_mut(|l| l.sequence_number = 5);
-    exec.cancel_queued_trade(&user, &queued_id);
+        env.ledger().with_mut(|l| l.sequence_number = 5);
+        exec.cancel_queued_trade(&user, &queued_id);
 
-    env.ledger().with_mut(|l| l.sequence_number = 20);
-    assert_eq!(exec.execute_queued_trades(), 0, "cancelled trade not executed");
-}
+        env.ledger().with_mut(|l| l.sequence_number = 20);
+        assert_eq!(
+            exec.execute_queued_trades(),
+            0,
+            "cancelled trade not executed"
+        );
+    }
 
     env.ledger().with_mut(|l| l.sequence_number = 15);
     let result = exec.try_cancel_queued_trade(&user, &queued_id);
@@ -238,4 +249,3 @@ fn cancel_nonexistent_queued_trade_fails() {
     let result = exec.try_cancel_queued_trade(&user, &999u64);
     assert_eq!(result, Err(Ok(ContractError::QueuedTradeNotFound)));
 }
-

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_storage_rent_benchmark.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_storage_rent_benchmark.rs
@@ -142,7 +142,7 @@ fn dca_interval_storage_rent_baseline_smoke() {
     // Create a DCA plan first.
     client.execute_dca_copy_trade(
         &user,
-        &1u64,   // signal_id
+        &1u64, // signal_id
         &10_000_000i128,
         &3u32,   // num_intervals
         &10u32,  // interval_ledgers
@@ -155,7 +155,10 @@ fn dca_interval_storage_rent_baseline_smoke() {
 
     let done = client.execute_dca_interval(&user, &1u64);
     // Returns false while the plan has remaining intervals.
-    assert!(!done, "DCA plan should not be complete after the first interval");
+    assert!(
+        !done,
+        "DCA plan should not be complete after the first interval"
+    );
 }
 
 /// Delta-check: compare the current write count to the baseline and fail if the

--- a/stellar-swipe/contracts/trade_executor/src/triggers.rs
+++ b/stellar-swipe/contracts/trade_executor/src/triggers.rs
@@ -223,6 +223,7 @@ fn close_position_keeper(
     args.push_back(trade_id.into_val(env));
     args.push_back(asset_pair.into_val(env));
     env.invoke_contract::<()>(portfolio, &sym, args);
+    crate::decrement_user_position_count(env, user);
 }
 
 /// If `current_price <= stop_loss_price`, closes the position and emits `StopLossTriggered`.

--- a/stellar-swipe/contracts/trade_executor/src/wire.rs
+++ b/stellar-swipe/contracts/trade_executor/src/wire.rs
@@ -15,8 +15,8 @@ pub enum OrderType {
 pub enum TradeStatus {
     Pending,
     PartiallyFilled,
-    ExecutedAwaitingConfirmation, 
-    Filled,                      
+    ExecutedAwaitingConfirmation,
+    Filled,
     Failed,
 }
 
@@ -46,7 +46,7 @@ pub struct Trade {
     pub executed_price: i128,
     pub timestamp: u64,
     pub status: TradeStatus,
-    pub execution_ledger: u32
+    pub execution_ledger: u32,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Closes #791.

`execute_copy_trade` and `queue_copy_trade` previously placed no limit on how many positions a single user could hold open at once, allowing thousands of micro-positions that inflate per-user storage cost and make close/sweep operations prohibitively expensive. This PR adds a user-level open-position cap — a standard copy-trading risk control — complementing the existing per-pair open-interest limit.

## Changes

- **Cap enforcement** — `execute_market_copy_trade` checks the user's open count before opening a position. The market, queued, and batch execution paths all funnel through it, so one check covers all three. `queue_copy_trade` also fails fast at queue time (the cap is re-checked at execution, when queued slots may have been freed by intervening closes). Non-exempt users at the cap get the new `ContractError::TooManyOpenPositions`.
- **Position counting** — new persistent `UserPositionCount(user)` storage key: incremented on successful open, decremented with **saturating** subtraction (never negative) on `cancel_copy_trade` and inside `close_position_keeper`, which covers all keeper-triggered closes (stop-loss, take-profit, trailing stop) with a single change.
- **Exemptions** — users allowlisted via the existing `set_position_limit_exempt` bypass the check but are **still counted**, so revoking an exemption immediately re-applies the cap with an accurate count.
- **Configuration** — new `MaxOpenPositions` instance key, default **50** (`DEFAULT_MAX_OPEN_POSITIONS`). Admin entry point `set_max_open_positions` (rejects 0), plus `get_max_open_positions` and `get_user_position_count` views.

## Tests

151 passed / 0 failed for the crate. 8 new tests cover the acceptance criteria: open below cap, open at exactly cap rejected, close frees a slot, exempt user ignores cap (and is still counted), count never goes negative when closing an uncounted position, queue rejected at cap, default cap is 50, and zero cap rejected.

## Pre-existing breakage repaired (required to build at all)

The trade_executor crate did not compile on `main` due to a half-merged confirmation-depth feature sitting directly on `finalize_trade` — a function this issue touches — so minimal repairs were unavoidable:

- Duplicate error discriminant: `ConfirmationDepthNotReached` and `GracePeriodExpired` both assigned `26` (renumbered to 30).
- `finalize_trade` referenced a nonexistent `ContractError::AutoTradeError` variant and a missing `Self::require_admin`; now maps to real error variants and the existing free `require_admin`.
- The copy-trade path wrote an incomplete `TradeOrder` **over the `UserPortfolio` address key**, which would have corrupted contract config on every executed trade; the pending order now lives under a dedicated `PendingTradeConfirmation` key with all fields populated.
- Five latent tests reused replay nonce 1 across sequential trades, which the sequential-nonce replay protection rejects; they now use sequential nonces.

All other pre-existing failures in unrelated crates (fee_collector, governance, the wasm duplicate-symbol link error) were left untouched.

