### PR TITLE
Audit and harden cross-contract reentrancy in signal_registry

### DIFF
--- a/stellar-swipe/contracts/integration_tests/Cargo.toml
+++ b/stellar-swipe/contracts/integration_tests/Cargo.toml
@@ -45,5 +45,9 @@ path = "tests/integration/test_chaos_ordering.rs"
 name = "test_arithmetic_invariants"
 path = "tests/integration/test_arithmetic_invariants.rs"
 
+[[test]]
+name = "test_signal_registry_reentrancy"
+path = "tests/integration/test_signal_registry_reentrancy.rs"
+
 [lints]
 workspace = true

--- a/stellar-swipe/contracts/integration_tests/tests/integration/test_signal_registry_reentrancy.rs
+++ b/stellar-swipe/contracts/integration_tests/tests/integration/test_signal_registry_reentrancy.rs
@@ -1,0 +1,235 @@
+//! Cross-contract reentrancy integration test for `SignalRegistry::ban_provider`
+//! (Issue #781).
+//!
+//! The issue's threat model: `signal_registry` calls out to an admin-supplied
+//! `stake_vault` address from `ban_provider`'s slashing step. A misconfigured
+//! or outright malicious address at that slot could, in principle, call back
+//! into `signal_registry` mid-transaction and observe or corrupt state.
+//!
+//! ## What this test found
+//!
+//! Soroban's host enforces `ContractReentryMode::Prohibited` on *every*
+//! standard cross-contract call (`env.invoke_contract` / `try_invoke_contract`
+//! — see `soroban-env-host`'s `host/frame.rs`), unconditionally, for every
+//! contract that doesn't opt in to a looser mode. There is currently no
+//! `#[contractimpl]`-level opt-out available to ordinary contract code, so a
+//! callee attempting to call back into a contract already on the stack — even
+//! for a *read-only* query — is rejected by the host itself before it ever
+//! reaches `signal_registry`'s own code, and the entire transaction reverts.
+//!
+//! `test_malicious_reentry_reverts_whole_call` below confirms exactly that:
+//! the attack in the issue is already closed at the protocol layer, and
+//! reverting is atomic — a rejected reentrant attempt leaves *zero* trace,
+//! not a half-applied ban.
+//!
+//! That platform guarantee doesn't make `signal_registry`'s own hardening
+//! redundant, though:
+//! - It's the only protection this contract controls; the protocol behavior
+//!   above is Soroban's, not `signal_registry`'s, and the host code itself
+//!   notes a `reentry` opt-in flag is planned for `try_call` (currently
+//!   hardcoded to `Prohibited`) — if a future protocol version relaxes this
+//!   default, `signal_registry`'s own guard is what keeps it safe.
+//! - It fails with a typed `AdminError::ReentrancyDetected` rather than an
+//!   opaque host trap, which is what `contracts/signal_registry`'s own unit
+//!   tests (`tests/test_reentrancy.rs`) exercise directly.
+//! - `apply_ban`'s checks-effects-interactions ordering (persist before
+//!   calling out) is correct practice independent of *why* reentrancy is
+//!   blocked.
+//!
+//! `test_ban_provider_slashes_via_real_stake_vault` below covers the *non*
+//! -adversarial path end-to-end against the real `StakeVaultContract`,
+//! which also exercises a correctness fix made alongside this audit:
+//! `providers::slash_stake` was previously calling `StakeVault::slash_stake`
+//! with a raw stake amount where the real contract expects a `SlashSeverity`
+//! tier — a mismatch that would have caused every `ban_provider` slash to
+//! trap against a real vault. `ban_provider` had no test coverage at all
+//! before this issue.
+
+extern crate std;
+
+use signal_registry::{
+    RiskLevel, SignalAction, SignalCategory, SignalRegistry, SignalRegistryClient, SignalStatus,
+};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::Address as _,
+    token::StellarAssetClient,
+    Address, Env, String, Symbol,
+};
+use stake_vault::{StakeVaultContract, StakeVaultContractClient};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+// ── Malicious StakeVault stand-in ───────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Registry,
+    Admin,
+    Provider,
+}
+
+/// A `StakeVault` stand-in exposing the exact `get_stake` / `slash_stake`
+/// wire ABI `providers::slash_stake` calls — but whose `slash_stake`
+/// attempts to call straight back into `SignalRegistry` instead of doing any
+/// real slashing.
+#[contract]
+struct MaliciousStakeVault;
+
+#[contractimpl]
+impl MaliciousStakeVault {
+    /// Test-only setup; a real `StakeVault` has no equivalent.
+    pub fn configure(env: Env, registry: Address, admin: Address, provider: Address) {
+        env.storage().instance().set(&DataKey::Registry, &registry);
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Provider, &provider);
+    }
+
+    pub fn get_stake(_env: Env, _staker: Address) -> i128 {
+        100_000_000
+    }
+
+    pub fn slash_stake(
+        env: Env,
+        _caller: Address,
+        provider: Address,
+        _severity: u32,
+        _reason: Symbol,
+    ) -> i128 {
+        let registry: Address = env.storage().instance().get(&DataKey::Registry).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let client = SignalRegistryClient::new(&env, &registry);
+
+        // Attempt to reenter `signal_registry` — even a read-only call.
+        // Soroban's host rejects this unconditionally (see module docs
+        // above); this call never returns normally.
+        let _ = client.is_provider_banned(&provider);
+
+        // Unreachable in practice, but keep the mock's control flow honest.
+        let reason = String::from_str(&env, "reentrant-attempt");
+        client.ban_provider(&admin, &provider, &reason, &env.current_contract_address());
+        0
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn sac_token(env: &Env, admin: &Address) -> Address {
+    env.register_stellar_asset_contract_v2(admin.clone()).address()
+}
+
+/// Deploy `SignalRegistry`, initialize it, stake and submit one signal for
+/// `provider`. Returns (client, signal_id).
+fn setup_registry_with_signal(env: &Env, admin: &Address, provider: &Address) -> (SignalRegistryClient<'static>, u64) {
+    let registry_id = env.register(SignalRegistry, ());
+    let registry = SignalRegistryClient::new(env, &registry_id);
+    registry.initialize(admin);
+    registry.stake_tokens(provider, &200_000_000i128);
+
+    let expiry = env.ledger().timestamp() + 7_200;
+    let signal_id = registry.create_signal(
+        provider,
+        &String::from_str(env, "XLM/USDC"),
+        &SignalAction::Buy,
+        &1_000_000i128,
+        &String::from_str(env, "reentrancy fixture signal"),
+        &expiry,
+        &SignalCategory::SWING,
+        &soroban_sdk::Vec::new(env),
+        &RiskLevel::Medium,
+    );
+
+    (registry, signal_id)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+/// A malicious `stake_vault` attempting to reenter `signal_registry` from
+/// `slash_stake` must not be able to leave the provider half-banned. Soroban
+/// rejects the reentrant call at the host level (see module docs), which
+/// aborts the *entire* `ban_provider` transaction — so this test asserts the
+/// stronger, end-to-end property the issue actually cares about: the attempt
+/// leaves no trace at all, not even the effects `apply_ban` persisted before
+/// the external call.
+#[test]
+fn test_malicious_reentry_reverts_whole_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let (registry, signal_id) = setup_registry_with_signal(&env, &admin, &provider);
+
+    let vault_id = env.register(MaliciousStakeVault, ());
+    MaliciousStakeVaultClient::new(&env, &vault_id).configure(&registry.address, &admin, &provider);
+
+    let reason = String::from_str(&env, "ipfs://ban-evidence");
+    let registry_for_call = SignalRegistryClient::new(&env, &registry.address);
+    let admin_for_call = admin.clone();
+    let provider_for_call = provider.clone();
+    let reason_for_call = reason.clone();
+    let vault_for_call = vault_id.clone();
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        registry_for_call.ban_provider(&admin_for_call, &provider_for_call, &reason_for_call, &vault_for_call);
+    }));
+
+    assert!(
+        result.is_err(),
+        "ban_provider with a reentrant stake_vault should have reverted the whole call"
+    );
+
+    // No trace of the attempted ban: the transaction-level revert must undo
+    // even the effects `apply_ban` persisted before calling out to the
+    // (malicious) vault.
+    assert!(
+        !registry.is_provider_banned(&provider),
+        "a reverted ban_provider call must not leave the provider banned"
+    );
+    assert_eq!(
+        registry.get_signal(&signal_id).unwrap().status,
+        SignalStatus::Active,
+        "a reverted ban_provider call must not leave signals cancelled"
+    );
+
+    // The registry must still be fully usable afterwards — a failed
+    // adversarial call must not brick the contract or leak a held lock.
+    let provider2 = Address::generate(&env);
+    registry.stake_tokens(&provider2, &200_000_000i128);
+    registry.unstake_tokens(&provider2);
+}
+
+/// Non-adversarial happy path against the real `StakeVaultContract`: proves
+/// `ban_provider` actually interoperates with the deployed vault ABI
+/// end-to-end (exercising the `SlashSeverity` encoding fix made alongside
+/// this audit), cancels the provider's active signals, and slashes their
+/// full stake (Critical tier = 100% by default).
+#[test]
+fn test_ban_provider_slashes_via_real_stake_vault() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let (registry, signal_id) = setup_registry_with_signal(&env, &admin, &provider);
+
+    let token = sac_token(&env, &admin);
+    let vault_id = env.register(StakeVaultContract, ());
+    let vault = StakeVaultContractClient::new(&env, &vault_id);
+    vault.initialize(&admin, &token, &registry.address);
+
+    StellarAssetClient::new(&env, &token).mint(&provider, &1_000_000_000i128);
+    vault.deposit_stake(&provider, &500_000_000i128);
+    assert_eq!(vault.get_stake(&provider), 500_000_000i128);
+
+    let reason = String::from_str(&env, "ipfs://ban-evidence");
+    registry.ban_provider(&admin, &provider, &reason, &vault_id);
+
+    assert!(registry.is_provider_banned(&provider));
+    assert_eq!(
+        registry.get_signal(&signal_id).unwrap().status,
+        SignalStatus::Failed
+    );
+    // Critical tier defaults to 100% — the vault's full stake is gone.
+    assert_eq!(vault.get_stake(&provider), 0i128);
+}

--- a/stellar-swipe/contracts/signal_registry/src/collaboration.rs
+++ b/stellar-swipe/contracts/signal_registry/src/collaboration.rs
@@ -1,9 +1,5 @@
 use crate::errors::AdminError;
 use crate::types::{Signal, SignalAction};
-use crate::collaboration::{
-    self, Author, CollaborationStatus, get_collaborative_signal,
-    is_collaborative_signal, distribute_collaborative_rewards,
-};
 use soroban_sdk::{contracttype, Address, Env, Map, Vec};
 
 #[contracttype]
@@ -130,11 +126,13 @@ pub fn distribute_collaborative_rewards(
     }
 
     // Adjust the last entry to absorb any rounding remainder
-    if let Some(last) = distributions.last_mut() {
+    // (soroban_sdk::Vec has no `last_mut`; read, mutate, and write back by index).
+    if distributions.len() > 0 {
+        let last_idx = distributions.len() - 1;
+        let (address, fee_share, roi_share) = distributions.get(last_idx).unwrap();
         let fee_rem = total_fees - fee_sum;
         let roi_rem = total_roi - roi_sum;
-        last.1 += fee_rem;
-        last.2 += roi_rem;
+        distributions.set(last_idx, (address, fee_share + fee_rem, roi_share + roi_rem));
     }
 
     distributions

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -27,6 +27,8 @@ mod multisig_approvals;
 mod performance;
 mod providers;
 mod query;
+/// Contract-wide cross-contract reentrancy guard (Issue #781).
+mod reentrancy;
 mod reports;
 pub mod reputation;
 mod scheduling;
@@ -49,6 +51,10 @@ mod validation;
 mod versioning;
 
 pub use categories::{RiskLevel, SignalCategory};
+/// Re-exported so downstream / integration-test callers (e.g.
+/// `contracts/integration_tests`) can pattern-match on contract errors —
+/// including `AdminError::ReentrancyDetected` — without duplicating the enum.
+pub use errors::AdminError;
 pub use multisig_approvals::CriticalActionPayload;
 pub use types::SignalAction;
 pub use types::{FeeBreakdown, ProviderPerformance, SignalOutcome, SignalStatus};
@@ -73,8 +79,8 @@ use community_voting::{
 };
 use contests::{Contest, ContestEntry, ContestMetric, ContestStatus};
 use errors::{
-    AdminError, AiScoreError, ComboError, ContestError, CrossChainError, SignalCancelError,
-    SignalEditError, SignalOutcomeError, TemplateError, VersioningError,
+    AiScoreError, ComboError, ContestError, CrossChainError, SignalCancelError, SignalEditError,
+    SignalOutcomeError, TemplateError, VersioningError,
 };
 pub use leaderboard::{
     get_leaderboard as get_leaderboard_internal, update_leaderboard_index, LeaderboardMetric,
@@ -291,6 +297,15 @@ impl SignalRegistry {
     }
 
     /// User stakes tokens. Rate-limited to 5 changes per day.
+    ///
+    /// # Reentrancy risk assessment (Issue #781)
+    /// `amount` is bookkeeping against the in-contract `ProviderStakes` map
+    /// only ([`stake::stake`]) — this entrypoint makes **no cross-contract
+    /// call** (no token transfer, no `StakeVault` invocation), so there is no
+    /// external callee that could reenter during this call. No guard needed.
+    /// If a real token transfer is added here in the future, it must go
+    /// through [`reentrancy::guarded`] the same way [`Self::ban_provider`] and
+    /// [`Self::unstake_tokens`] do.
     pub fn stake_tokens(env: Env, provider: Address, amount: i128) -> Result<(), AdminError> {
         provider.require_auth();
         let trust = reputation::get_trust_score(&env, &provider)
@@ -313,25 +328,23 @@ impl SignalRegistry {
     }
 
     /// User unstakes tokens. Rate-limited to 5 changes per day.
+    ///
+    /// # Reentrancy risk assessment (Issue #781)
+    /// Like [`Self::stake_tokens`], this entrypoint makes no cross-contract
+    /// call today — `amount` is bookkeeping against the in-contract
+    /// `ProviderStakes` map only ([`stake::unstake`]). It is nonetheless
+    /// guarded (originally Issue #264, now on the shared
+    /// [`reentrancy::guarded`] primitive) as defense in depth for a
+    /// fund-affecting flow, and so that a future token transfer added here
+    /// is automatically covered by the same contract-wide lock used by
+    /// [`Self::ban_provider`].
     pub fn unstake_tokens(env: Env, provider: Address) -> Result<(), AdminError> {
         provider.require_auth();
 
-        // ── Reentrancy guard ──────────────────────────────────────────────────
-        let lock_key = soroban_sdk::Symbol::new(&env, "UnstakeLock");
-        if env
-            .storage()
-            .temporary()
-            .get::<_, bool>(&lock_key)
-            .unwrap_or(false)
-        {
-            return Err(AdminError::ReentrancyDetected);
-        }
-        env.storage().temporary().set(&lock_key, &true);
-
-        let trust = reputation::get_trust_score(&env, &provider)
-            .map(|d| d.score)
-            .unwrap_or(0);
-        let result = (|| -> Result<(), AdminError> {
+        reentrancy::guarded(&env, || {
+            let trust = reputation::get_trust_score(&env, &provider)
+                .map(|d| d.score)
+                .unwrap_or(0);
             rl::check_rate_limit(&env, &provider, RLAction::StakeChange, trust)
                 .map_err(|_| AdminError::RateLimitExceeded)?;
 
@@ -346,10 +359,7 @@ impl SignalRegistry {
             Self::save_provider_stakes_map(&env, &stakes);
             rl::record_action(&env, &provider, RLAction::StakeChange);
             Ok(())
-        })();
-
-        env.storage().temporary().remove(&lock_key);
-        result
+        })
     }
 
     pub fn set_trade_fee(env: Env, caller: Address, new_fee_bps: u32) -> Result<(), AdminError> {
@@ -923,6 +933,12 @@ impl SignalRegistry {
     /// Create a new trading signal. The provider must authorize the call.
     /// Signals are rate-limited and subject to pause state checks.
     ///
+    /// # Reentrancy risk assessment (Issue #781)
+    /// The provider's stake tier is read from local storage
+    /// (`ProviderStakes` / the provider's `stake_tier` profile field) — this
+    /// function makes **no cross-contract call**, so there is no external
+    /// callee that could reenter during signal creation. No guard needed.
+    ///
     /// # Parameters
     /// - `env`: Soroban environment.
     /// - `provider`: Address of the signal provider (must authorize).
@@ -1239,6 +1255,17 @@ impl SignalRegistry {
     /// signals are visible to any viewer. PREMIUM signals require an active on-chain
     /// subscription (via UserPortfolio [`check_subscription`]) unless the viewer is the
     /// signal provider.
+    ///
+    /// # Reentrancy risk assessment (Issue #781)
+    /// Calls out to `UserPortfolio::check_subscription`
+    /// ([`Self::invoke_check_subscription`]) for PREMIUM signals. This is a
+    /// **read-only query path**: it never authorizes a fund movement or
+    /// mutates business-logic state, so it cannot be used to double-spend or
+    /// corrupt state via reentrancy regardless of what the callee does. The
+    /// one write on this path — `emit_session_started_once`'s per-session
+    /// dedup flag — is explicitly documented as "No business-logic state is
+    /// changed" (see `shared::events`) and only suppresses a duplicate
+    /// analytics event; it carries no reentrancy risk. No guard needed.
     pub fn get_signal_for_viewer(env: Env, signal_id: u64, viewer: Address) -> Option<Signal> {
         let signals = Self::get_signals_map(&env);
         let signal = signals.get(signal_id)?;
@@ -1890,6 +1917,20 @@ impl SignalRegistry {
     /// Ban a provider, cancelling all active signals and slashing full stake.
     /// Admin only. Emits `ProviderBanned` event.
     ///
+    /// # Reentrancy risk assessment (Issue #781)
+    /// This entrypoint makes a cross-contract call into the admin-supplied
+    /// `stake_vault` (see [`providers::slash_stake`]), which — unlike a
+    /// hardcoded protocol contract — cannot be assumed non-malicious. It is
+    /// therefore hardened two ways:
+    /// - **Checks-effects-interactions**: the ban reason and every cancelled
+    ///   signal ([`providers::apply_ban`]) are persisted *before* the
+    ///   `stake_vault` call, so a reentrant call during that call sees the
+    ///   fully-banned state, never an intermediate one.
+    /// - **Reentrancy guard**: the whole body runs under
+    ///   [`reentrancy::guarded`], so any reentrant call back into another
+    ///   guarded `signal_registry` entrypoint (including `ban_provider`
+    ///   itself) is rejected with [`AdminError::ReentrancyDetected`].
+    ///
     /// # Arguments
     /// * `caller` - Must be the current admin.
     /// * `provider` - Provider address to ban.
@@ -1905,10 +1946,17 @@ impl SignalRegistry {
         admin::require_admin(&env, &caller)?;
         caller.require_auth();
 
-        let mut signals = Self::get_signals_map(&env);
-        let (signals_cancelled, stake_slashed) =
-            providers::ban_provider(&env, &mut signals, &provider, &reason_hash, &stake_vault);
-        Self::save_signals_map(&env, &signals);
+        let (signals_cancelled, stake_slashed) = reentrancy::guarded(&env, || {
+            // Effects: persist the ban and cancel signals before the external call.
+            let mut signals = Self::get_signals_map(&env);
+            let signals_cancelled = providers::apply_ban(&env, &mut signals, &provider, &reason_hash);
+            Self::save_signals_map(&env, &signals);
+
+            // Interaction: cross-contract call to StakeVault to slash the stake.
+            let stake_slashed = providers::slash_stake(&env, &provider, &stake_vault);
+
+            Ok((signals_cancelled, stake_slashed))
+        })?;
 
         providers::emit_provider_banned(
             &env,
@@ -2017,6 +2065,13 @@ impl SignalRegistry {
        SIGNAL ADOPTION (Issue #169)
     ========================== */
 
+    /// # Reentrancy risk assessment (Issue #781)
+    /// This is an *inbound* trust boundary, not an outbound call site: the
+    /// caller must equal the registered `TradeExecutor` address, checked via
+    /// `caller.require_auth()` (a signature check, not a cross-contract
+    /// invocation). `increment_adoption` itself makes **no cross-contract
+    /// call** — nothing here can be reentered mid-execution by an external
+    /// contract. No guard needed.
     pub fn increment_adoption(
         env: Env,
         caller: Address,

--- a/stellar-swipe/contracts/signal_registry/src/providers.rs
+++ b/stellar-swipe/contracts/signal_registry/src/providers.rs
@@ -518,24 +518,31 @@ pub fn get_ban_reason(env: &Env, provider: &Address) -> Option<String> {
         .get(&BanStorageKey::ProviderBanReason(provider.clone()))
 }
 
-/// Ban a provider: cancel all active signals, slash full stake, block future submissions.
+/// Ban a provider: persist the ban and cancel all active signals.
+///
+/// This is the "effects" half of the ban flow — it performs **no external
+/// calls** and is safe to call and persist in full before the caller talks
+/// to `StakeVault` (see [`slash_stake`]). Splitting the pure-storage work
+/// from the cross-contract interaction lets the caller follow
+/// checks-effects-interactions: persist the ban reason and cancelled
+/// signals first, *then* invoke the external contract, so a reentrant call
+/// arriving during that external call can never observe a signal that is
+/// "active" but already mid-ban (Issue #781).
 ///
 /// # Arguments
 /// * `env` - Soroban environment
 /// * `signals_map` - Mutable reference to the signals map (signals will be cancelled in-place)
 /// * `provider` - Address of the provider to ban
 /// * `reason_hash` - On-chain evidence hash (e.g. IPFS CID of dispute documentation)
-/// * `stake_vault` - Address of the StakeVault contract for slashing
 ///
 /// # Returns
-/// `(signals_cancelled, stake_slashed)` tuple
-pub fn ban_provider(
+/// Number of signals cancelled.
+pub fn apply_ban(
     env: &Env,
     signals_map: &mut Map<u64, Signal>,
     provider: &Address,
     reason_hash: &String,
-    stake_vault: &Address,
-) -> (u32, i128) {
+) -> u32 {
     // Mark provider as banned by storing the reason hash
     env.storage().persistent().set(
         &BanStorageKey::ProviderBanReason(provider.clone()),
@@ -556,34 +563,58 @@ pub fn ban_provider(
         }
     }
 
-    // Slash full stake via cross-contract call to StakeVault
-    let stake_slashed = slash_stake(env, provider, stake_vault);
-
-    (signals_cancelled, stake_slashed)
+    signals_cancelled
 }
 
-/// Slash the full stake of a provider via StakeVault cross-contract call
-fn slash_stake(env: &Env, provider: &Address, stake_vault: &Address) -> i128 {
+/// Slash the full stake of a provider via a `StakeVault` cross-contract call.
+///
+/// # Reentrancy risk assessment (Issue #781)
+/// This is the only cross-contract *write* call site in `signal_registry`.
+/// `stake_vault` is admin-supplied and, in the general case, untrusted code:
+/// nothing stops a misconfigured or malicious address from calling back into
+/// `signal_registry` while its `slash_stake` entrypoint is executing. The
+/// caller (`SignalRegistry::ban_provider` in `lib.rs`) addresses this with
+/// two independent layers:
+/// 1. **Checks-effects-interactions** — all storage effects of the ban
+///    ([`apply_ban`]) are persisted *before* this function is called, so a
+///    reentrant read sees the post-ban state, not an intermediate one.
+/// 2. **Reentrancy guard** — the caller wraps the whole entrypoint in
+///    [`crate::reentrancy::guarded`], so any reentrant *state-changing*
+///    call back into a guarded `signal_registry` entrypoint (including a
+///    second `ban_provider`) is rejected with `AdminError::ReentrancyDetected`
+///    before it can touch storage.
+pub fn slash_stake(env: &Env, provider: &Address, stake_vault: &Address) -> i128 {
     let sym = soroban_sdk::Symbol::new(env, "get_stake");
     let mut args = soroban_sdk::Vec::<soroban_sdk::Val>::new(env);
     args.push_back(provider.clone().into_val(env));
     let stake: i128 = env.invoke_contract(stake_vault, &sym, args);
 
-    if stake > 0 {
-        // Call slash_stake on StakeVault — pass this contract as caller (authorizes the slash),
-        // the provider, the full stake amount, and a reason tag for the audit event.
-        let slash_sym = soroban_sdk::Symbol::new(env, "slash_stake");
-        let mut slash_args = soroban_sdk::Vec::<soroban_sdk::Val>::new(env);
-        let caller = env.current_contract_address();
-        slash_args.push_back(caller.into_val(env));
-        slash_args.push_back(provider.clone().into_val(env));
-        slash_args.push_back(stake.into_val(env));
-        let reason = soroban_sdk::Symbol::new(env, "ban");
-        slash_args.push_back(reason.into_val(env));
-        let _ = env.invoke_contract::<()>(stake_vault, &slash_sym, slash_args);
+    if stake <= 0 {
+        return 0;
     }
 
-    stake
+    // Call slash_stake on StakeVault — pass this contract as caller (authorizes
+    // the slash), the provider, the slash severity tier, and a reason tag for
+    // the audit event. A ban always applies the harshest tier: StakeVault's
+    // `SlashSeverity` is a `#[repr(u32)]` fieldless enum (Minor=0, Major=1,
+    // Critical=2), so it crosses the contract boundary as a plain u32 — there
+    // is no shared Rust type between the two independently deployed contracts.
+    const SLASH_SEVERITY_CRITICAL: u32 = 2;
+
+    let slash_sym = soroban_sdk::Symbol::new(env, "slash_stake");
+    let mut slash_args = soroban_sdk::Vec::<soroban_sdk::Val>::new(env);
+    let caller = env.current_contract_address();
+    slash_args.push_back(caller.into_val(env));
+    slash_args.push_back(provider.clone().into_val(env));
+    slash_args.push_back(SLASH_SEVERITY_CRITICAL.into_val(env));
+    let reason = soroban_sdk::Symbol::new(env, "ban");
+    slash_args.push_back(reason.into_val(env));
+
+    // StakeVault::slash_stake returns the amount actually slashed, which is
+    // the tier percentage of `stake` (default Critical = 100%) — read it back
+    // instead of assuming `stake` in full, so the emitted event always
+    // reflects what was really burned.
+    env.invoke_contract::<i128>(stake_vault, &slash_sym, slash_args)
 }
 
 /// Emit the ProviderBanned event

--- a/stellar-swipe/contracts/signal_registry/src/reentrancy.rs
+++ b/stellar-swipe/contracts/signal_registry/src/reentrancy.rs
@@ -1,0 +1,123 @@
+//! Cross-contract reentrancy guard (Issue #781).
+//!
+//! `signal_registry` calls out to other Soroban contracts (e.g. `StakeVault`
+//! via [`crate::providers::ban_provider`]) from a handful of state-changing
+//! entrypoints. Soroban permits a callee to invoke back into the caller
+//! within the same transaction, so any entrypoint that writes storage on
+//! either side of an external call is a reentrancy candidate.
+//!
+//! The guard follows the pattern already established for `unstake_tokens`
+//! (Issue #264): a boolean flag in *temporary* storage, set for the duration
+//! of the guarded call and cleared before returning on every path (success
+//! or error). Temporary storage is used because the lock only needs to
+//! survive for the lifetime of the current transaction — it must not persist
+//! (or cost rent) across ledgers.
+//!
+//! A single, contract-wide lock is used rather than one lock per entrypoint.
+//! This matches the classic `nonReentrant` modifier pattern (e.g. OpenZeppelin's
+//! `ReentrancyGuard`): it is simpler to reason about, and it also blocks
+//! *cross-entrypoint* reentrancy (e.g. a malicious callee invoked from
+//! `ban_provider` trying to call back into a different guarded function)
+//! which a per-function lock would miss.
+//!
+//! Guarded entrypoints must persist all storage effects *before* making the
+//! external call (checks-effects-interactions) — the lock is defense in
+//! depth, not a substitute for that ordering. See the call-site comments in
+//! `providers.rs` and `lib.rs` for the per-site risk assessment.
+
+use crate::errors::AdminError;
+use soroban_sdk::{Env, Symbol};
+
+fn lock_key(env: &Env) -> Symbol {
+    Symbol::new(env, "XContractLock")
+}
+
+/// Returns `Err(AdminError::ReentrancyDetected)` if the contract-wide guard
+/// is currently held (i.e. this call is nested inside another guarded call).
+pub fn require_not_locked(env: &Env) -> Result<(), AdminError> {
+    let locked = env
+        .storage()
+        .temporary()
+        .get::<_, bool>(&lock_key(env))
+        .unwrap_or(false);
+    if locked {
+        return Err(AdminError::ReentrancyDetected);
+    }
+    Ok(())
+}
+
+/// Runs `f` under the reentrancy guard. The lock is acquired *before* `f`
+/// runs and released after it returns, regardless of whether `f` succeeded —
+/// so a failed guarded call never leaves the lock held for the rest of the
+/// transaction.
+///
+/// Callers are responsible for persisting all storage effects inside `f`
+/// before performing the external call, per checks-effects-interactions.
+pub fn guarded<F, T>(env: &Env, f: F) -> Result<T, AdminError>
+where
+    F: FnOnce() -> Result<T, AdminError>,
+{
+    require_not_locked(env)?;
+    let key = lock_key(env);
+    env.storage().temporary().set(&key, &true);
+    let result = f();
+    env.storage().temporary().remove(&key);
+    result
+}
+
+/// Test-only introspection into the guard's lock state, so tests can assert
+/// on lock/unlock behaviour without depending on the private storage key.
+#[cfg(any(test, feature = "testutils"))]
+pub fn is_locked(env: &Env) -> bool {
+    env.storage()
+        .temporary()
+        .get::<_, bool>(&lock_key(env))
+        .unwrap_or(false)
+}
+
+/// Test-only helper to simulate a reentrant call arriving while the guard is
+/// already held (i.e. as if a nested cross-contract call were in progress).
+#[cfg(any(test, feature = "testutils"))]
+pub fn force_lock(env: &Env) {
+    env.storage().temporary().set(&lock_key(env), &true);
+}
+
+/// Test-only helper to clear a simulated lock.
+#[cfg(any(test, feature = "testutils"))]
+pub fn force_unlock(env: &Env) {
+    env.storage().temporary().remove(&lock_key(env));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guarded_blocks_nested_call() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, crate::SignalRegistry);
+        env.as_contract(&contract_id, || {
+            let outcome = guarded(&env, || {
+                // Attempt a nested guarded call while the outer one is active.
+                let nested = guarded(&env, || Ok::<_, AdminError>(1));
+                assert_eq!(nested, Err(AdminError::ReentrancyDetected));
+                Ok::<_, AdminError>(())
+            });
+            assert!(outcome.is_ok());
+
+            // Lock must be released after the outer call completes.
+            assert!(require_not_locked(&env).is_ok());
+        });
+    }
+
+    #[test]
+    fn guarded_releases_lock_on_error() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, crate::SignalRegistry);
+        env.as_contract(&contract_id, || {
+            let outcome = guarded(&env, || Err::<(), AdminError>(AdminError::InvalidParameter));
+            assert_eq!(outcome, Err(AdminError::InvalidParameter));
+            assert!(require_not_locked(&env).is_ok());
+        });
+    }
+}

--- a/stellar-swipe/contracts/signal_registry/src/tests/test_reentrancy.rs
+++ b/stellar-swipe/contracts/signal_registry/src/tests/test_reentrancy.rs
@@ -1,9 +1,17 @@
 #![cfg(test)]
-//! Reentrancy guard tests for `unstake_tokens` (Issue #264).
+//! Reentrancy guard tests (Issue #264, extended by the cross-contract audit
+//! in Issue #781).
+//!
+//! `unstake_tokens` and `ban_provider` both run under the shared,
+//! contract-wide lock in [`crate::reentrancy`]. These tests exercise the
+//! lock in isolation (fast, no cross-contract registration needed); the
+//! adversarial end-to-end scenario — a malicious `StakeVault` attempting to
+//! reenter `ban_provider` mid-call — is covered by the integration test
+//! `test_signal_registry_reentrancy` in `contracts/integration_tests`.
 
 use crate::errors::AdminError;
-use crate::{SignalRegistry, SignalRegistryClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+use crate::{reentrancy, SignalRegistry, SignalRegistryClient};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env, String};
 
 fn setup() -> (Env, Address, SignalRegistryClient<'static>) {
     let env = Env::default();
@@ -16,9 +24,30 @@ fn setup() -> (Env, Address, SignalRegistryClient<'static>) {
     (env, admin, client)
 }
 
-/// Simulate a reentrant call by manually setting the `UnstakeLock` flag in
-/// temporary storage before calling `unstake_tokens`. The function must return
-/// `ReentrancyDetected` without modifying any state.
+/// Minimal `StakeVault` stand-in exposing only `get_stake`, always returning
+/// zero so `ban_provider`'s slash sub-call is skipped. Sufficient for
+/// exercising the guard/lock mechanics around `ban_provider` without pulling
+/// in the real `stake_vault` crate as a dev-dependency of `signal_registry`.
+#[contract]
+struct ZeroStakeVaultStub;
+
+#[contractimpl]
+impl ZeroStakeVaultStub {
+    pub fn get_stake(_env: Env, _staker: Address) -> i128 {
+        0
+    }
+}
+
+fn zero_stake_vault(env: &Env) -> Address {
+    #[allow(deprecated)]
+    env.register_contract(None, ZeroStakeVaultStub)
+}
+
+// ── unstake_tokens ──────────────────────────────────────────────────────────
+
+/// Simulate a reentrant call by manually holding the shared guard before
+/// calling `unstake_tokens`. The function must return `ReentrancyDetected`
+/// without modifying any state.
 #[test]
 fn unstake_tokens_rejects_reentrant_call() {
     let (env, _, client) = setup();
@@ -27,25 +56,16 @@ fn unstake_tokens_rejects_reentrant_call() {
     // Stake enough to be eligible for unstaking.
     client.stake_tokens(&provider, &100_000_000i128);
 
-    // Simulate reentrancy: set the lock flag as if a reentrant call is in progress.
+    // Simulate reentrancy: hold the lock as if a nested call is in progress.
     let contract_id = client.address.clone();
-    env.as_contract(&contract_id, || {
-        let lock_key = Symbol::new(&env, "UnstakeLock");
-        env.storage().temporary().set(&lock_key, &true);
-    });
+    env.as_contract(&contract_id, || reentrancy::force_lock(&env));
 
     // The call must be rejected with ReentrancyDetected.
     let err = client.try_unstake_tokens(&provider).unwrap_err().unwrap();
     assert_eq!(err, AdminError::ReentrancyDetected);
 
-    // State must be unchanged: stake balance still present.
-    env.as_contract(&contract_id, || {
-        let lock_key = Symbol::new(&env, "UnstakeLock");
-        // Clear the simulated lock so we can verify stake state.
-        env.storage().temporary().remove(&lock_key);
-    });
-
-    // After clearing the simulated lock, a legitimate unstake succeeds.
+    // Clear the simulated lock; a legitimate unstake then succeeds.
+    env.as_contract(&contract_id, || reentrancy::force_unlock(&env));
     client.unstake_tokens(&provider);
 }
 
@@ -58,14 +78,11 @@ fn unstake_tokens_clears_lock_on_success() {
     client.stake_tokens(&provider, &100_000_000i128);
     client.unstake_tokens(&provider);
 
-    // Lock must not be set after a successful call.
     let contract_id = client.address.clone();
     env.as_contract(&contract_id, || {
-        let lock_key = Symbol::new(&env, "UnstakeLock");
-        let locked: bool = env.storage().temporary().get(&lock_key).unwrap_or(false);
         assert!(
-            !locked,
-            "UnstakeLock was not cleared after successful unstake"
+            !reentrancy::is_locked(&env),
+            "guard was not released after successful unstake"
         );
     });
 }
@@ -80,11 +97,93 @@ fn unstake_tokens_clears_lock_on_error() {
     let err = client.try_unstake_tokens(&provider).unwrap_err().unwrap();
     assert_eq!(err, AdminError::InvalidParameter);
 
-    // Lock must not be set after a failed call.
     let contract_id = client.address.clone();
     env.as_contract(&contract_id, || {
-        let lock_key = Symbol::new(&env, "UnstakeLock");
-        let locked: bool = env.storage().temporary().get(&lock_key).unwrap_or(false);
-        assert!(!locked, "UnstakeLock was not cleared after failed unstake");
+        assert!(
+            !reentrancy::is_locked(&env),
+            "guard was not released after failed unstake"
+        );
     });
+}
+
+// ── ban_provider ─────────────────────────────────────────────────────────
+
+/// Simulate a reentrant call arriving during `ban_provider`: the guard must
+/// reject it with `ReentrancyDetected`, and — because `apply_ban` persists
+/// its effects before any external call — the provider must not be left
+/// half-banned.
+#[test]
+fn ban_provider_rejects_reentrant_call() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+    let stake_vault = zero_stake_vault(&env);
+    let reason = String::from_str(&env, "ipfs://evidence");
+
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || reentrancy::force_lock(&env));
+
+    let err = client
+        .try_ban_provider(&admin, &provider, &reason, &stake_vault)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, AdminError::ReentrancyDetected);
+
+    // Rejected before any effect ran: provider is not banned.
+    assert!(!client.is_provider_banned(&provider));
+
+    env.as_contract(&contract_id, || reentrancy::force_unlock(&env));
+}
+
+/// Verify the lock is cleared after a successful ban (no lock leak), and
+/// that the ban itself took effect.
+#[test]
+fn ban_provider_clears_lock_on_success() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+    let stake_vault = zero_stake_vault(&env);
+    let reason = String::from_str(&env, "ipfs://evidence");
+
+    client.ban_provider(&admin, &provider, &reason, &stake_vault);
+    assert!(client.is_provider_banned(&provider));
+
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || {
+        assert!(
+            !reentrancy::is_locked(&env),
+            "guard was not released after successful ban_provider"
+        );
+    });
+}
+
+/// The guard is contract-wide: holding it blocks *any* guarded entrypoint,
+/// not just the one that acquired it. This is what stops a malicious
+/// `stake_vault` invoked from `ban_provider` from reentering via a
+/// different guarded function (e.g. `unstake_tokens`).
+#[test]
+fn guard_blocks_across_entrypoints() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+    let stake_vault = zero_stake_vault(&env);
+    let reason = String::from_str(&env, "ipfs://evidence");
+    client.stake_tokens(&provider, &100_000_000i128);
+
+    let contract_id = client.address.clone();
+    env.as_contract(&contract_id, || reentrancy::force_lock(&env));
+
+    assert_eq!(
+        client
+            .try_unstake_tokens(&provider)
+            .unwrap_err()
+            .unwrap(),
+        AdminError::ReentrancyDetected
+    );
+    assert_eq!(
+        client
+            .try_ban_provider(&admin, &provider, &reason, &stake_vault)
+            .unwrap_err()
+            .unwrap(),
+        AdminError::ReentrancyDetected
+    );
+
+    env.as_contract(&contract_id, || reentrancy::force_unlock(&env));
 }


### PR DESCRIPTION
Closes #781.

## Summary

Audits every cross-contract call site in `signal_registry` for reentrancy risk and hardens the one genuine finding, per the issue's acceptance criteria.

**The audit** (each site now has an in-code risk-assessment comment):

| Entrypoint | Makes an external call? | Verdict |
|---|---|---|
| `stake_tokens` | No — pure `ProviderStakes` map bookkeeping | No guard needed |
| `unstake_tokens` | No | Already guarded (#264); migrated to the shared primitive below |
| `create_signal` | No — stake tier read from local storage | No guard needed |
| `get_signal_for_viewer` → `invoke_check_subscription` | Yes, but read-only (`UserPortfolio::check_subscription`) | No guard needed |
| `increment_adoption` | No — inbound only (`caller == TradeExecutor`) | No guard needed |
| **`ban_provider` → `providers::slash_stake`** | **Yes — write to `StakeVault`, admin-supplied address** | **Hardened (below)** |

Worth flagging: the issue's own description says `create_signal`/`stake_tokens`/`unstake_tokens` call into `stake_vault` for a stake check — that isn't what the current code does (it's all local-map bookkeeping). `ban_provider` is the actual write-before-external-call site in this contract today, and it had **zero test coverage** before this PR.

**The fix**, for `ban_provider`:
1. **Checks-effects-interactions.** Split the old `providers::ban_provider` into `apply_ban` (persists the ban reason + cancels signals — pure storage, no external call) and `slash_stake` (the `StakeVault` call). The caller now persists `apply_ban`'s effects fully *before* calling out, so a reentrant call during that call can never observe a signal that's "active" but mid-ban.
2. **Reentrancy guard.** Added `contracts/signal_registry/src/reentrancy.rs`: a contract-wide `guarded()`/`require_not_locked()` primitive (temp-storage flag, released on every path). Generalizes the per-function `UnstakeLock` from #264 into something reusable — `unstake_tokens` now runs on the same primitive, which also means the lock now blocks *cross-entrypoint* reentry (e.g. a callback from inside `ban_provider` trying to sneak in through `unstake_tokens`), not just self-reentry.

## A bonus find while building the integration test

Wiring up a real `StakeVaultContract` to test this end-to-end surfaced a separate, pre-existing bug: `providers::slash_stake` was calling `StakeVault::slash_stake` with a raw `i128` stake amount, but the deployed contract's signature expects a `SlashSeverity` tier (`#[repr(u32)]` enum). That mismatch would trap against a real vault — `ban_provider`'s slashing step was untested and broken. Fixed by encoding `SlashSeverity::Critical` (100% by default, matching "ban slashes full stake") and reading back the actual slashed amount from the call.

## An even more interesting find

The integration test's "malicious vault reenters mid-call" scenario doesn't reach `signal_registry`'s own guard at all — **Soroban's host rejects it first.** `soroban-env-host`'s `call`/`try_call` hardcode `ContractReentryMode::Prohibited` for every standard cross-contract call, unconditionally (no `#[contractimpl]`-level opt-out exists today). So the literal attack described in the issue is already closed at the protocol layer, and it fails atomically — the whole transaction reverts, no partial state.

That doesn't make the contract-level guard pointless:
- It's the one protection `signal_registry` itself controls; the host behavior is Soroban's, not this contract's, and the host source notes a `reentry` opt-in flag is planned for `try_call` (currently hardcoded) — if that lands, this guard is what keeps `ban_provider` safe.
- It fails with a typed `AdminError::ReentrancyDetected` instead of an opaque host trap.
- CEI ordering is correct practice regardless of *why* reentrancy is blocked.

This is documented in the integration test's module doc so the reasoning isn't lost.

## Also fixed (unrelated, blocking)

`collaboration.rs` had a pre-existing compile break — `signal_registry` didn't build at all on `main` (self-importing its own not-yet-defined items, and a call to `Vec::last_mut`, which `soroban_sdk::Vec` doesn't have). Fixed both so this crate — and this PR's own tests — can actually build and run. Unrelated to reentrancy; happy to split into its own PR if preferred.

I also hit a second, larger pre-existing break in `fee_collector` (several referral-system functions referenced in `lib.rs` don't exist anywhere in the crate), which currently blocks `cargo test -p integration_tests` at the workspace level. I did **not** touch that — it's a real missing feature, not a quick fix, and well outside this issue's scope. I verified my new integration test by temporarily excluding that dependency locally; the committed `Cargo.toml` change is only the new `[[test]]` entry. Happy to file a separate issue for it if useful.

## Testing

- `cargo test -p signal_registry --features testutils`: 296 passing, including 7 reentrancy-guard unit tests (`unstake_tokens_*`, and new `ban_provider_*` / `guard_blocks_across_entrypoints` coverage). 12 pre-existing failures (`cohort_retention`, `churn_risk`, `providers::`-specialization tests) and one CPU-budget-exceeded `leaderboard` test reproduce identically on `main` without this change — confirmed by re-running with only the `collaboration.rs` fix applied.
- `cargo test -p integration_tests --test test_signal_registry_reentrancy`: 2 passing — the malicious-vault-reverts-the-whole-call scenario, and a happy-path `ban_provider` run against the real `StakeVaultContract` exercising the `SlashSeverity` fix end-to-end.

## Acceptance criteria

- [x] All cross-contract call sites in `signal_registry` documented in-code with a reentrancy risk assessment.
- [x] Reentrancy guard applied to the one write-before-call site found (`ban_provider`); CEI reordering applied there too.
- [x] A reentrancy error variant exists in `errors.rs` — `AdminError::ReentrancyDetected` (added in #264; reused rather than duplicated, and re-exported from the crate root so it's nameable from integration tests).
- [x] Integration test simulates reentrancy via a mock malicious contract and asserts rejection (against `ban_provider`/`StakeVault`, the site that's actually reachable — `stake_tokens` has no external call to attack, see audit table above).
- [x] `cargo test` passes with no regressions (see Testing section for the pre-existing, unrelated failures that were already present).