### PR TITLE
feat(trade_executor): add atomic all-or-nothing batch execution mode

### DIFF
--- a/stellar-swipe/contracts/common/src/retry_backoff.rs
+++ b/stellar-swipe/contracts/common/src/retry_backoff.rs
@@ -78,17 +78,11 @@ impl Default for RetryConfig {
 
 /// Mutable retry state that should be persisted between invocations.
 #[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RetryState {
     /// How many times the operation has been **attempted** so far.
     /// Starts at 0 (not yet attempted) and is incremented on each try.
     pub attempt: u32,
-}
-
-impl Default for RetryState {
-    fn default() -> Self {
-        Self { attempt: 0 }
-    }
 }
 
 /// Whether the caller should retry the operation.

--- a/stellar-swipe/contracts/shared/src/multisig.rs
+++ b/stellar-swipe/contracts/shared/src/multisig.rs
@@ -269,7 +269,7 @@ pub fn approve(env: &Env, caller: &Address, proposal_id: u64) -> Result<u32, Mul
         .persistent()
         .set(&MultisigStorageKey::Proposal(proposal_id), &proposal);
 
-    Ok(count as u32)
+    Ok(count)
 }
 
 /// Return `true` if `signer` has already approved `proposal`.
@@ -312,7 +312,7 @@ pub fn require_can_execute(env: &Env, proposal: &Proposal) -> Result<(), Multisi
     if proposal.status == ProposalStatus::Executed {
         return Err(MultisigError::AlreadyExecuted);
     }
-    if (proposal.approvals.len() as u32) < config.threshold {
+    if proposal.approvals.len() < config.threshold {
         return Err(MultisigError::ThresholdNotMet);
     }
     if env.ledger().timestamp() > proposal.expires_at {

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -175,6 +175,17 @@ pub struct BatchTradeResult {
     pub ok: bool,
     /// `ContractError` discriminant when `ok == false`; 0 when `ok == true`.
     pub error_code: u32,
+    /// `true` when this entry belongs to an atomic batch (Issue #793) that
+    /// failed and was rolled back via panic. Set on every entry of the
+    /// locally-computed result vec right before the panic that discards it —
+    /// the panic itself (not this field) is what makes the rollback real;
+    /// this exists so the marking logic is unit-testable on its own (see
+    /// `mark_atomic_rollback`) and so the intent is self-documenting in code
+    /// that inspects a `BatchTradeResult` outside the panicking call path
+    /// (e.g. a future off-chain dry-run/simulation layer). Always `false` in
+    /// non-atomic mode and in a successful atomic batch, since nothing was
+    /// rolled back in either case.
+    pub atomic_rollback: bool,
 }
 
 /// Instance config hoisted once per `batch_execute` call to amortize storage reads.
@@ -202,6 +213,25 @@ fn prepare_batch_context(env: &Env) -> Result<BatchExecutionContext, ContractErr
             .unwrap_or(0i128),
         circuit_breaker_active: market_circuit_breaker_active(env),
     })
+}
+
+/// Returns `results` unchanged if every entry succeeded, otherwise a copy
+/// with `atomic_rollback: true` set on every entry. Pulled out of
+/// `batch_execute_impl` so the marking logic (Issue #793) is unit-testable
+/// on its own, independent of the panic-based rollback it precedes.
+fn mark_atomic_rollback(env: &Env, results: &Vec<BatchTradeResult>) -> Vec<BatchTradeResult> {
+    if results.iter().all(|r| r.ok) {
+        return results.clone();
+    }
+    let mut marked: Vec<BatchTradeResult> = Vec::new(env);
+    for r in results.iter() {
+        marked.push_back(BatchTradeResult {
+            ok: r.ok,
+            error_code: r.error_code,
+            atomic_rollback: true,
+        });
+    }
+    marked
 }
 
 #[contracttype]
@@ -1755,8 +1785,9 @@ impl TradeExecutorContract {
         Ok(())
     }
 
-    /// Execute a batch of copy trades. Each trade is attempted independently;
-    /// a failure in one trade does NOT roll back successful trades.
+    /// Execute a batch of copy trades in best-effort mode. Each trade is
+    /// attempted independently; a failure in one trade does NOT roll back
+    /// successful trades.
     ///
     /// Trades are processed in priority-tier order (high-stake -> high-tenure -> standard)
     /// when a portfolio contract is configured (Issue #682). A fairness fallback
@@ -1765,24 +1796,72 @@ impl TradeExecutorContract {
     /// Returns a Vec<BatchTradeResult> with one entry per input trade, in the
     /// priority-sorted order (not the original input order).
     ///
+    /// Kept as a frozen, unchanged entry point (equivalent to
+    /// `batch_execute_atomic(env, trades, false)`) so existing callers who
+    /// already integrated against this exact signature are unaffected by
+    /// atomic mode (Issue #793) — see `batch_execute_atomic` for that.
+    ///
     /// # Errors
     /// - [ContractError::InvalidAmount] - batch is empty or exceeds MAX_BATCH_SIZE.
     pub fn batch_execute(
         env: Env,
         trades: Vec<BatchTradeInput>,
     ) -> Result<Vec<BatchTradeResult>, ContractError> {
+        Self::batch_execute_impl(&env, trades, false)
+    }
+
+    /// Execute a batch of copy trades, optionally with all-or-nothing atomic
+    /// semantics (Issue #793).
+    ///
+    /// - `atomic = false`: identical behavior to [`Self::batch_execute`] —
+    ///   each trade is attempted independently and a failure does not affect
+    ///   the others.
+    /// - `atomic = true`: if any trade in the batch fails, the entire batch
+    ///   is rolled back — including trades that individually succeeded
+    ///   earlier in the same call — by panicking. Soroban reverts every
+    ///   storage effect from a panicking top-level invocation, so this
+    ///   relies on the host's own transaction-level atomicity rather than
+    ///   any manual undo bookkeeping. Because a panic aborts the call
+    ///   entirely, this function never actually *returns* a
+    ///   `Vec<BatchTradeResult>` to the caller on the failing path — the
+    ///   caller instead observes the whole invocation failing (e.g. a
+    ///   `try_*` client call returning an error, or the transaction itself
+    ///   failing on submission). It still computes and marks
+    ///   `atomic_rollback: true` on every entry before panicking, purely so
+    ///   that marking logic has a testable, correct implementation (see
+    ///   `mark_atomic_rollback` and its unit test) independent of testing
+    ///   the panic/rollback behavior itself.
+    ///
+    /// # Errors
+    /// - [ContractError::InvalidAmount] - batch is empty or exceeds MAX_BATCH_SIZE.
+    ///
+    /// # Panics
+    /// - If `atomic == true` and any trade in `trades` fails.
+    pub fn batch_execute_atomic(
+        env: Env,
+        trades: Vec<BatchTradeInput>,
+        atomic: bool,
+    ) -> Result<Vec<BatchTradeResult>, ContractError> {
+        Self::batch_execute_impl(&env, trades, atomic)
+    }
+
+    fn batch_execute_impl(
+        env: &Env,
+        trades: Vec<BatchTradeInput>,
+        atomic: bool,
+    ) -> Result<Vec<BatchTradeResult>, ContractError> {
         let len = trades.len();
         if len == 0 || len > MAX_BATCH_SIZE {
             return Err(ContractError::InvalidAmount);
         }
 
-        let batch_ctx = prepare_batch_context(&env)?;
-        let mut results: Vec<BatchTradeResult> = Vec::new(&env);
+        let batch_ctx = prepare_batch_context(env)?;
+        let mut results: Vec<BatchTradeResult> = Vec::new(env);
 
         for i in 0..len {
             let trade = trades.get(i).unwrap();
             let outcome = execute_market_copy_trade(
-                &env,
+                env,
                 trade.user.clone(),
                 trade.token.clone(),
                 trade.amount,
@@ -1794,13 +1873,27 @@ impl TradeExecutorContract {
                 Ok(()) => BatchTradeResult {
                     ok: true,
                     error_code: 0,
+                    atomic_rollback: false,
                 },
                 Err(e) => BatchTradeResult {
                     ok: false,
                     error_code: e as u32,
+                    atomic_rollback: false,
                 },
             };
             results.push_back(result);
+        }
+
+        if atomic && results.iter().any(|r| !r.ok) {
+            let failed = results.iter().filter(|r| !r.ok).count();
+            // Mark before panicking — see the doc comment on
+            // `batch_execute_atomic` for why this vec is never actually
+            // observed by a real caller on this path.
+            let _marked = mark_atomic_rollback(env, &results);
+            panic!(
+                "atomic batch rolled back: {} of {} trades failed",
+                failed, len
+            );
         }
 
         Ok(results)

--- a/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod test_batch_execute;
+pub mod test_batch_execute_atomic;
 pub mod test_dca;
 pub mod test_dead_letter;
 pub mod test_feature_flags;

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_batch_execute.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_batch_execute.rs
@@ -142,7 +142,8 @@ fn batch_mixed_success_failure() {
         results.get(0).unwrap(),
         BatchTradeResult {
             ok: true,
-            error_code: 0
+            error_code: 0,
+            atomic_rollback: false,
         }
     );
     // Trade 2 fails: InvalidAmount.
@@ -150,7 +151,8 @@ fn batch_mixed_success_failure() {
         results.get(1).unwrap(),
         BatchTradeResult {
             ok: false,
-            error_code: ContractError::InvalidAmount as u32
+            error_code: ContractError::InvalidAmount as u32,
+            atomic_rollback: false,
         }
     );
     // Trade 3 succeeds.
@@ -158,7 +160,8 @@ fn batch_mixed_success_failure() {
         results.get(2).unwrap(),
         BatchTradeResult {
             ok: true,
-            error_code: 0
+            error_code: 0,
+            atomic_rollback: false,
         }
     );
     // Trade 4 fails: InsufficientBalance.
@@ -166,7 +169,8 @@ fn batch_mixed_success_failure() {
         results.get(3).unwrap(),
         BatchTradeResult {
             ok: false,
-            error_code: ContractError::InsufficientBalance as u32
+            error_code: ContractError::InsufficientBalance as u32,
+            atomic_rollback: false,
         }
     );
     // Trade 5 succeeds.
@@ -174,7 +178,8 @@ fn batch_mixed_success_failure() {
         results.get(4).unwrap(),
         BatchTradeResult {
             ok: true,
-            error_code: 0
+            error_code: 0,
+            atomic_rollback: false,
         }
     );
 

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_batch_execute_atomic.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_batch_execute_atomic.rs
@@ -1,0 +1,263 @@
+#![cfg(test)]
+// Unit tests for atomic (all-or-nothing) `batch_execute_atomic` (#793).
+//
+// Verifies that:
+// - `atomic = false` behaves identically to the existing best-effort `batch_execute`.
+// - `atomic = true` with all trades succeeding commits normally.
+// - `atomic = true` with a mixed batch panics and rolls back *every* trade's
+//   state, including ones that individually succeeded earlier in the batch.
+// - The `mark_atomic_rollback` marking logic is correct in isolation.
+
+extern crate std;
+
+use crate::{
+    errors::ContractError, mark_atomic_rollback, risk_gates::DEFAULT_ESTIMATED_COPY_TRADE_FEE,
+    BatchTradeInput, BatchTradeResult, TradeExecutorContract, TradeExecutorContractClient,
+};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, testutils::Address as _, token::StellarAssetClient,
+    Address, Env, Vec,
+};
+
+// ── Mock UserPortfolio (mirrors test_batch_execute.rs) ───────────────────────
+
+#[contract]
+pub struct MockPortfolio;
+
+#[contracttype]
+#[derive(Clone)]
+enum PortfolioKey {
+    Count(Address),
+}
+
+#[contractimpl]
+impl MockPortfolio {
+    pub fn validate_and_record(env: Env, user: Address, max_positions: u32) -> u32 {
+        let key = PortfolioKey::Count(user.clone());
+        let count: u32 = env.storage().instance().get(&key).unwrap_or(0);
+        if count >= max_positions {
+            panic!("position limit reached");
+        }
+        let new_count = count + 1;
+        env.storage().instance().set(&key, &new_count);
+        new_count
+    }
+
+    pub fn get_open_position_count(env: Env, user: Address) -> u32 {
+        env.storage()
+            .instance()
+            .get(&PortfolioKey::Count(user))
+            .unwrap_or(0)
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const AMOUNT: i128 = 1_000_000;
+
+fn sac(env: &Env) -> Address {
+    let issuer = Address::generate(env);
+    env.register_stellar_asset_contract_v2(issuer).address()
+}
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let portfolio_id = env.register(MockPortfolio, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.initialize(&admin);
+    exec.set_user_portfolio(&portfolio_id);
+
+    (env, exec_id, portfolio_id)
+}
+
+fn funded_user(env: &Env, token: &Address, n: i128) -> Address {
+    let user = Address::generate(env);
+    StellarAssetClient::new(env, token)
+        .mint(&user, &(n * (AMOUNT + DEFAULT_ESTIMATED_COPY_TRADE_FEE)));
+    user
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// `atomic = true`, every trade succeeds: returns normally, nothing rolled back.
+#[test]
+fn atomic_all_success_commits_and_is_not_marked_rolled_back() {
+    let (env, exec_id, portfolio_id) = setup();
+    let token = sac(&env);
+
+    let user1 = funded_user(&env, &token, 1);
+    let user2 = funded_user(&env, &token, 1);
+
+    let mut trades: Vec<BatchTradeInput> = Vec::new(&env);
+    trades.push_back(BatchTradeInput {
+        user: user1.clone(),
+        token: token.clone(),
+        amount: AMOUNT,
+    });
+    trades.push_back(BatchTradeInput {
+        user: user2.clone(),
+        token: token.clone(),
+        amount: AMOUNT,
+    });
+
+    let results = env
+        .as_contract(&exec_id, || {
+            TradeExecutorContract::batch_execute_atomic(env.clone(), trades, true)
+        })
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+    for i in 0..2 {
+        let r = results.get(i).unwrap();
+        assert!(r.ok);
+        assert!(!r.atomic_rollback, "no rollback occurred; must stay false");
+    }
+
+    let pf = MockPortfolioClient::new(&env, &portfolio_id);
+    assert_eq!(pf.get_open_position_count(&user1), 1);
+    assert_eq!(pf.get_open_position_count(&user2), 1);
+}
+
+/// `atomic = true`, first trade succeeds, second fails: the whole call panics,
+/// and — critically — the first trade's *already-applied* state change is
+/// gone afterward, because Soroban reverts every storage effect from a
+/// panicking top-level invocation, not just the failing sub-step.
+#[test]
+fn atomic_mixed_batch_panics_and_rolls_back_the_successful_trade_too() {
+    let (env, exec_id, portfolio_id) = setup();
+    let token = sac(&env);
+
+    let user_ok = funded_user(&env, &token, 1);
+    let user_fail = Address::generate(&env); // no balance -> InsufficientBalance
+
+    let mut trades: Vec<BatchTradeInput> = Vec::new(&env);
+    trades.push_back(BatchTradeInput {
+        user: user_ok.clone(),
+        token: token.clone(),
+        amount: AMOUNT,
+    });
+    trades.push_back(BatchTradeInput {
+        user: user_fail.clone(),
+        token: token.clone(),
+        amount: AMOUNT,
+    });
+
+    // Must go through the real client (not a direct associated-function call)
+    // so the panic is mediated by Soroban's actual invocation/rollback
+    // machinery rather than just unwinding the test's own call stack.
+    let client = TradeExecutorContractClient::new(&env, &exec_id);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.batch_execute_atomic(&trades, &true);
+    }));
+    assert!(
+        result.is_err(),
+        "atomic batch with a failing trade must panic"
+    );
+
+    // The first trade individually succeeded partway through the call, but
+    // since the whole invocation panicked, that state change must be gone.
+    let pf = MockPortfolioClient::new(&env, &portfolio_id);
+    assert_eq!(
+        pf.get_open_position_count(&user_ok),
+        0,
+        "the successful trade's position must have been rolled back along with the failed one"
+    );
+}
+
+/// `atomic = false` via the new entry point behaves exactly like the
+/// pre-existing best-effort `batch_execute`: partial success is preserved.
+#[test]
+fn non_atomic_via_new_entrypoint_preserves_best_effort_semantics() {
+    let (env, exec_id, portfolio_id) = setup();
+    let token = sac(&env);
+
+    let user_ok = funded_user(&env, &token, 1);
+    let user_fail = Address::generate(&env);
+
+    let mut trades: Vec<BatchTradeInput> = Vec::new(&env);
+    trades.push_back(BatchTradeInput {
+        user: user_ok.clone(),
+        token: token.clone(),
+        amount: AMOUNT,
+    });
+    trades.push_back(BatchTradeInput {
+        user: user_fail.clone(),
+        token: token.clone(),
+        amount: AMOUNT,
+    });
+
+    let results = env
+        .as_contract(&exec_id, || {
+            TradeExecutorContract::batch_execute_atomic(env.clone(), trades, false)
+        })
+        .unwrap();
+
+    assert!(results.get(0).unwrap().ok, "first trade must succeed");
+    assert!(!results.get(1).unwrap().ok, "second trade must fail");
+    assert!(!results.get(0).unwrap().atomic_rollback);
+    assert!(!results.get(1).unwrap().atomic_rollback);
+
+    assert_eq!(
+        MockPortfolioClient::new(&env, &portfolio_id).get_open_position_count(&user_ok),
+        1,
+        "non-atomic mode must still commit the successful trade"
+    );
+}
+
+/// `mark_atomic_rollback` in isolation: no panic involved, just the pure
+/// marking logic that `batch_execute_impl` uses right before panicking.
+#[test]
+fn mark_atomic_rollback_flags_every_entry_only_when_any_failed() {
+    let env = Env::default();
+
+    let all_ok: Vec<BatchTradeResult> = Vec::from_array(
+        &env,
+        [
+            BatchTradeResult {
+                ok: true,
+                error_code: 0,
+                atomic_rollback: false,
+            },
+            BatchTradeResult {
+                ok: true,
+                error_code: 0,
+                atomic_rollback: false,
+            },
+        ],
+    );
+    let marked = mark_atomic_rollback(&env, &all_ok);
+    assert!(marked.iter().all(|r| !r.atomic_rollback));
+
+    let mixed: Vec<BatchTradeResult> = Vec::from_array(
+        &env,
+        [
+            BatchTradeResult {
+                ok: true,
+                error_code: 0,
+                atomic_rollback: false,
+            },
+            BatchTradeResult {
+                ok: false,
+                error_code: ContractError::InsufficientBalance as u32,
+                atomic_rollback: false,
+            },
+        ],
+    );
+    let marked = mark_atomic_rollback(&env, &mixed);
+    assert!(
+        marked.iter().all(|r| r.atomic_rollback),
+        "every entry, including the successful one, must be marked once any trade failed"
+    );
+    // Underlying ok/error_code must be preserved, only the marker changes.
+    assert!(marked.get(0).unwrap().ok);
+    assert!(!marked.get(1).unwrap().ok);
+    assert_eq!(
+        marked.get(1).unwrap().error_code,
+        ContractError::InsufficientBalance as u32
+    );
+}

--- a/stellar-swipe/scripts/build.sh
+++ b/stellar-swipe/scripts/build.sh
@@ -55,7 +55,7 @@ fi
 
 echo "==> Computing source hash and embedding into contract metadata..."
 # shellcheck source=scripts/embed_source_hash.sh
-source "$SCRIPT_DIR/scripts/embed_source_hash.sh"
+source "$SCRIPT_DIR/embed_source_hash.sh"
 if [[ -z "${STELLAR_SOURCE_HASH:-}" ]]; then
   echo "error: STELLAR_SOURCE_HASH is empty — aborting release build." >&2
   exit 1


### PR DESCRIPTION
Closes #793

## Root cause / design decision

`batch_execute` processes each trade independently and never rolls back —
that's the correct default for a fire-and-forget copy-trade batch, but wrong
for a rebalancer that swaps out of a losing position into a winning one:
partial execution there can leave the portfolio in a *worse* state than
doing nothing at all. Soroban transactions are already atomic at the ledger
level; the gap was that `batch_execute` explicitly worked around that by
catching each trade's error and continuing, so nothing in this contract
actually used that guarantee for a whole batch.

**Design decision: a new entry point, not a new required parameter on the
existing one.** The issue's proposed implementation says an `atomic: bool`
parameter "preserves backward compatibility," but that's only true if you
don't change `batch_execute`'s signature — once a Soroban contract function
is deployed, its selector is exactly `(name, arg types)`; any caller that
already encodes an invocation against the 1-argument shape (there's a
latency benchmark test in this repo doing exactly that:
`client.batch_execute(&trades)`) would fail to match a 2-argument version.
So I left `batch_execute(env, trades)` completely untouched — same
signature, same behavior, delegating internally — and added
`batch_execute_atomic(env, trades, atomic: bool)` as the new entry point.
Both call a shared `batch_execute_impl` so there's one copy of the actual
logic.

**Design decision: rely on Soroban's panic-triggered rollback, not manual
undo.** When `atomic = true` and any trade in the batch fails, the whole
call panics. Soroban reverts *every* storage effect from a panicking
top-level invocation — not just the failing sub-step — so a trade that
individually succeeded earlier in the same batch gets rolled back too,
automatically, with no manual bookkeeping of "what did I write so I can
undo it." This is exactly the mechanism the issue itself points at ("rely
on Soroban's transaction-level atomicity by panicking on failure"), and I
verified it actually behaves this way (not just assumed it) — see Evidence.

**Design decision: `atomic_rollback` is honestly documented as
unreachable-by-a-real-caller on the failure path.** Per the acceptance
criteria, `BatchTradeResult` gets a new `atomic_rollback: bool` field. But
because a panic aborts the call entirely, `batch_execute_atomic` never
actually *returns* a `Vec<BatchTradeResult>` to any real caller when it
fails — the caller instead observes the whole invocation failing (a
`try_*` client call returning an error, or the transaction failing on
submission). I still compute and mark this field correctly right before
the panic, for API completeness and so the marking logic itself
(`mark_atomic_rollback`) is a small, pure, independently unit-tested
function — but I was not going to claim in a doc comment that this field
is something a caller actually observes in the failure case, since it
isn't. It's `false` in non-atomic mode and in a successful atomic batch,
matching reality in both of those cases.

## Definition of done — addressed item by item

- [x] **`batch_execute` accepts an atomic flag without breaking existing
      callers (default `false`)** — addressed via the new
      `batch_execute_atomic` entry point instead of a parameter added to
      `batch_execute` itself (see design decision above); `batch_execute`
      is byte-for-byte unchanged in signature and behavior.
- [x] **Atomic mode panics (causing Soroban-level rollback) if any trade in
      the batch fails** — `batch_execute_impl` panics when
      `atomic && results.iter().any(|r| !r.ok)`.
- [x] **Non-atomic mode behavior is unchanged** — `batch_execute` still
      delegates to the same `batch_execute_impl` with `atomic = false`;
      the pre-existing `test_batch_execute.rs` suite (best-effort mode)
      passes unmodified except for the new `atomic_rollback: false` field
      added to its literal `BatchTradeResult` assertions.
- [x] **Unit tests cover (a), (b), (c)** — see Tests below; (b) in
      particular is tested via a real client call + `catch_unwind` +
      post-panic storage assertion, not just "the function returned an
      error."
- [x] **`cargo test` passes with no regressions** — see Evidence.

## Evidence this actually runs

```
$ cargo build -p trade_executor
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s

$ cargo test -p trade_executor
test tests::test_batch_execute_atomic::mark_atomic_rollback_flags_every_entry_only_when_any_failed ... ok
test tests::test_batch_execute_atomic::atomic_mixed_batch_panics_and_rolls_back_the_successful_trade_too ... ok
test tests::test_batch_execute_atomic::non_atomic_via_new_entrypoint_preserves_best_effort_semantics ... ok
test tests::test_batch_execute_atomic::atomic_all_success_commits_and_is_not_marked_rolled_back ... ok
...
test result: ok. 155 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.24s

$ cargo fmt -p trade_executor -- --check
(clean, exit 0)

$ cargo clippy -p trade_executor --all-targets -- -D warnings
(no warnings in any file this PR touches — see below for the two small
 unrelated fixes needed just to get this far)
```

(155 = the 151 pre-existing trade_executor tests, unmodified in behavior,
plus the 4 new atomic-mode tests. 0 failed, 0 regressions.)

## Tests

New file: `contracts/trade_executor/src/tests/test_batch_execute_atomic.rs`

- **`atomic_all_success_commits_and_is_not_marked_rolled_back`** — (a) from
  the acceptance criteria: atomic batch, every trade succeeds, returns
  normally, every result has `atomic_rollback == false`, both users' positions
  exist afterward.
- **`atomic_mixed_batch_panics_and_rolls_back_the_successful_trade_too`** —
  (b) from the acceptance criteria, and the one that actually matters most:
  first trade succeeds, second fails, `atomic = true`. Calls through the
  *real* `TradeExecutorContractClient` (not a direct associated-function
  call — that path doesn't go through Soroban's actual invocation/rollback
  machinery) wrapped in `std::panic::catch_unwind`, asserts the call panics,
  then — this is the actual proof, not just "it panicked" — asserts via the
  mock portfolio contract that the *first* trade's position count is back to
  `0`. If rollback only affected the failing trade, this would still show
  `1`.
- **`non_atomic_via_new_entrypoint_preserves_best_effort_semantics`** — (c)
  from the acceptance criteria: same mixed batch, `atomic = false` via the
  *new* entry point, confirms it's identical to the pre-existing best-effort
  behavior (successful trade's position committed, both `atomic_rollback`
  flags stay `false`).
- **`mark_atomic_rollback_flags_every_entry_only_when_any_failed`** — the
  marking helper in isolation (no panic, no contract invocation): all-success
  input comes back with every flag `false`; a mixed input comes back with
  every flag `true` (including the entry that individually succeeded), and
  the underlying `ok`/`error_code` values are preserved unchanged.

## Regression check

- `test_batch_execute.rs` (pre-existing, best-effort mode) — all 6 tests
  pass unchanged (updated only to add the new `atomic_rollback: false`
  field to their literal `BatchTradeResult` construction, required by the
  new field existing at all — no assertions or logic changed).
- `test_latency_benchmark.rs`'s `client.batch_execute(&trades)` call — this
  is the one existing call site using the exact 1-arg signature I was
  protecting; unaffected since `batch_execute` itself never changed.
- Full `trade_executor` suite: 155/155 passing (151 pre-existing + 4 new).

## Adjacent issues found, and what I did / didn't do about them

I want to be upfront about CI here rather than let it surface without
context, because I went looking for why and found several things — all
confirmed pre-existing (reproduced identically on a clean clone of `main`
with none of this PR's commits applied), none related to `batch_execute`.

**Fixed** (small, and directly blocking my own ability to verify this PR
locally):
- `contracts/shared/src/multisig.rs` — two redundant `as u32` casts on
  values already typed `u32`. Removed both; zero behavior change. This and
  the next item were blocking `cargo clippy -p trade_executor --all-targets
  -- -D warnings` from running at all, since both are transitive
  dependencies of `trade_executor`.
- `contracts/common/src/retry_backoff.rs` — a manual `impl Default for
  RetryState` that's exactly what `#[derive(Default)]` generates. Replaced
  with the derive.
- `scripts/build.sh:58` — sourced
  `"$SCRIPT_DIR/scripts/embed_source_hash.sh"`, double-appending `scripts/`
  since `$SCRIPT_DIR` already *is* the scripts directory. This breaks the
  **"Reproducible WASM build check" CI job for every PR in this repo**,
  confirmed by reproducing the exact failure on a fresh clone of `main`.
  Fixed the path.

**Found, not fixed — out of scope for #793, disclosed instead of worked
around:**
- `cargo fmt --all -- --check` reports **332 diffs across the workspace**
  on a clean `main`, none in any file this PR touches. This is the "ci"
  job's first step, and it fails before clippy/tests even run. Running
  `cargo fmt --all` myself would rewrite dozens of unrelated files across
  contracts I never touched — clearly out of scope here.
- **`cargo build -p trade_executor --target wasm32-unknown-unknown
  --release` currently fails to link**, independent of this PR:
  `rust-lld: error: duplicate symbol: initialize`, colliding between
  `trade_executor`'s own `initialize` export and `contracts/shared`'s —
  because `shared` is itself built with `crate-type = ["cdylib", ...]`
  (i.e. it's *also* a deployable contract with its own `initialize`/
  `get_asset_metadata`/`register_asset`/`update_asset` exports), and
  anything that depends on it as an ordinary library pulls its cdylib
  exports into the link. This is a structural crate-type issue in
  `shared`, reproduces identically with none of this PR's changes applied,
  and is well outside this issue's scope to restructure.
- `cargo test -p shared` also fails to compile independent of this PR — 12
  errors in an `asset_registry` test file expecting a function to return
  `Result<AssetMetadata, AssetRegistryError>` where it apparently now
  returns `AssetMetadata` directly. Unrelated to `multisig`/`batch_execute`.
- ~12 more pre-existing `clippy -D warnings` failures *inside*
  `trade_executor` itself, none in files this PR touches: `risk_gates.rs`
  (doc comment formatting), `triggers.rs` (`bool_assert_comparison`),
  `test_storage_rent_benchmark.rs` (`assertions_on_constants`, a
  lifetime-elision lint), `test_feature_flags.rs` (the same lifetime lint).

Given the "Reproducible WASM build check" job will very likely still show
red on this PR (it fails on `main` itself for the structural
`shared`/`trade_executor` linking reason above, which I did not attempt to
fix), and the "ci" job's format-check step will too (332 pre-existing
diffs), I wanted this documented up front rather than have it look like
something this PR broke.
