### PR TITLE
trade_executor: TTL-based dead-letter queue pruning

### DIFF
--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -85,6 +85,12 @@ pub enum StorageKey {
     DeadLetterTrade(u64),
     /// Per-user index of dead-lettered trade IDs.
     DeadLetterIds(Address),
+    /// Global index of all dead-lettered trade IDs across every user, used by
+    /// `prune_dead_letter_queue` when sweeping without a `user` filter.
+    DeadLetterAllIds,
+    /// Retention window (in ledgers) after which a dead-lettered trade becomes
+    /// eligible for removal via `prune_dead_letter_queue`.
+    DeadLetterRetentionLedgers,
     /// Priority-lane configuration (PriorityConfig).
     PriorityConfig,
     /// The most recent trade order awaiting confirmation-depth finalization.
@@ -130,6 +136,10 @@ pub const DEFAULT_GRACE_PERIOD_LEDGERS: u32 = 10;
 /// Default maximum execution attempts before a trade is dead-lettered (3 attempts total).
 pub const DEFAULT_MAX_RETRY_COUNT: u32 = 3;
 
+/// Default dead-letter retention window: ~30 days at 5s/ledger
+/// (30 * 24 * 60 * 60 / 5 = 518_400 ledgers).
+pub const DEFAULT_DEAD_LETTER_RETENTION_LEDGERS: u32 = 518_400;
+
 /// A trade that has exhausted all retry attempts and been moved to the dead-letter queue.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -156,6 +166,15 @@ pub struct TradeDeadLettered {
     pub user: Address,
     pub failure_code: u32,
     pub retry_count: u32,
+}
+
+/// Event emitted when a dead-lettered trade is removed by `prune_dead_letter_queue`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeadLetterPruned {
+    pub user: Address,
+    pub trade_id: u64,
+    pub reason: String,
 }
 
 /// A single trade input for [`TradeExecutorContract::batch_execute`].
@@ -807,6 +826,7 @@ fn dead_letter_trade_internal(env: &Env, trade: &QueuedTrade, failure_code: u32)
     env.storage()
         .instance()
         .set(&StorageKey::DeadLetterIds(trade.user.clone()), &ids);
+    add_dead_letter_index(env, trade.queued_trade_id);
 
     env.events().publish(
         (
@@ -818,6 +838,83 @@ fn dead_letter_trade_internal(env: &Env, trade: &QueuedTrade, failure_code: u32)
             user: trade.user.clone(),
             failure_code,
             retry_count: trade.retry_count.saturating_add(1),
+        },
+    );
+}
+
+/// Return the configured dead-letter retention window in ledgers
+/// (defaults to [`DEFAULT_DEAD_LETTER_RETENTION_LEDGERS`]).
+fn effective_dead_letter_retention(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&StorageKey::DeadLetterRetentionLedgers)
+        .unwrap_or(DEFAULT_DEAD_LETTER_RETENTION_LEDGERS)
+}
+
+/// Add `id` to the global index of all dead-lettered trade IDs.
+fn add_dead_letter_index(env: &Env, id: u64) {
+    let mut all: Vec<u64> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::DeadLetterAllIds)
+        .unwrap_or_else(|| Vec::new(env));
+    all.push_back(id);
+    env.storage()
+        .instance()
+        .set(&StorageKey::DeadLetterAllIds, &all);
+}
+
+/// Remove `id` from the global index of all dead-lettered trade IDs.
+fn remove_dead_letter_index(env: &Env, id: u64) {
+    let mut all: Vec<u64> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::DeadLetterAllIds)
+        .unwrap_or_else(|| Vec::new(env));
+    let mut i = 0;
+    while i < all.len() {
+        if all.get(i).unwrap() == id {
+            all.remove(i);
+            break;
+        }
+        i += 1;
+    }
+    env.storage()
+        .instance()
+        .set(&StorageKey::DeadLetterAllIds, &all);
+}
+
+/// Remove `id` from `user`'s per-user dead-letter index.
+fn remove_dead_letter_id(env: &Env, user: &Address, id: u64) {
+    let mut ids: Vec<u64> = env
+        .storage()
+        .instance()
+        .get(&StorageKey::DeadLetterIds(user.clone()))
+        .unwrap_or_else(|| Vec::new(env));
+    let mut i = 0;
+    while i < ids.len() {
+        if ids.get(i).unwrap() == id {
+            ids.remove(i);
+            break;
+        }
+        i += 1;
+    }
+    env.storage()
+        .instance()
+        .set(&StorageKey::DeadLetterIds(user.clone()), &ids);
+}
+
+/// Emit a `dead_letter_pruned` event for a single removed entry.
+fn emit_dead_letter_pruned(env: &Env, user: Address, trade_id: u64) {
+    env.events().publish(
+        (
+            Symbol::new(env, "trade_executor"),
+            Symbol::new(env, "dead_letter_pruned"),
+        ),
+        DeadLetterPruned {
+            user,
+            trade_id,
+            reason: String::from_str(env, "retention_expired"),
         },
     );
 }
@@ -2024,22 +2121,8 @@ impl TradeExecutorContract {
         env.storage()
             .instance()
             .remove(&StorageKey::DeadLetterTrade(trade_id));
-        let mut dl_ids: Vec<u64> = env
-            .storage()
-            .instance()
-            .get(&StorageKey::DeadLetterIds(failed.user.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
-        let mut i = 0;
-        while i < dl_ids.len() {
-            if dl_ids.get(i).unwrap() == trade_id {
-                dl_ids.remove(i);
-                break;
-            }
-            i += 1;
-        }
-        env.storage()
-            .instance()
-            .set(&StorageKey::DeadLetterIds(failed.user.clone()), &dl_ids);
+        remove_dead_letter_id(&env, &failed.user, trade_id);
+        remove_dead_letter_index(&env, trade_id);
 
         // Re-queue with a fresh retry_count.
         let trade = QueuedTrade {
@@ -2067,23 +2150,83 @@ impl TradeExecutorContract {
         env.storage()
             .instance()
             .remove(&StorageKey::DeadLetterTrade(trade_id));
-        let mut dl_ids: Vec<u64> = env
-            .storage()
+        remove_dead_letter_id(&env, &failed.user, trade_id);
+        remove_dead_letter_index(&env, trade_id);
+        Ok(())
+    }
+
+    /// Admin: configure the dead-letter retention window (in ledgers) used by
+    /// `prune_dead_letter_queue`. Default is
+    /// [`DEFAULT_DEAD_LETTER_RETENTION_LEDGERS`] (~30 days at 5s/ledger).
+    pub fn set_dead_letter_retention(env: Env, ledgers: u32) -> Result<(), ContractError> {
+        require_admin(&env)?;
+        env.storage()
             .instance()
-            .get(&StorageKey::DeadLetterIds(failed.user.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
+            .set(&StorageKey::DeadLetterRetentionLedgers, &ledgers);
+        Ok(())
+    }
+
+    /// Return the configured dead-letter retention window in ledgers.
+    pub fn get_dead_letter_retention(env: Env) -> u32 {
+        effective_dead_letter_retention(&env)
+    }
+
+    /// Admin: prune dead-lettered trades older than the configured retention
+    /// window (see [`Self::set_dead_letter_retention`]).
+    ///
+    /// When `user` is `Some`, only that user's dead-letter queue is scanned;
+    /// when `None`, every dead-lettered trade across all users is scanned.
+    /// At most `max_entries` stale entries are removed per call, bounding the
+    /// resource cost of a single invocation — callers sweeping a larger
+    /// backlog should call this repeatedly.
+    ///
+    /// Emits `dead_letter_pruned` for each entry removed. Returns the count removed.
+    pub fn prune_dead_letter_queue(
+        env: Env,
+        user: Option<Address>,
+        max_entries: u32,
+    ) -> Result<u32, ContractError> {
+        require_admin(&env)?;
+
+        let retention = effective_dead_letter_retention(&env);
+        let current_ledger = env.ledger().sequence();
+
+        let ids: Vec<u64> = match &user {
+            Some(u) => env
+                .storage()
+                .instance()
+                .get(&StorageKey::DeadLetterIds(u.clone()))
+                .unwrap_or_else(|| Vec::new(&env)),
+            None => env
+                .storage()
+                .instance()
+                .get(&StorageKey::DeadLetterAllIds)
+                .unwrap_or_else(|| Vec::new(&env)),
+        };
+
+        let mut removed: u32 = 0;
         let mut i = 0;
-        while i < dl_ids.len() {
-            if dl_ids.get(i).unwrap() == trade_id {
-                dl_ids.remove(i);
-                break;
+        while i < ids.len() && removed < max_entries {
+            let id = ids.get(i).unwrap();
+            if let Some(failed) = env
+                .storage()
+                .instance()
+                .get::<_, FailedTrade>(&StorageKey::DeadLetterTrade(id))
+            {
+                if current_ledger.saturating_sub(failed.dead_lettered_at_ledger) >= retention {
+                    env.storage()
+                        .instance()
+                        .remove(&StorageKey::DeadLetterTrade(id));
+                    remove_dead_letter_id(&env, &failed.user, id);
+                    remove_dead_letter_index(&env, id);
+                    emit_dead_letter_pruned(&env, failed.user.clone(), id);
+                    removed = removed.saturating_add(1);
+                }
             }
             i += 1;
         }
-        env.storage()
-            .instance()
-            .set(&StorageKey::DeadLetterIds(failed.user.clone()), &dl_ids);
-        Ok(())
+
+        Ok(removed)
     }
 
     // ── Feature flag registry ─────────────────────────────────────────────────

--- a/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
@@ -2,6 +2,7 @@ pub mod test_batch_execute;
 pub mod test_batch_execute_atomic;
 pub mod test_dca;
 pub mod test_dead_letter;
+pub mod test_dead_letter_pruning;
 pub mod test_feature_flags;
 pub mod test_grace_period;
 pub mod test_market_simulation;

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_dead_letter_pruning.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_dead_letter_pruning.rs
@@ -1,0 +1,213 @@
+#![cfg(test)]
+//! Unit tests for TTL-based dead-letter queue pruning (Issue #792).
+//!
+//! Covers:
+//! - `prune_dead_letter_queue` removes nothing when no entries are stale
+//! - A mix of fresh and stale entries: only stale entries are removed
+//! - `max_entries` bounds a single call to a partial prune
+
+use crate::{
+    errors::ContractError, TradeExecutorContract, TradeExecutorContractClient,
+    DEFAULT_MAX_RETRY_COUNT,
+};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+// ── Mock UserPortfolio ────────────────────────────────────────────────────────
+
+#[contract]
+pub struct MockPortfolio;
+
+#[contracttype]
+#[derive(Clone)]
+enum PortfolioKey {
+    Count(Address),
+}
+
+#[contractimpl]
+impl MockPortfolio {
+    pub fn validate_and_record(env: Env, user: Address, max_positions: u32) -> u32 {
+        let key = PortfolioKey::Count(user.clone());
+        let count: u32 = env.storage().instance().get(&key).unwrap_or(0);
+        if count >= max_positions {
+            panic!("position limit reached");
+        }
+        let new_count = count + 1;
+        env.storage().instance().set(&key, &new_count);
+        new_count
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const AMOUNT: i128 = 1_000_000;
+
+fn sac(env: &Env) -> Address {
+    let issuer = Address::generate(env);
+    env.register_stellar_asset_contract_v2(issuer).address()
+}
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let portfolio_id = env.register(MockPortfolio, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.initialize(&admin);
+    exec.set_user_portfolio(&portfolio_id);
+    (env, exec_id, admin)
+}
+
+/// Queue a trade for a user that has NOT been funded — guaranteed to fail on execution.
+fn queue_failing_trade(env: &Env, exec_id: &Address, token: &Address) -> (Address, u64) {
+    let user = Address::generate(env); // no mint → always InsufficientBalance
+    let exec = TradeExecutorContractClient::new(env, exec_id);
+    let queued_id = exec.queue_copy_trade(&user, token, &AMOUNT, &None);
+    (user, queued_id)
+}
+
+/// Queue a failing trade, advance past the grace period, and exhaust all
+/// retries at the current ledger so it becomes dead-lettered right now.
+fn dead_letter_now(env: &Env, exec_id: &Address, token: &Address) -> Address {
+    let exec = TradeExecutorContractClient::new(env, exec_id);
+    let queued_at = env.ledger().sequence();
+    let (user, _queued_id) = queue_failing_trade(env, exec_id, token);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = queued_at + 20);
+    for _ in 0..DEFAULT_MAX_RETRY_COUNT {
+        exec.execute_queued_trades();
+    }
+    assert_eq!(exec.get_dead_letter_trades(&user).len(), 1);
+    user
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Default retention is [`crate::DEFAULT_DEAD_LETTER_RETENTION_LEDGERS`].
+#[test]
+fn default_retention_matches_constant() {
+    let (env, exec_id, _) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    assert_eq!(
+        exec.get_dead_letter_retention(),
+        crate::DEFAULT_DEAD_LETTER_RETENTION_LEDGERS
+    );
+}
+
+/// Admin can configure the retention window.
+#[test]
+fn admin_can_set_dead_letter_retention() {
+    let (env, exec_id, _) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.set_dead_letter_retention(&100);
+    assert_eq!(exec.get_dead_letter_retention(), 100);
+}
+
+/// (a) No stale entries: pruning removes nothing and leaves the queue intact.
+#[test]
+fn prune_removes_nothing_when_no_stale_entries() {
+    let (env, exec_id, _) = setup();
+    let token = sac(&env);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().with_mut(|l| l.sequence_number = 0);
+    let user = dead_letter_now(&env, &exec_id, &token);
+
+    // Retention is the default (large) window — nothing is stale yet.
+    let removed = exec.prune_dead_letter_queue(&None, &10);
+    assert_eq!(removed, 0);
+    assert_eq!(exec.get_dead_letter_trades(&user).len(), 1);
+}
+
+/// (b) A mix of fresh and stale entries: only the stale entry is removed.
+#[test]
+fn prune_removes_only_stale_entries() {
+    let (env, exec_id, _) = setup();
+    let token = sac(&env);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().with_mut(|l| l.sequence_number = 0);
+    let user_a = dead_letter_now(&env, &exec_id, &token); // dead-lettered at ledger 20
+
+    env.ledger().with_mut(|l| l.sequence_number = 35);
+    let user_b = dead_letter_now(&env, &exec_id, &token); // dead-lettered at ledger 55
+
+    exec.set_dead_letter_retention(&10);
+    env.ledger().with_mut(|l| l.sequence_number = 60);
+    // user_a: 60 - 20 = 40 >= 10 → stale. user_b: 60 - 55 = 5 < 10 → fresh.
+
+    let removed = exec.prune_dead_letter_queue(&None, &10);
+    assert_eq!(removed, 1);
+    assert_eq!(
+        exec.get_dead_letter_trades(&user_a).len(),
+        0,
+        "stale entry should be removed"
+    );
+    assert_eq!(
+        exec.get_dead_letter_trades(&user_b).len(),
+        1,
+        "fresh entry should remain"
+    );
+}
+
+/// (c) `max_entries` caps a single call to a partial prune when more entries
+/// are stale than the requested cap.
+#[test]
+fn prune_respects_max_entries_cap() {
+    let (env, exec_id, _) = setup();
+    let token = sac(&env);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().with_mut(|l| l.sequence_number = 0);
+    let user_a = dead_letter_now(&env, &exec_id, &token);
+
+    env.ledger().with_mut(|l| l.sequence_number = 25);
+    let user_b = dead_letter_now(&env, &exec_id, &token);
+
+    env.ledger().with_mut(|l| l.sequence_number = 50);
+    let user_c = dead_letter_now(&env, &exec_id, &token);
+
+    exec.set_dead_letter_retention(&5);
+    env.ledger().with_mut(|l| l.sequence_number = 200);
+    // All three are well past the 5-ledger retention window at this point.
+
+    let removed = exec.prune_dead_letter_queue(&None, &2);
+    assert_eq!(removed, 2, "only max_entries should be removed in one call");
+
+    let remaining = exec.get_dead_letter_trades(&user_a).len()
+        + exec.get_dead_letter_trades(&user_b).len()
+        + exec.get_dead_letter_trades(&user_c).len();
+    assert_eq!(remaining, 1, "one stale entry should remain uncapped");
+
+    // A second call sweeps the rest.
+    let removed_2 = exec.prune_dead_letter_queue(&None, &10);
+    assert_eq!(removed_2, 1);
+}
+
+/// Pruning scoped to a single `user` only inspects that user's dead-letter queue.
+#[test]
+fn prune_scoped_to_single_user() {
+    let (env, exec_id, _) = setup();
+    let token = sac(&env);
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().with_mut(|l| l.sequence_number = 0);
+    let user_a = dead_letter_now(&env, &exec_id, &token);
+    let user_b = dead_letter_now(&env, &exec_id, &token);
+
+    exec.set_dead_letter_retention(&5);
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+
+    let removed = exec.prune_dead_letter_queue(&Some(user_a.clone()), &10);
+    assert_eq!(removed, 1);
+    assert_eq!(exec.get_dead_letter_trades(&user_a).len(), 0);
+    assert_eq!(
+        exec.get_dead_letter_trades(&user_b).len(),
+        1,
+        "user_b's entry must be untouched by a user-scoped prune"
+    );
+}


### PR DESCRIPTION
Fixes #792

## Summary
Failed trades in the dead-letter queue previously required manual per-user cleanup via `discard_dead_lettered_trade`, so abandoned accounts' entries accumulated persistent-storage rent indefinitely.

## Changes
- `FailedTrade.dead_lettered_at_ledger` (already present) is now the basis for retention checks.
- Added `DeadLetterAllIds` (instance storage) — a global index of every dead-lettered trade ID across all users, enabling cross-user sweeps.
- Added `set_dead_letter_retention(ledgers: u32)` (admin) and `get_dead_letter_retention()`; default is `DEFAULT_DEAD_LETTER_RETENTION_LEDGERS` (~30 days at 5s/ledger).
- Added `prune_dead_letter_queue(user: Option<Address>, max_entries: u32) -> u32` (admin): scoped to one user when `Some`, global when `None`; removes entries whose age exceeds the retention window, capped at `max_entries` removals per call; returns the count removed.
- Emits `dead_letter_pruned` (`DeadLetterPruned { user, trade_id, reason }`) per removed entry.
- `requeue_dead_lettered_trade` / `discard_dead_lettered_trade` now also maintain the new global index via shared helpers (`remove_dead_letter_id`, `remove_dead_letter_index`).
- Unit tests in `src/tests/test_dead_letter_pruning.rs`: no stale entries removes nothing, mixed fresh/stale removes only stale, `max_entries` caps a single call to a partial prune, and user-scoped pruning is isolated from other users' queues.

## Note
Per repo convention, this PR is opened from a fork since this account doesn't have push access to the upstream repo.