### PR TITLE
Add treasury spend proposal execution expiry and reclamation

### DIFF
--- a/stellar-swipe/contracts/governance/src/errors.rs
+++ b/stellar-swipe/contracts/governance/src/errors.rs
@@ -76,4 +76,8 @@ impl GovernanceError {
     pub const ProposalAlreadyWithdrawn: GovernanceError = GovernanceError::ProposalNotActive;
     /// Decay rate is outside the valid range (MIN_DECAY_RATE..=MAX_DECAY_RATE).
     pub const InvalidDecayRate: GovernanceError = GovernanceError::InvalidGovernanceConfig;
+    /// A succeeded proposal's execution window (`execution_deadline`) has
+    /// passed — it can no longer be executed and must instead be reclaimed
+    /// via `reclaim_expired_proposal` (Issue #796).
+    pub const ProposalExpired: GovernanceError = GovernanceError::BudgetPeriodEnded;
 }

--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -60,10 +60,11 @@ pub use errors::GovernanceError;
 pub use proposals::{CategoryThreshold, GovernanceConfig, ProposalCategory};
 use proposals::{
     calculate_proposal_statistics, cancel_proposal, configure_governance, create_proposal,
-    default_governance_config, execute_proposal, finalize_proposal, get_all_proposals,
-    get_category_threshold, get_governance_config, get_proposal, set_category_thresholds,
-    withdraw_proposal, Proposal, ProposalStatistics, ProposalStatus, ProposalType, Vote,
-    VoteDelegation, VoteType as GovernanceVoteType,
+    default_governance_config, execute_proposal, finalize_proposal, get_active_proposals,
+    get_all_proposals, get_category_threshold, get_governance_config, get_proposal,
+    reclaim_expired_proposal, set_category_thresholds, withdraw_proposal, Proposal,
+    ProposalStatistics, ProposalStatus, ProposalType, Vote, VoteDelegation,
+    VoteType as GovernanceVoteType,
 };
 use quadratic_voting::{
     allocate_vote_credits, calculate_marginal_cost, cast_quadratic_vote, compare_voting_systems,
@@ -589,6 +590,38 @@ impl GovernanceContract {
     ) -> Result<ProposalStatus, GovernanceError> {
         require_initialized(&env)?;
         proposals::cancel_proposal(&env, proposal_id, canceller)
+    }
+
+    /// # Summary
+    /// List proposals still eligible for voting or execution — i.e. not
+    /// `Cancelled`/`Failed`/`Executed`/`Withdrawn`/`Expired`, and not past
+    /// their `execution_deadline` even if their stored status hasn't caught
+    /// up yet (Issue #796).
+    pub fn get_active_proposals(env: Env) -> Result<Vec<Proposal>, GovernanceError> {
+        require_initialized(&env)?;
+        Ok(proposals::get_active_proposals(&env))
+    }
+
+    /// # Summary
+    /// Reclaim a `Succeeded` treasury spend proposal that was never executed
+    /// before its `execution_deadline` elapsed. Callable by **any** address —
+    /// not admin-gated — so DAO members can free up stale spend
+    /// authorisations without waiting on an admin. Removes the proposal and
+    /// emits a `TreasuryProposalExpired` event.
+    ///
+    /// # Errors
+    /// - [`GovernanceError::NotInitialized`] — contract not initialized.
+    /// - [`GovernanceError::ProposalNotFound`] — `proposal_id` does not exist.
+    /// - [`GovernanceError::ProposalNotApproved`] — proposal never succeeded.
+    /// - [`GovernanceError::InvalidDuration`] — execution window hasn't closed yet.
+    pub fn reclaim_expired_proposal(
+        env: Env,
+        proposal_id: u64,
+        caller: Address,
+    ) -> Result<(), GovernanceError> {
+        require_initialized(&env)?;
+        require_not_paused(&env)?;
+        proposals::reclaim_expired_proposal(&env, proposal_id, caller)
     }
 
     /// # Summary

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -126,7 +126,20 @@ pub struct Proposal {
     /// Sum of floor(sqrt(p)) for all snapshotted holders at proposal creation.
     /// Used as the quadratic-adjusted total supply for quorum checks.
     pub quadratic_total_supply: i128,
+    // ── #796: Treasury spend proposal execution expiry ───────────────────────
+    /// Ledger timestamp after which a `Succeeded` proposal can no longer be
+    /// executed. Set at creation as `voting_ends + EXECUTION_WINDOW`. Prevents
+    /// approved-but-unexecuted spend authorisations from locking treasury
+    /// funds indefinitely — once past this deadline, `execute_proposal`
+    /// rejects with `GovernanceError::ProposalExpired` and any DAO member may
+    /// call `reclaim_expired_proposal` to clear the entry.
+    pub execution_deadline: u64,
 }
+
+/// Execution window after `voting_ends` during which a `Succeeded` proposal
+/// may still be executed (Issue #796). Mirrors the 7-day period used
+/// elsewhere in this module for the default voting period.
+pub const EXECUTION_WINDOW: u64 = 7 * 24 * 60 * 60;
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -315,6 +328,10 @@ pub fn create_proposal(
         0
     };
 
+    let voting_ends = now
+        .saturating_add(config.voting_delay)
+        .saturating_add(config.voting_period);
+
     let proposal = Proposal {
         id,
         proposer: proposer.clone(),
@@ -323,9 +340,7 @@ pub fn create_proposal(
         description,
         execution_payload,
         voting_starts: now.saturating_add(config.voting_delay),
-        voting_ends: now
-            .saturating_add(config.voting_delay)
-            .saturating_add(config.voting_period),
+        voting_ends,
         votes_for: 0,
         votes_against: 0,
         votes_abstain: 0,
@@ -337,6 +352,7 @@ pub fn create_proposal(
         category,
         use_quadratic_voting,
         quadratic_total_supply,
+        execution_deadline: voting_ends.saturating_add(EXECUTION_WINDOW),
     };
 
     state.proposals.set(id, proposal.clone());
@@ -543,8 +559,19 @@ pub fn execute_proposal(
     let ready = proposal
         .voting_ends
         .saturating_add(get_governance_config(env).execution_delay);
-    if env.ledger().timestamp() < ready {
+    let now = env.ledger().timestamp();
+    if now < ready {
         return Err(GovernanceError::InvalidDuration);
+    }
+
+    // ── #796: Reject execution once the proposal's execution window has
+    // closed. Approved-but-unexecuted proposals must be reclaimed instead of
+    // executed once expired, so treasury funds don't stay conceptually locked
+    // forever behind a stale authorisation.
+    if now > proposal.execution_deadline {
+        proposal.status = ProposalStatus::Expired;
+        put_proposal(env, &proposal)?;
+        return Err(GovernanceError::ProposalExpired);
     }
 
     execute_proposal_action(env, &proposal)?;
@@ -834,6 +861,95 @@ pub fn get_all_proposals(env: &Env) -> Vec<Proposal> {
         i += 1;
     }
     out
+}
+
+// ── #796: Treasury spend proposal execution expiry ───────────────────────────
+
+/// Reclaim a `Succeeded` proposal whose execution window has closed without
+/// ever being executed. Callable by **any** address (not admin-only) — any
+/// DAO member can clear a stale authorisation once it has expired. Removes
+/// the proposal entry entirely and emits a `TreasuryProposalExpired` event.
+///
+/// # Errors
+/// - [`GovernanceError::ProposalNotFound`] — `proposal_id` does not exist.
+/// - [`GovernanceError::ProposalNotApproved`] — proposal never reached
+///   `Succeeded` status (nothing to reclaim).
+/// - [`GovernanceError::InvalidDuration`] — the execution window has not
+///   closed yet; the proposal can still be executed normally.
+pub fn reclaim_expired_proposal(
+    env: &Env,
+    proposal_id: u64,
+    caller: Address,
+) -> Result<(), GovernanceError> {
+    caller.require_auth();
+
+    let mut state = get_proposals_state(env);
+    let proposal = state
+        .proposals
+        .get(proposal_id)
+        .ok_or(GovernanceError::ProposalNotFound)?;
+
+    // A proposal is reclaimable once it succeeded but was never executed —
+    // whether its status is still `Succeeded` or a prior `execute_proposal`
+    // call already flipped it to `Expired` after the deadline passed.
+    if proposal.status != ProposalStatus::Succeeded && proposal.status != ProposalStatus::Expired {
+        return Err(GovernanceError::ProposalNotApproved);
+    }
+    if env.ledger().timestamp() <= proposal.execution_deadline {
+        return Err(GovernanceError::InvalidDuration);
+    }
+
+    state.proposals.remove(proposal_id);
+    remove_proposal_id(&mut state.proposal_ids, proposal_id);
+    put_proposals_state(env, &state);
+
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("treasury"), symbol_short!("propexp")),
+        (
+            proposal_id,
+            proposal.proposer,
+            caller,
+            env.ledger().timestamp(),
+        ),
+    );
+
+    Ok(())
+}
+
+/// Proposals that are still eligible for voting or execution: `Pending`,
+/// `Active`, or `Succeeded` (awaiting execution) *and* not past their
+/// `execution_deadline`. Proposals whose execution window has closed are
+/// excluded even if their on-chain status hasn't been transitioned to
+/// `Expired` yet (Issue #796).
+pub fn get_active_proposals(env: &Env) -> Vec<Proposal> {
+    let now = env.ledger().timestamp();
+    let all = get_all_proposals(env);
+    let mut out = Vec::new(env);
+    let mut i = 0;
+    while i < all.len() {
+        let p = all.get(i).unwrap();
+        let active_status = matches!(
+            p.status,
+            ProposalStatus::Pending | ProposalStatus::Active | ProposalStatus::Succeeded
+        );
+        if active_status && now <= p.execution_deadline {
+            out.push_back(p);
+        }
+        i += 1;
+    }
+    out
+}
+
+fn remove_proposal_id(ids: &mut Vec<u64>, target: u64) {
+    let mut i = 0;
+    while i < ids.len() {
+        if ids.get(i).unwrap() == target {
+            ids.remove(i);
+            return;
+        }
+        i += 1;
+    }
 }
 
 pub fn delegate_voting_power(

--- a/stellar-swipe/contracts/governance/src/test.rs
+++ b/stellar-swipe/contracts/governance/src/test.rs
@@ -5,7 +5,7 @@ use crate::distribution::{
     TEAM_VESTING_DURATION, YEAR_SECONDS,
 };
 use crate::proposals::{
-    GovernanceConfig, ProposalStatus, ProposalType, VoteType as GovernanceVoteType,
+    GovernanceConfig, ProposalCategory, ProposalStatus, ProposalType, VoteType as GovernanceVoteType,
 };
 use crate::{
     Authority, CommitteeAction, CommitteeElectionStatus, CrossCommitteeStatus, DecisionStatus,
@@ -2795,9 +2795,151 @@ fn conviction_score_bounded_across_valid_decay_rates() {
         // After decay, it should be less than or equal to the base (no decay case)
         // The maximum possible conviction without decay would be tokens * sqrt(days) / 1000
         let max_possible = tokens * (30i128).checked_mul(1).unwrap_or(1) / 1000;
-        assert!(conviction <= max_possible + 100, 
-            "Conviction {} exceeds max possible {} for decay_rate={}", 
+        assert!(conviction <= max_possible + 100,
+            "Conviction {} exceeds max possible {} for decay_rate={}",
             conviction, max_possible, decay_rate);
     }
+}
+
+// ── Issue #796: Treasury spend proposal execution expiry ──────────────────────
+
+/// Shared setup for the execution-expiry tests below: initializes the
+/// contract, configures a non-zero `execution_delay` (so `finalize_proposal`
+/// does not auto-execute the proposal), funds the treasury, stakes voting
+/// power for two holders, creates a `TreasurySpend` proposal, votes it to
+/// `Succeeded`, and returns the proposal id plus the recipient/asset used.
+fn setup_succeeded_treasury_spend_proposal(
+    env: &Env,
+    client: &GovernanceContractClient<'_>,
+    admin: &Address,
+    recipients: &DistributionRecipients,
+) -> (u64, Address, Asset) {
+    let cfg = GovernanceConfig {
+        min_proposal_threshold: 1_000,
+        voting_period: 7 * 86_400,
+        voting_delay: 60,
+        quorum_threshold: 1_000,
+        approval_threshold: 5_000,
+        execution_delay: 60,
+        discussion_duration: 0,
+    };
+    client.configure_governance(admin, &cfg);
+
+    client.stake(&recipients.community_rewards, &120_000_000i128);
+    client.stake(&recipients.public_sale, &40_000_000i128);
+
+    let spend_asset = asset(env, "USDC");
+    client.set_treasury_asset(admin, &spend_asset, &10_000i128);
+    let payout_recipient = Address::generate(env);
+
+    let proposal_id = client.create_proposal(
+        &recipients.community_rewards,
+        &ProposalType::TreasurySpend(
+            payout_recipient.clone(),
+            500i128,
+            spend_asset.clone(),
+            String::from_str(env, "payout"),
+        ),
+        &String::from_str(env, "Fund payout"),
+        &String::from_str(env, "treasury spend"),
+        &Bytes::new(env),
+        &ProposalCategory::TreasuryTransfer,
+        &false,
+    );
+
+    env.ledger().set_timestamp(70);
+    client.cast_vote(
+        &proposal_id,
+        &recipients.community_rewards,
+        &GovernanceVoteType::For,
+    );
+    client.cast_vote(
+        &proposal_id,
+        &recipients.public_sale,
+        &GovernanceVoteType::For,
+    );
+
+    // voting_ends = 60 (delay) + 7 * 86_400 (period) = 604_860.
+    env.ledger().set_timestamp(8 * 86_400);
+    assert_eq!(
+        client.finalize_proposal(&proposal_id),
+        ProposalStatus::Succeeded
+    );
+
+    (proposal_id, payout_recipient, spend_asset)
+}
+
+#[test]
+fn treasury_spend_proposal_executes_within_execution_window() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    let (proposal_id, payout_recipient, spend_asset) =
+        setup_succeeded_treasury_spend_proposal(&env, &client, &admin, &recipients);
+
+    // Still well inside the 7-day execution window (voting_ends + 7 days).
+    let status = client.execute_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(status, ProposalStatus::Executed);
+
+    let treasury = client.treasury();
+    assert_eq!(treasury.assets.get(spend_asset).unwrap(), 9_500);
+    assert_eq!(client.balance(&payout_recipient), 500);
+}
+
+#[test]
+fn treasury_spend_proposal_execution_past_deadline_is_rejected() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    let (proposal_id, _payout_recipient, _spend_asset) =
+        setup_succeeded_treasury_spend_proposal(&env, &client, &admin, &recipients);
+
+    // execution_deadline = voting_ends (604_860) + EXECUTION_WINDOW (7 days) = 1_209_660.
+    // Jump well past it.
+    env.ledger().set_timestamp(1_209_661);
+
+    let result = client.try_execute_proposal(&proposal_id, &recipients.community_rewards);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalExpired)));
+
+    let proposal = client.proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Expired);
+}
+
+#[test]
+fn reclaim_expired_proposal_removes_entry_and_is_callable_by_anyone() {
+    let (env, contract_id, admin, recipients) = setup();
+    let client = client(&env, &contract_id);
+    initialize(&client, &env, &admin, &recipients);
+
+    let (proposal_id, _payout_recipient, _spend_asset) =
+        setup_succeeded_treasury_spend_proposal(&env, &client, &admin, &recipients);
+
+    // Too early: execution window hasn't closed yet.
+    let too_early = client.try_reclaim_expired_proposal(&proposal_id, &recipients.public_sale);
+    assert_eq!(too_early, Err(Ok(GovernanceError::InvalidDuration)));
+
+    env.ledger().set_timestamp(1_209_661);
+
+    // Any address (not just admin) may reclaim once the deadline has passed.
+    let random_caller = Address::generate(&env);
+    client.reclaim_expired_proposal(&proposal_id, &random_caller);
+
+    // The proposal entry is gone entirely.
+    let missing = client.try_proposal(&proposal_id);
+    assert_eq!(missing, Err(Ok(GovernanceError::ProposalNotFound)));
+
+    // It no longer shows up in the active-proposals listing either.
+    let active = client.get_active_proposals();
+    let mut i = 0;
+    let mut found = false;
+    while i < active.len() {
+        if active.get(i).unwrap().id == proposal_id {
+            found = true;
+        }
+        i += 1;
+    }
+    assert!(!found);
 }
 


### PR DESCRIPTION
Fixes #796

## Summary

Governance treasury spend proposals (`ProposalType::TreasurySpend`) could be approved by the DAO but never executed, holding a conceptual lock on treasury funds indefinitely.

This PR adapts the issue's proposal to this repo's actual data model: there is no separate `SpendProposal` struct — treasury spends are one variant of the single `Proposal` type in `governance/src/proposals.rs`, executed via the shared `execute_proposal` entry point. The fix is applied at that level so it covers `TreasurySpend` proposals (and, as a side effect, any other proposal type, which is a reasonable generalization of the same governance hygiene principle).

## Changes

- `Proposal` gains an `execution_deadline: u64` field, set at creation as `voting_ends + EXECUTION_WINDOW` (7 days, `proposals::EXECUTION_WINDOW`).
- `execute_proposal` now rejects execution once `now > execution_deadline`, returning `GovernanceError::ProposalExpired` (new alias added in `errors.rs`, mapped to `BudgetPeriodEnded` per this crate's "≤ 50 variants" constraint) and flips the proposal's status to the existing `ProposalStatus::Expired`.
- New `reclaim_expired_proposal(proposal_id)`: callable by **any** address (not admin-gated), removes a `Succeeded`/`Expired` proposal past its deadline from storage and emits a `(treasury, propexp)` event carrying the proposal id, original proposer, caller, and timestamp.
- New `get_active_proposals()`: returns proposals still `Pending`/`Active`/`Succeeded` and not yet past their `execution_deadline`, so expired-but-not-yet-reclaimed entries are filtered out of the "active" view.
- Unit tests in `governance/src/test.rs` (via the contract client, matching this file's existing integration-test style) covering: execution within the window succeeds, execution past the deadline is rejected with `ProposalExpired`, and `reclaim_expired_proposal` removes the entry and is usable by a non-admin caller.

## Notes for reviewers

- Per the task instructions for this issue, I did not run `cargo build`/`cargo test` before pushing.
- `governance/src/test.rs` already calls `create_proposal` with 5 arguments in several pre-existing tests, while the current `create_proposal` entry point takes 7 (`category`, `use_quadratic_voting` were added later). That mismatch predates this change; the new tests added here use the correct current 7-argument signature.