### PR TITLE
trade_executor: audit nonce replay protection, add TTL + purge_expired_nonces

### DIFF
--- a/stellar-swipe/contracts/common/src/lib.rs
+++ b/stellar-swipe/contracts/common/src/lib.rs
@@ -75,7 +75,10 @@ pub use rate_limit::{
     check_rate_limit, record_action, set_config as set_rate_limit_config, ActionType,
     RateLimitConfig, RateLimitError,
 };
-pub use replay_protection::{current_nonce, verify_and_commit, ReplayError};
+pub use replay_protection::{
+    current_nonce, purge_expired_nonces, verify_and_commit, PendingNonceRecord, ReplayError,
+    ReplayKey,
+};
 pub use retry_backoff::{
     has_remaining_attempts, next_retry_state, should_retry, RetryConfig, RetryState,
 };

--- a/stellar-swipe/contracts/common/src/replay_protection.rs
+++ b/stellar-swipe/contracts/common/src/replay_protection.rs
@@ -1,21 +1,41 @@
 //! Replay protection: sequential nonces + tx-hash deduplication with 1-hour TTL.
 //!
 //! Storage layout:
-//!   UserNonce(Address)          -> u64   (persistent) — current committed nonce
-//!   TxHash([u8;32])             -> u64   (persistent) — ledger timestamp of execution
+//!   UserNonce(Address)          -> u64   (persistent, per-entry TTL) — current committed nonce
+//!   TxHash([u8;32])             -> u64   (persistent, per-entry TTL) — ledger timestamp of execution
+//!   PendingQueue                -> Vec<PendingNonceRecord> (persistent) — FIFO index of
+//!                                  committed tx hashes so `purge_expired_nonces` can find
+//!                                  and evict expired entries without key enumeration.
 //!
 //! Usage per transaction:
 //!   1. `verify_and_commit(env, user, nonce, tx_hash, expiry_ts)` — call once per action.
-//!      Returns `Err(ReplayError)` on any violation; on success the nonce is incremented
-//!      and the hash is stored.
+//!      Returns `Err(ReplayError)` on any violation; on success the nonce is incremented,
+//!      the hash is stored, both entries' TTLs are extended to cover `expiry_ts`, and a
+//!      `PendingNonceRecord` is appended to the purge queue.
+//!   2. `purge_expired_nonces(env, max)` — keeper/admin maintenance call. Scans up to
+//!      `max` entries from the front of the purge queue and removes the ones whose
+//!      `expiry_ts` has passed, reclaiming persistent storage without breaking the
+//!      replay guarantee (only entries already past their usable window are removed).
 
 #![allow(dead_code)]
 
-use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Symbol, Vec};
+
+use crate::constants::LEDGER_CLOSE_TIME_SECONDS;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const TX_HASH_TTL_SECS: u64 = 3_600; // 1 hour
+
+/// Floor applied to per-entry TTL extensions so a `expiry_ts` very close to `now`
+/// doesn't produce a near-zero TTL that gets evicted before the tx can even settle.
+const MIN_TTL_LEDGERS: u32 = 17_280; // ~24 hours at 5s/ledger, matches shared::auth::NONCE_TTL_LEDGERS
+
+/// Convert a duration in seconds to an approximate ledger count.
+fn seconds_to_ledgers(seconds: u64) -> u32 {
+    let ledgers = seconds / (LEDGER_CLOSE_TIME_SECONDS as u64);
+    core::cmp::max(ledgers.min(u32::MAX as u64) as u32, MIN_TTL_LEDGERS)
+}
 
 // ── Error type ────────────────────────────────────────────────────────────────
 
@@ -36,6 +56,19 @@ pub enum ReplayError {
 pub enum ReplayKey {
     UserNonce(Address),
     TxHash(Bytes),
+    /// FIFO queue of committed tx hashes, used by [`purge_expired_nonces`] to find
+    /// expired entries without relying on persistent-storage key enumeration
+    /// (which Soroban does not support).
+    PendingQueue,
+}
+
+/// One entry in the [`ReplayKey::PendingQueue`] index.
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingNonceRecord {
+    pub user: Address,
+    pub tx_hash: Bytes,
+    pub expiry_ts: u64,
 }
 
 // ── Core API ──────────────────────────────────────────────────────────────────
@@ -89,12 +122,76 @@ pub fn verify_and_commit(
     }
 
     // 4. Commit
-    env.storage()
-        .persistent()
-        .set(&ReplayKey::UserNonce(user.clone()), &nonce);
+    let nonce_key = ReplayKey::UserNonce(user.clone());
+    env.storage().persistent().set(&nonce_key, &nonce);
     env.storage().persistent().set(&hash_key, &now);
 
+    // 5. Extend TTL on both persistent entries to cover the trade's expiry window
+    // (Issue: replay attack prevention audit — nonces must not be evicted while
+    // still within their usable window).
+    let ttl_ledgers = seconds_to_ledgers(expiry_ts.saturating_sub(now));
+    env.storage()
+        .persistent()
+        .extend_ttl(&nonce_key, ttl_ledgers, ttl_ledgers);
+    env.storage()
+        .persistent()
+        .extend_ttl(&hash_key, ttl_ledgers, ttl_ledgers);
+
+    // 6. Index this hash in the purge queue so `purge_expired_nonces` can reclaim it
+    // once `expiry_ts` has passed.
+    let queue_key = ReplayKey::PendingQueue;
+    let mut queue: Vec<PendingNonceRecord> = env
+        .storage()
+        .persistent()
+        .get(&queue_key)
+        .unwrap_or_else(|| Vec::new(env));
+    queue.push_back(PendingNonceRecord {
+        user: user.clone(),
+        tx_hash,
+        expiry_ts,
+    });
+    env.storage().persistent().set(&queue_key, &queue);
+    env.storage()
+        .persistent()
+        .extend_ttl(&queue_key, ttl_ledgers, ttl_ledgers);
+
     Ok(())
+}
+
+/// Purge tx-hash entries whose `expiry_ts` has passed, scanning at most `max` entries
+/// from the front of the purge queue.
+///
+/// This only removes entries that are objectively past their usable window — it
+/// never touches an entry that could still be legitimately referenced, so it cannot
+/// weaken the replay guarantee. Entries within the scanned window that are not yet
+/// expired are kept in the queue for a future purge pass.
+///
+/// Returns the number of entries removed.
+pub fn purge_expired_nonces(env: &Env, max: u32) -> u32 {
+    let now = env.ledger().timestamp();
+    let queue_key = ReplayKey::PendingQueue;
+    let queue: Vec<PendingNonceRecord> = env
+        .storage()
+        .persistent()
+        .get(&queue_key)
+        .unwrap_or_else(|| Vec::new(env));
+
+    let mut remaining: Vec<PendingNonceRecord> = Vec::new(env);
+    let mut purged: u32 = 0;
+
+    for (i, record) in queue.iter().enumerate() {
+        if (i as u32) < max && record.expiry_ts < now {
+            let hash_key = ReplayKey::TxHash(record.tx_hash.clone());
+            env.storage().persistent().remove(&hash_key);
+            emit_purged(env, &record.user, &record.tx_hash);
+            purged = purged.saturating_add(1);
+        } else {
+            remaining.push_back(record.clone());
+        }
+    }
+
+    env.storage().persistent().set(&queue_key, &remaining);
+    purged
 }
 
 // ── Event ─────────────────────────────────────────────────────────────────────
@@ -103,6 +200,12 @@ fn emit_replay(env: &Env, user: &Address, tx_hash: &Bytes, reason: soroban_sdk::
     let topics = (Symbol::new(env, "replay_detected"),);
     env.events()
         .publish(topics, (user.clone(), reason, tx_hash.clone()));
+}
+
+fn emit_purged(env: &Env, user: &Address, tx_hash: &Bytes) {
+    let topics = (Symbol::new(env, "nonce_purged"),);
+    env.events()
+        .publish(topics, (user.clone(), tx_hash.clone()));
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/stellar-swipe/contracts/trade_executor/src/errors.rs
+++ b/stellar-swipe/contracts/trade_executor/src/errors.rs
@@ -71,6 +71,14 @@ pub enum ContractError {
     ConfirmationDepthNotReached = 30,
     /// The user already holds the maximum number of concurrent open positions.
     TooManyOpenPositions = 31,
+    /// The submitted nonce has already been committed (replay of a previously
+    /// executed or currently in-flight trade). See the replay-protection audit
+    /// (Issue: nonce replay attack prevention).
+    NonceAlreadyUsed = 32,
+    /// The trade's `expiry_ts` has passed; the replay-protection window for this
+    /// nonce/tx_hash has closed. See the replay-protection audit
+    /// (Issue: nonce replay attack prevention).
+    TradeExpired = 33,
 }
 
 /// Populated when [`ContractError::InsufficientLiquidity`] is returned.

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -24,7 +24,9 @@ use soroban_sdk::{
     Val, Vec,
 };
 
-use stellar_swipe_common::replay_protection::verify_and_commit;
+use stellar_swipe_common::replay_protection::{
+    purge_expired_nonces as replay_purge_expired_nonces, verify_and_commit, ReplayError,
+};
 use triggers::{ORACLE_KEY, PORTFOLIO_KEY};
 use wire::TRADE_TIMEOUT_LEDGERS;
 
@@ -294,6 +296,17 @@ fn effective_estimated_fee(env: &Env) -> i128 {
 fn require_admin(env: &Env) -> Result<Address, ContractError> {
     oracle::require_admin(env)
 }
+
+/// Map a low-level [`ReplayError`] onto the contract's public error surface so
+/// callers can distinguish "already used" from "expired" (Issue: nonce replay
+/// attack prevention audit).
+fn map_replay_error(err: ReplayError) -> ContractError {
+    match err {
+        ReplayError::Expired => ContractError::TradeExpired,
+        ReplayError::InvalidNonce | ReplayError::DuplicateTx => ContractError::NonceAlreadyUsed,
+    }
+}
+
 fn get_confirmation_depth(env: &Env) -> u32 {
     env.storage()
         .instance()
@@ -1229,7 +1242,7 @@ impl TradeExecutorContract {
         expiry_ts: u64,
     ) -> Result<(), ContractError> {
         verify_and_commit(&env, &user, nonce, tx_hash, expiry_ts)
-            .map_err(|_| ContractError::ReplayDetected)?;
+            .map_err(map_replay_error)?;
         feature_flags::require_feature_enabled(&env, feature_flags::FEAT_COPY_TRADE)?;
         match order_type {
             OrderType::Market => {
@@ -1276,6 +1289,18 @@ impl TradeExecutorContract {
                 Ok(())
             }
         }
+    }
+
+    /// Admin/keeper maintenance call: reclaim persistent storage held by
+    /// replay-protection tx-hash entries that are past their `expiry_ts`.
+    ///
+    /// Scans at most `max` entries from the front of the internal purge queue and
+    /// removes the ones that are objectively expired, so it can never break the
+    /// replay guarantee for a still-valid nonce/tx_hash. Returns the number of
+    /// entries removed. See the nonce replay attack prevention audit.
+    pub fn purge_expired_nonces(env: Env, max: u32) -> Result<u32, ContractError> {
+        require_admin(&env)?;
+        Ok(replay_purge_expired_nonces(&env, max))
     }
 
     // ── SDEX router configuration ─────────────────────────────────────────────
@@ -1719,7 +1744,7 @@ impl TradeExecutorContract {
         replay: ReplayParams,
     ) -> Result<(), ContractError> {
         verify_and_commit(&env, &user, replay.nonce, replay.tx_hash, replay.expiry_ts)
-            .map_err(|_| ContractError::ReplayDetected)?;
+            .map_err(map_replay_error)?;
         caller.require_auth();
         if caller != user {
             return Err(ContractError::Unauthorized);

--- a/stellar-swipe/contracts/trade_executor/src/test.rs
+++ b/stellar-swipe/contracts/trade_executor/src/test.rs
@@ -1186,7 +1186,7 @@ fn cancel_copy_trade_replay_nonce_rejected() {
             },
         )
     });
-    assert_eq!(err, Err(ContractError::ReplayDetected));
+    assert_eq!(err, Err(ContractError::NonceAlreadyUsed));
 }
 
 // ── Event format tests ────────────────────────────────────────────────────────

--- a/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/mod.rs
@@ -5,5 +5,6 @@ pub mod test_dead_letter;
 pub mod test_feature_flags;
 pub mod test_grace_period;
 pub mod test_market_simulation;
+pub mod test_nonce_replay_audit;
 pub mod test_oracle_staleness;
 pub mod test_storage_rent_benchmark;

--- a/stellar-swipe/contracts/trade_executor/src/tests/test_nonce_replay_audit.rs
+++ b/stellar-swipe/contracts/trade_executor/src/tests/test_nonce_replay_audit.rs
@@ -1,0 +1,279 @@
+#![cfg(test)]
+//! Integration tests for the nonce replay-protection audit on `execute_copy_trade`
+//! (Issue: replay attack prevention audit for execute_copy_trade nonce handling).
+//!
+//! Covers the three scenarios from the audit's acceptance criteria:
+//! (a) the same nonce submitted twice in the same ledger is rejected with
+//!     `ContractError::NonceAlreadyUsed`,
+//! (b) a nonce submitted after `expiry_ts` is rejected with
+//!     `ContractError::TradeExpired`,
+//! (c) a committed nonce cannot be replayed across a simulated contract
+//!     upgrade / storage migration (ledger sequence jump), since nonces live
+//!     in persistent storage rather than instance/temporary storage.
+//!
+//! Also covers `purge_expired_nonces`, the admin/keeper maintenance entrypoint
+//! that reclaims persistent storage for expired replay-protection entries.
+
+use crate::{errors::ContractError, OrderType, TradeExecutorContract, TradeExecutorContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::StellarAssetClient,
+    Address, Bytes, Env,
+};
+
+// ── Mock UserPortfolio (mirrors `crate::test`'s fixture; kept self-contained
+// so this file has no dependency on the private `test` module) ────────────────
+
+#[soroban_sdk::contract]
+pub struct MockPortfolio;
+
+#[soroban_sdk::contracttype]
+#[derive(Clone)]
+enum PortfolioKey {
+    Count(Address),
+}
+
+#[soroban_sdk::contractimpl]
+impl MockPortfolio {
+    pub fn validate_and_record(env: Env, user: Address, max_positions: u32) -> u32 {
+        let key = PortfolioKey::Count(user.clone());
+        let count: u32 = env.storage().instance().get(&key).unwrap_or(0);
+        if count >= max_positions {
+            panic!("position limit reached");
+        }
+        let new_count = count + 1;
+        env.storage().instance().set(&key, &new_count);
+        new_count
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const TRADE_AMOUNT: i128 = 1_000_000;
+
+fn sac(env: &Env) -> Address {
+    let issuer = Address::generate(env);
+    env.register_stellar_asset_contract_v2(issuer).address()
+}
+
+fn test_tx_hash(env: &Env, seed: u8) -> Bytes {
+    let mut arr = [0u8; 32];
+    arr[0] = seed;
+    arr[31] = seed;
+    Bytes::from_array(env, &arr)
+}
+
+fn far_future(env: &Env) -> u64 {
+    env.ledger().timestamp() + 86_400 * 365
+}
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token = sac(&env);
+    let portfolio_id = env.register(MockPortfolio, ());
+    let exec_id = env.register(TradeExecutorContract, ());
+
+    StellarAssetClient::new(&env, &token).mint(&user, &(TRADE_AMOUNT * 100));
+
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+    exec.initialize(&admin);
+    exec.set_user_portfolio(&portfolio_id);
+
+    (env, exec_id, user, token)
+}
+
+// ── (a) Same nonce, same ledger ────────────────────────────────────────────────
+
+#[test]
+fn same_nonce_resubmitted_same_ledger_is_rejected() {
+    let (env, exec_id, user, token) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    exec.execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &far_future(&env),
+    );
+
+    // Same nonce, same ledger, different tx_hash — still rejected because the
+    // nonce counter has already advanced past 1.
+    let err = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 2),
+        &far_future(&env),
+    );
+    assert_eq!(err, Err(Ok(ContractError::NonceAlreadyUsed)));
+}
+
+// ── (b) Nonce submitted after expiry ───────────────────────────────────────────
+
+#[test]
+fn nonce_submitted_after_expiry_is_rejected() {
+    let (env, exec_id, user, token) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().set_timestamp(1_000);
+
+    // expiry_ts (999) is already in the past relative to `now` (1_000).
+    let err = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &999u64,
+    );
+    assert_eq!(err, Err(Ok(ContractError::TradeExpired)));
+}
+
+// ── (c) Nonce state survives a simulated contract upgrade ─────────────────────
+
+#[test]
+fn nonce_state_survives_simulated_upgrade() {
+    let (env, exec_id, user, token) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    exec.execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &far_future(&env),
+    );
+
+    // Simulate a contract upgrade: the ledger sequence advances substantially
+    // (as it would across the deploy of a new wasm), but persistent storage —
+    // and therefore the committed nonce — is untouched by an upgrade, unlike
+    // instance/temporary storage which can be evicted or reset.
+    env.ledger().with_mut(|l| {
+        l.sequence_number += 1_000;
+        l.timestamp += 5_000;
+    });
+
+    // Replaying nonce 1 post-upgrade must still be rejected.
+    let err = exec.try_execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 3),
+        &far_future(&env),
+    );
+    assert_eq!(err, Err(Ok(ContractError::NonceAlreadyUsed)));
+
+    // A fresh, correctly-sequenced nonce still succeeds post-upgrade.
+    exec.execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &2u64,
+        &test_tx_hash(&env, 4),
+        &far_future(&env),
+    );
+}
+
+// ── purge_expired_nonces ────────────────────────────────────────────────────
+
+#[test]
+fn purge_expired_nonces_removes_only_expired_entries() {
+    let (env, exec_id, user, token) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().set_timestamp(1_000);
+
+    // Nonce 1: expires soon.
+    exec.execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &1u64,
+        &test_tx_hash(&env, 1),
+        &2_000u64,
+    );
+
+    // Nonce 2: expires far in the future.
+    exec.execute_copy_trade(
+        &user,
+        &token,
+        &TRADE_AMOUNT,
+        &None,
+        &OrderType::Market,
+        &None,
+        &2u64,
+        &test_tx_hash(&env, 2),
+        &far_future(&env),
+    );
+
+    // Advance past nonce 1's expiry but not nonce 2's.
+    env.ledger().set_timestamp(2_001);
+
+    let purged = exec.purge_expired_nonces(&10u32);
+    assert_eq!(purged, 1, "only the expired entry should be purged");
+
+    // Nothing left to purge on a second pass.
+    assert_eq!(exec.purge_expired_nonces(&10u32), 0);
+}
+
+#[test]
+fn purge_expired_nonces_respects_max_bound() {
+    let (env, exec_id, user, token) = setup();
+    let exec = TradeExecutorContractClient::new(&env, &exec_id);
+
+    env.ledger().set_timestamp(1_000);
+
+    for i in 1..=3u64 {
+        exec.execute_copy_trade(
+            &user,
+            &token,
+            &TRADE_AMOUNT,
+            &None,
+            &OrderType::Market,
+            &None,
+            &i,
+            &test_tx_hash(&env, i as u8),
+            &2_000u64,
+        );
+    }
+
+    env.ledger().set_timestamp(2_001);
+
+    // Only scan the first entry.
+    let purged = exec.purge_expired_nonces(&1u32);
+    assert_eq!(purged, 1);
+
+    // The remaining two are cleaned up on a subsequent call.
+    let purged_rest = exec.purge_expired_nonces(&10u32);
+    assert_eq!(purged_rest, 2);
+}


### PR DESCRIPTION
Fixes #788

## Summary

Audits `execute_copy_trade`'s replay-protection storage (`common::replay_protection::verify_and_commit`). The nonce and tx-hash dedup entries were already in `persistent` storage (not `instance`/`temporary`), but had no explicit per-entry TTL and no cleanup path once a nonce's window expired.

## Changes

- `extend_ttl` is now called on the `UserNonce`/`TxHash` persistent entries on every successful commit, sized to `expiry_ts - now` (with a floor so a near-term `expiry_ts` can't produce a near-zero TTL that evicts before the tx settles).
- Added a FIFO purge index (`ReplayKey::PendingQueue`) of committed tx hashes — Soroban persistent storage has no key enumeration, so this is required to find expired entries.
- Added `purge_expired_nonces(max: u32) -> u32`, an admin-callable entrypoint on `TradeExecutorContract` that scans up to `max` queue entries and removes ones past their `expiry_ts`, returning the count removed. It only ever removes objectively-expired entries, so it cannot weaken the replay guarantee.
- Added `ContractError::NonceAlreadyUsed` and `ContractError::TradeExpired`, and mapped `execute_copy_trade` / `cancel_copy_trade`'s replay-check failures onto them (previously both collapsed into the generic `ReplayDetected`).
- Updated the one existing test that asserted the old generic error to expect `NonceAlreadyUsed`.
- New integration tests in `trade_executor/src/tests/test_nonce_replay_audit.rs`:
  - same nonce resubmitted in the same ledger → `NonceAlreadyUsed`
  - nonce submitted after `expiry_ts` → `TradeExpired`
  - nonce persistence across a simulated contract upgrade (ledger sequence jump)
  - `purge_expired_nonces` removes only expired entries and respects `max`

## Acceptance criteria

- [x] Nonces stored in persistent storage with per-entry TTL
- [x] Re-submitting a used nonce before expiry → `Error::NonceAlreadyUsed`
- [x] Submitting a nonce after `expiry_ts` → `Error::TradeExpired`
- [x] `purge_expired_nonces` exists and is admin/keeper callable
- [x] Integration tests cover all three scenarios

Per repo owner's request, this PR was written without running `cargo test`/`cargo build` locally — please run CI before merging.