### PR TITLE
fix(governance): harden quadratic voting isqrt against overflow

### DIFF
--- a/stellar-swipe/Cargo.lock
+++ b/stellar-swipe/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
 name = "governance"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "shared",
  "soroban-sdk",
  "stellar_swipe_common",

--- a/stellar-swipe/contracts/governance/Cargo.toml
+++ b/stellar-swipe/contracts/governance/Cargo.toml
@@ -15,6 +15,7 @@ shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { version = "1", default-features = false, features = ["std"] }
 
 [lints]
 workspace = true

--- a/stellar-swipe/contracts/governance/src/conviction_voting.rs
+++ b/stellar-swipe/contracts/governance/src/conviction_voting.rs
@@ -2,6 +2,7 @@ use core::cmp::max;
 
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, String, Vec};
 
+use crate::proposals::isqrt;
 use crate::{checked_mul, GovernanceError, StorageKey};
 
 const PRECISION: i128 = 10_000;
@@ -618,7 +619,7 @@ pub fn calculate_conviction(
         return 0;
     }
 
-    let sqrt_days = integer_sqrt(days_elapsed as i128);
+    let sqrt_days = isqrt(days_elapsed as i128);
     let mut conviction = tokens.saturating_mul(sqrt_days) / 1000;
 
     // ── Apply exponential decay based on decay_rate_bps ──────────────────
@@ -672,19 +673,6 @@ fn calculate_conviction_threshold(
     let threshold =
         checked_mul(ratio_squared, total_conviction)?.saturating_mul(alpha) / (PRECISION * 100);
     Ok(max(1000, threshold))
-}
-
-fn integer_sqrt(n: i128) -> i128 {
-    if n <= 0 {
-        return 0;
-    }
-    let mut x = n;
-    let mut y = (x + 1) / 2;
-    while y < x {
-        x = y;
-        y = (x + n / x) / 2;
-    }
-    x
 }
 
 fn update_vote_conviction(env: &Env, vote: &mut ConvictionVote) -> Result<(), GovernanceError> {

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -8,14 +8,30 @@ use crate::{
 };
 
 // ── #692: Integer square root (Newton's method, no floating-point) ───────────
+//
+// #837: the previous version seeded Newton's method with `(x + 1) / 2`. When
+// `x == i128::MAX` (a whale's token balance), `x + 1` overflows before the
+// division ever runs — panicking in debug builds and wrapping to a bogus,
+// tiny voting weight in release builds. Widening to `u128` and seeding with
+// `x / 2 + (x & 1)` (an overflow-free way to compute `ceil(x / 2)`) keeps
+// every intermediate step comfortably inside range, including at
+// `u128::MAX`, which is more headroom than an `i128` balance can ever need.
 
-/// Compute floor(sqrt(n)) using integer arithmetic only.
+/// Compute floor(sqrt(n)) using integer arithmetic only. Returns 0 for n <= 0.
 pub fn isqrt(n: i128) -> i128 {
     if n <= 0 {
         return 0;
     }
+    isqrt_u128(n as u128) as i128
+}
+
+/// Overflow-safe floor(sqrt(n)) for the full `u128` range.
+fn isqrt_u128(n: u128) -> u128 {
+    if n == 0 {
+        return 0;
+    }
     let mut x = n;
-    let mut y = (x + 1) / 2;
+    let mut y = x / 2 + (x & 1);
     while y < x {
         x = y;
         y = (x + n / x) / 2;
@@ -1183,5 +1199,74 @@ fn category_to_key(category: &ProposalCategory) -> u32 {
         ProposalCategory::ContractUpgrade => 1,
         ProposalCategory::TreasuryTransfer => 2,
         ProposalCategory::General => 3,
+    }
+}
+
+// ── #837: isqrt overflow-safety tests ─────────────────────────────────────────
+
+#[cfg(test)]
+mod isqrt_tests {
+    use super::*;
+
+    #[test]
+    fn isqrt_of_u128_max_does_not_panic() {
+        // Regression test for #837: seeding Newton's method with `x + 1`
+        // overflowed at the top of the range. This must run cleanly (no
+        // panic in debug, no silent wraparound in release) and produce the
+        // exact expected result: floor(sqrt(2^128 - 1)) == 2^64 - 1.
+        assert_eq!(isqrt_u128(u128::MAX), 18_446_744_073_709_551_615);
+    }
+
+    #[test]
+    fn isqrt_of_i128_max_does_not_panic() {
+        // A whale's token balance can approach i128::MAX; the public,
+        // i128-typed entry point must handle that without overflowing.
+        let result = isqrt(i128::MAX);
+        assert!(result > 0);
+        assert!(result * result <= i128::MAX);
+    }
+
+    #[test]
+    fn isqrt_known_values() {
+        assert_eq!(isqrt(0), 0);
+        assert_eq!(isqrt(-5), 0);
+        assert_eq!(isqrt(1), 1);
+        assert_eq!(isqrt(4), 2);
+        assert_eq!(isqrt(10), 3);
+        assert_eq!(isqrt(99), 9);
+        assert_eq!(isqrt(100), 10);
+        assert_eq!(isqrt(101), 10);
+        assert_eq!(isqrt_u128(0), 0);
+        assert_eq!(isqrt_u128(u128::MAX - 1), 18_446_744_073_709_551_615);
+    }
+}
+
+#[cfg(test)]
+mod isqrt_proptests {
+    use super::isqrt_u128;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 4096, ..ProptestConfig::default() })]
+
+        /// isqrt(n)^2 must never exceed n, for any n across the full u128 range.
+        #[test]
+        fn isqrt_squared_never_exceeds_n(n in any::<u128>()) {
+            let r = isqrt_u128(n);
+            let squared = r.checked_mul(r);
+            prop_assert!(squared.is_some(), "isqrt({n}) = {r} but r*r overflowed u128");
+            prop_assert!(squared.unwrap() <= n, "isqrt({n}) = {r} but {r}*{r} > {n}");
+        }
+
+        /// isqrt(n) must be the *floor* of the true square root: the next
+        /// integer up should overshoot (when that check itself doesn't
+        /// overflow, e.g. when n is u128::MAX).
+        #[test]
+        fn isqrt_is_the_floor_not_an_underestimate(n in any::<u128>()) {
+            let r = isqrt_u128(n);
+            if let Some(next_squared) = (r + 1).checked_mul(r + 1) {
+                prop_assert!(next_squared > n, "isqrt({n}) = {r} but ({r}+1)^2 <= {n}");
+            }
+        }
     }
 }

--- a/stellar-swipe/contracts/governance/src/quadratic_voting.rs
+++ b/stellar-swipe/contracts/governance/src/quadratic_voting.rs
@@ -545,7 +545,7 @@ mod tests {
         assert_eq!(10i128 * 10, 100);
         // 100 credits → 10 votes (√100 = 10)
         let credits: i128 = 100;
-        let votes = integer_sqrt(credits);
+        let votes = crate::proposals::isqrt(credits);
         assert_eq!(votes, 10);
     }
 
@@ -576,18 +576,5 @@ mod tests {
         let new_credits_required: i128 = 25;
         let refund = original_credits_spent - new_credits_required;
         assert_eq!(refund, 75);
-    }
-
-    fn integer_sqrt(value: i128) -> i128 {
-        if value <= 0 {
-            return 0;
-        }
-        let mut x0 = value;
-        let mut x1 = (x0 + value / x0) / 2;
-        while x1 < x0 {
-            x0 = x1;
-            x1 = (x0 + value / x0) / 2;
-        }
-        x0
     }
 }

--- a/stellar-swipe/contracts/governance/src/test_portableDD.rs
+++ b/stellar-swipe/contracts/governance/src/test_portableDD.rs
@@ -1,7 +1,7 @@
 extern crate std;
 
 use crate::distribution::{DistributionRecipients, YEAR_SECONDS};
-use crate::proposals::{ProposalType, VoteType as GovernanceVoteType};
+use crate::proposals::{ProposalCategory, ProposalType, VoteType as GovernanceVoteType};
 use crate::{GovernanceContract, GovernanceContractClient, GovernanceError};
 use soroban_sdk::testutils::{Address as _, Events, Ledger};
 use soroban_sdk::{Address, Bytes, Env, String, Symbol, TryFromVal, Val};
@@ -176,6 +176,8 @@ fn proposal_contract_upgrade_invalid_payload_rejected() {
         &String::from_str(&env, "Upgrade"),
         &String::from_str(&env, "Upgrade the contract"),
         &bad_payload,
+        &ProposalCategory::General,
+        &false,
     );
     assert_eq!(result, Err(Ok(GovernanceError::InvalidProposal)));
 }
@@ -197,6 +199,8 @@ fn proposal_contract_upgrade_valid_payload_accepted() {
         &String::from_str(&env, "Upgrade"),
         &String::from_str(&env, "Upgrade the contract"),
         &hash,
+        &ProposalCategory::General,
+        &false,
     );
     assert!(
         matches!(result, Ok(Ok(_))),
@@ -221,6 +225,8 @@ fn proposal_custom_empty_payload_rejected() {
         &String::from_str(&env, "Custom"),
         &String::from_str(&env, "Custom proposal"),
         &empty,
+        &ProposalCategory::General,
+        &false,
     );
     assert_eq!(result, Err(Ok(GovernanceError::InvalidProposal)));
 }
@@ -255,6 +261,8 @@ fn proposal_treasury_spend_bad_version_prefix_rejected() {
         &String::from_str(&env, "Spend"),
         &String::from_str(&env, "Treasury spend proposal"),
         &bad,
+        &ProposalCategory::General,
+        &false,
     );
     assert_eq!(result, Err(Ok(GovernanceError::InvalidProposal)));
 }


### PR DESCRIPTION
closes #794 

quadratic_voting.rs in contracts/governance/ computes voting weight as sqrt(token_balance). For very large token holders (balance approaching u128::MAX), the squaring operation used in the Newton's method square root approximation can overflow. Since Soroban uses u128 and Rust's arithmetic wraps in release mode by default (or panics in debug), this is a latent safety bug.

Motivation
A governance contract with an overflow bug in vote counting is a critical vulnerability: a whale could craft a balance that causes overflow, artificially setting their voting weight to a very small number and suppressing their quorum contribution — or, depending on the direction of overflow, gaining an impossibly large weight.
Quadratic voting specifically requires careful integer arithmetic; standard sqrt(u128) is non-trivial to implement without