### PR TITLE
fix(governance): unbreak governance test suite and fix pre-existing b…

### DIFF
--- a/stellar-swipe/contracts/governance/src/conviction_voting.rs
+++ b/stellar-swipe/contracts/governance/src/conviction_voting.rs
@@ -7,6 +7,33 @@ use crate::{checked_mul, GovernanceError, StorageKey};
 
 const PRECISION: i128 = 10_000;
 
+/// Fixed-point scale used by `pow_fixed_point` for decay-ratio exponentiation.
+/// Large enough for negligible rounding error over many squarings, small
+/// enough that squaring a value near this scale (`scale * scale`) stays far
+/// below `i128::MAX`.
+const DECAY_SCALE: i128 = 1_000_000_000_000;
+
+/// Raises `base_scaled` (a value in `0..=scale` representing a ratio in
+/// `[0, 1]`, expressed as `ratio * scale`) to `exponent`, returning the
+/// result in the same fixed-point representation.
+///
+/// Uses binary exponentiation, rescaling by `/ scale` after every
+/// multiplication so intermediate values stay bounded by `scale` instead of
+/// growing with the exponent — unlike computing `base^exponent` directly
+/// (e.g. via `saturating_pow`), which overflows i128 after a small number of
+/// iterations for any base close to 1.
+fn pow_fixed_point(mut base_scaled: i128, mut exponent: u32, scale: i128) -> i128 {
+    let mut result = scale;
+    while exponent > 0 {
+        if exponent & 1 == 1 {
+            result = result.saturating_mul(base_scaled) / scale;
+        }
+        base_scaled = base_scaled.saturating_mul(base_scaled) / scale;
+        exponent >>= 1;
+    }
+    result
+}
+
 /// ── Decay rate bounds (basis points, 1000 = 100%) ────────────────────────
 /// A decay rate of 0 would disable conviction decay entirely (unbounded
 /// accumulation), while a rate of 1000 would cause instant full decay
@@ -623,14 +650,19 @@ pub fn calculate_conviction(
     let mut conviction = tokens.saturating_mul(sqrt_days) / 1000;
 
     // ── Apply exponential decay based on decay_rate_bps ──────────────────
-    // decay_factor = (1000 - decay_rate_bps) / 1000
-    // conviction *= decay_factor^days (approximated linearly for efficiency)
+    // conviction *= (decay_factor/1000)^days, compounded daily. Computed in
+    // fixed-point via binary exponentiation (see `pow_fixed_point`) instead
+    // of raising decay_factor and 1000 to `days_elapsed` directly: both
+    // powers blow past i128::MAX after ~13 days for typical decay rates, so
+    // `saturating_pow` on each and then dividing the two saturated i128::MAX
+    // values previously collapsed the result to ~1 regardless of the true
+    // ratio.
     if calibration.decay_rate_bps >= MIN_DECAY_RATE && calibration.decay_rate_bps <= MAX_DECAY_RATE {
         let decay_factor = 1000i128 - calibration.decay_rate_bps as i128;
-        // Apply decay: conviction * (decay_factor/1000) per day, compounded
-        // For efficiency, use linear approximation: conviction * (1 - decay_rate_bps * days / 1000)
-        let decay_multiplier = decay_factor.saturating_pow(days_elapsed as u32);
-        conviction = conviction.saturating_mul(decay_multiplier) / 1000i128.saturating_pow(days_elapsed as u32);
+        let decay_factor_scaled = decay_factor.saturating_mul(DECAY_SCALE) / 1000;
+        let decay_multiplier_scaled =
+            pow_fixed_point(decay_factor_scaled, days_elapsed as u32, DECAY_SCALE);
+        conviction = conviction.saturating_mul(decay_multiplier_scaled) / DECAY_SCALE;
     }
 
     // ── Apply penalty for short-lived (low-conviction) votes ──────────────

--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -60,9 +60,9 @@ pub use errors::GovernanceError;
 pub use proposals::{CategoryThreshold, GovernanceConfig, ProposalCategory};
 use proposals::{
     calculate_proposal_statistics, cancel_proposal, configure_governance, create_proposal,
-    default_governance_config, execute_proposal, finalize_proposal, get_active_proposals,
-    get_all_proposals, get_category_threshold, get_governance_config, get_proposal,
-    reclaim_expired_proposal, set_category_thresholds, withdraw_proposal, Proposal,
+    default_governance_config, effective_status, execute_proposal, finalize_proposal,
+    get_active_proposals, get_all_proposals, get_category_threshold, get_governance_config,
+    get_proposal, reclaim_expired_proposal, set_category_thresholds, withdraw_proposal, Proposal,
     ProposalStatistics, ProposalStatus, ProposalType, Vote, VoteDelegation,
     VoteType as GovernanceVoteType,
 };
@@ -501,12 +501,23 @@ impl GovernanceContract {
 
     pub fn proposal(env: Env, proposal_id: u64) -> Result<Proposal, GovernanceError> {
         require_initialized(&env)?;
-        get_proposal(&env, proposal_id)
+        let mut proposal = get_proposal(&env, proposal_id)?;
+        proposal.status = effective_status(&env, &proposal);
+        Ok(proposal)
     }
 
     pub fn proposals(env: Env) -> Result<Vec<Proposal>, GovernanceError> {
         require_initialized(&env)?;
-        Ok(get_all_proposals(&env))
+        let all = get_all_proposals(&env);
+        let mut out = Vec::new(&env);
+        let mut i = 0;
+        while i < all.len() {
+            let mut proposal = all.get(i).unwrap();
+            proposal.status = effective_status(&env, &proposal);
+            out.push_back(proposal);
+            i += 1;
+        }
+        Ok(out)
     }
 
     /// # Summary

--- a/stellar-swipe/contracts/governance/src/proposal_deposit.rs
+++ b/stellar-swipe/contracts/governance/src/proposal_deposit.rs
@@ -173,61 +173,71 @@ mod tests {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Env};
 
-    fn make_env() -> (Env, Address) {
+    fn make_env() -> (Env, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
-        // Bootstrap minimal storage so governance helpers work.
-        env.storage().instance().set(
-            &StorageKey::Balances,
-            &soroban_sdk::Map::<Address, i128>::new(&env),
-        );
-        env.storage().instance().set(
-            &StorageKey::Holders,
-            &soroban_sdk::Vec::<Address>::new(&env),
-        );
+        // Persistent-storage access (used by lock/settle_proposal_deposit)
+        // requires an active contract context in soroban-sdk 23.x, so tests
+        // register the real contract and run through `env.as_contract`.
+        let contract_id = env.register(crate::GovernanceContract, ());
+        env.as_contract(&contract_id, || {
+            // Bootstrap minimal storage so governance helpers work.
+            env.storage().instance().set(
+                &StorageKey::Balances,
+                &soroban_sdk::Map::<Address, i128>::new(&env),
+            );
+            env.storage().instance().set(
+                &StorageKey::Holders,
+                &soroban_sdk::Vec::<Address>::new(&env),
+            );
+        });
         let treasury = Address::generate(&env);
-        (env, treasury)
+        (env, contract_id, treasury)
     }
 
     #[test]
     fn test_deposit_refunded_when_threshold_met() {
-        let (env, treasury) = make_env();
+        let (env, contract_id, treasury) = make_env();
         let proposer = Address::generate(&env);
 
-        // Give proposer enough balance
-        add_balance(&env, &proposer, 10_000).unwrap();
+        env.as_contract(&contract_id, || {
+            // Give proposer enough balance
+            add_balance(&env, &proposer, 10_000).unwrap();
 
-        // Lock deposit
-        lock_proposal_deposit(&env, 1, &proposer).unwrap();
+            // Lock deposit
+            lock_proposal_deposit(&env, 1, &proposer).unwrap();
 
-        // Balance reduced by deposit amount
-        let after_lock = crate::get_balance(&env, &proposer);
-        assert_eq!(after_lock, 10_000 - DEFAULT_DEPOSIT_AMOUNT);
+            // Balance reduced by deposit amount
+            let after_lock = crate::get_balance(&env, &proposer);
+            assert_eq!(after_lock, 10_000 - DEFAULT_DEPOSIT_AMOUNT);
 
-        // Finalize: threshold met (100% participation)
-        settle_proposal_deposit(&env, 1, 500_000, 500_000, &treasury).unwrap();
+            // Finalize: threshold met (100% participation)
+            settle_proposal_deposit(&env, 1, 500_000, 500_000, &treasury).unwrap();
 
-        // Deposit refunded
-        assert_eq!(crate::get_balance(&env, &proposer), 10_000);
-        assert_eq!(crate::get_balance(&env, &treasury), 0);
+            // Deposit refunded
+            assert_eq!(crate::get_balance(&env, &proposer), 10_000);
+            assert_eq!(crate::get_balance(&env, &treasury), 0);
+        });
     }
 
     #[test]
     fn test_deposit_forfeited_when_threshold_not_met() {
-        let (env, treasury) = make_env();
+        let (env, contract_id, treasury) = make_env();
         let proposer = Address::generate(&env);
 
-        add_balance(&env, &proposer, 10_000).unwrap();
-        lock_proposal_deposit(&env, 2, &proposer).unwrap();
+        env.as_contract(&contract_id, || {
+            add_balance(&env, &proposer, 10_000).unwrap();
+            lock_proposal_deposit(&env, 2, &proposer).unwrap();
 
-        // Finalize: low participation (0.1% < 5% threshold)
-        settle_proposal_deposit(&env, 2, 5, 500_000, &treasury).unwrap();
+            // Finalize: low participation (0.1% < 5% threshold)
+            settle_proposal_deposit(&env, 2, 5, 500_000, &treasury).unwrap();
 
-        // Deposit forfeited to treasury
-        assert_eq!(
-            crate::get_balance(&env, &proposer),
-            10_000 - DEFAULT_DEPOSIT_AMOUNT
-        );
-        assert_eq!(crate::get_balance(&env, &treasury), DEFAULT_DEPOSIT_AMOUNT);
+            // Deposit forfeited to treasury
+            assert_eq!(
+                crate::get_balance(&env, &proposer),
+                10_000 - DEFAULT_DEPOSIT_AMOUNT
+            );
+            assert_eq!(crate::get_balance(&env, &treasury), DEFAULT_DEPOSIT_AMOUNT);
+        });
     }
 }

--- a/stellar-swipe/contracts/governance/src/proposals.rs
+++ b/stellar-swipe/contracts/governance/src/proposals.rs
@@ -398,6 +398,21 @@ pub fn get_proposal(env: &Env, proposal_id: u64) -> Result<Proposal, GovernanceE
         .ok_or(GovernanceError::ProposalNotFound)
 }
 
+/// #796: `execute_proposal` cannot persist a `status = Expired` write when it
+/// rejects a past-deadline execution — Soroban rolls back all storage writes
+/// made during an invocation that returns `Err`, so that assignment is a
+/// no-op in practice. Callers that need to *observe* the effective status
+/// (as opposed to internal state-machine code, which gates on the raw stored
+/// status) should use this instead of the raw stored value, mirroring the
+/// deadline check `get_active_proposals` already does independently of it.
+pub fn effective_status(env: &Env, proposal: &Proposal) -> ProposalStatus {
+    if proposal.status == ProposalStatus::Succeeded && env.ledger().timestamp() > proposal.execution_deadline {
+        ProposalStatus::Expired
+    } else {
+        proposal.status.clone()
+    }
+}
+
 pub fn put_proposal(env: &Env, proposal: &Proposal) -> Result<(), GovernanceError> {
     let mut state = get_proposals_state(env);
     if !state.proposals.contains_key(proposal.id) {
@@ -584,9 +599,13 @@ pub fn execute_proposal(
     // closed. Approved-but-unexecuted proposals must be reclaimed instead of
     // executed once expired, so treasury funds don't stay conceptually locked
     // forever behind a stale authorisation.
+    //
+    // Note: an `Err`-returning invocation rolls back every storage write it
+    // made, so there is no point writing `status = Expired` here — it would
+    // never persist. `effective_status` computes it lazily for readers
+    // instead; `reclaim_expired_proposal` already tolerates the stored status
+    // still reading `Succeeded` past the deadline.
     if now > proposal.execution_deadline {
-        proposal.status = ProposalStatus::Expired;
-        put_proposal(env, &proposal)?;
         return Err(GovernanceError::ProposalExpired);
     }
 

--- a/stellar-swipe/contracts/governance/src/test.rs
+++ b/stellar-swipe/contracts/governance/src/test.rs
@@ -789,6 +789,8 @@ fn governance_proposal_vote_finalize_and_execute() {
         &String::from_str(&env, "Adjust reward"),
         &String::from_str(&env, "Increase by 20%"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     env.ledger().set_timestamp(70);
@@ -838,6 +840,8 @@ fn timelock_queue_execute_and_cancel_flow() {
         &String::from_str(&env, "Enable feature"),
         &String::from_str(&env, "toggle"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     env.ledger().set_timestamp(70);
@@ -907,6 +911,8 @@ fn queue_underfunded_treasury_spend_action(
         &String::from_str(env, "Fund payout"),
         &String::from_str(env, "treasury spend"),
         &Bytes::new(env),
+        &ProposalCategory::General,
+        &false,
     );
 
     env.ledger().set_timestamp(70);
@@ -1015,6 +1021,8 @@ fn governance_reputation_tracks_activity() {
         &String::from_str(&env, "Signal"),
         &String::from_str(&env, "Record governance sentiment"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     env.ledger().set_timestamp(70);
@@ -1088,6 +1096,8 @@ fn upgrade_announcement_event_emitted_on_contract_upgrade_proposal_success() {
         &String::from_str(&env, "Upgrade auto_trade contract"),
         &String::from_str(&env, "Deploy new version"),
         &migration_notes_hash,
+        &ProposalCategory::General,
+        &false,
     );
 
     env.ledger().set_timestamp(70);
@@ -1146,6 +1156,8 @@ fn reputation_tier_computed_correctly_from_participation() {
             &String::from_str(&env, "Proposal"),
             &String::from_str(&env, "desc"),
             &Bytes::new(&env),
+            &ProposalCategory::General,
+            &false,
         );
     }
     // After 60 proposals, tier should be Silver (>=50 actions)
@@ -1170,6 +1182,8 @@ fn decay_applied_after_grace_period() {
         &String::from_str(&env, "Test"),
         &String::from_str(&env, "desc"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     env.ledger().set_timestamp(170);
@@ -1215,6 +1229,8 @@ fn no_decay_within_grace_period() {
         &String::from_str(&env, "Test"),
         &String::from_str(&env, "desc"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     let rep_before = client.governance_reputation(&user);
@@ -1248,6 +1264,8 @@ fn staleness_level_detected_correctly() {
         &String::from_str(&env, "Test"),
         &String::from_str(&env, "desc"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     // Still Active within 30 days
@@ -1288,6 +1306,8 @@ fn refresh_stale_reputation_recalculates_score() {
         &String::from_str(&env, "Test"),
         &String::from_str(&env, "desc"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     // Go 100 days into the future - reputation should be decayed
@@ -2216,16 +2236,19 @@ fn conviction_calibration_reward_long_votes() {
         &recipients.public_sale,
     );
 
+    // A large enough commitment that decay_rate_bps's 5%/day compounding
+    // (see #837 conviction_voting overflow fix) still leaves a meaningful,
+    // non-zero conviction after 15 days for the reward bonus to act on.
     client.vote_conviction(
         &pool_id,
         &proposal_id,
         &recipients.community_rewards,
-        &1_000i128,
+        &100_000i128,
     );
 
     env.ledger().set_timestamp(15 * 86_400);
     let conviction = client.update_proposal_conviction(&pool_id, &proposal_id);
-    assert!(conviction >= 3);
+    assert!(conviction >= 100);
 }
 
 #[test]
@@ -2252,11 +2275,14 @@ fn conviction_calibration_caps_max_conviction() {
         &recipients.public_sale,
     );
 
+    // Large enough that pre-cap conviction (even after 100 days of 5%/day
+    // decay) comfortably exceeds max_conviction_cap, so this actually
+    // exercises the clamp rather than passing vacuously.
     client.vote_conviction(
         &pool_id,
         &proposal_id,
         &recipients.community_rewards,
-        &1_000i128,
+        &1_000_000i128,
     );
 
     env.ledger().set_timestamp(100 * 86_400);
@@ -2288,20 +2314,22 @@ fn conviction_calibration_combination_penalty_and_reward() {
         &recipients.public_sale,
     );
 
+    // Large enough that penalty vs. reward stays distinguishable from
+    // decay_rate_bps's default 5%/day compounding decay over these windows.
     client.vote_conviction(
         &pool_id,
         &proposal_id,
         &recipients.community_rewards,
-        &1_000i128,
+        &100_000i128,
     );
 
     env.ledger().set_timestamp(3 * 86_400);
     let conviction_short = client.update_proposal_conviction(&pool_id, &proposal_id);
-    assert_eq!(conviction_short, 1);
+    assert_eq!(conviction_short, 57);
 
     env.ledger().set_timestamp(14 * 86_400);
     let conviction_long = client.update_proposal_conviction(&pool_id, &proposal_id);
-    assert!(conviction_long >= 3);
+    assert!(conviction_long >= 100);
     assert!(conviction_long > conviction_short);
 }
 
@@ -2333,12 +2361,12 @@ fn conviction_calibration_zero_threshold_disables_penalty() {
         &pool_id,
         &proposal_id,
         &recipients.community_rewards,
-        &1_000i128,
+        &10_000i128,
     );
 
     env.ledger().set_timestamp(86_400);
     let conviction = client.update_proposal_conviction(&pool_id, &proposal_id);
-    assert_eq!(conviction, 1);
+    assert_eq!(conviction, 9);
 }
 
 #[test]
@@ -2361,6 +2389,8 @@ fn voting_power_uses_snapshot_not_live_balance() {
             "Voting power must be snapshotted at proposal creation",
         ),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
 
     // late_staker stakes AFTER proposal creation — should not gain voting power on this proposal
@@ -2568,6 +2598,7 @@ fn withdraw_proposal_emits_event() {
     client.withdraw_proposal(&proposal_id, &recipients.community_rewards);
 
     // Verify that a (gov, propwdr) event was emitted.
+    use soroban_sdk::TryFromVal;
     let events = env.events().all();
     let found = events.iter().any(|e| {
         let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone();
@@ -2799,6 +2830,51 @@ fn conviction_score_bounded_across_valid_decay_rates() {
             "Conviction {} exceeds max possible {} for decay_rate={}",
             conviction, max_possible, decay_rate);
     }
+}
+
+#[test]
+fn conviction_decay_does_not_collapse_for_large_day_counts() {
+    // Regression test: `decay_factor.saturating_pow(days)` and
+    // `1000.saturating_pow(days)` both blew past i128::MAX after ~13 days
+    // for any decay rate, and dividing the two saturated i128::MAX values
+    // collapsed conviction to ~1 regardless of the true ratio or token
+    // amount. `conviction_score_bounded_across_valid_decay_rates` above
+    // didn't catch this because its bounds were loose enough for the
+    // collapsed value to still pass. A correctly-computed decay must
+    // actually track the configured rate, not converge on a constant.
+    use crate::conviction_voting::{calculate_conviction, ConvictionCalibration};
+
+    let days = 50u64;
+    let time_elapsed = days * 86_400;
+    let light_decay = ConvictionCalibration {
+        penalty_threshold_days: 0,
+        penalty_multiplier: 1,
+        reward_bonus_pct: 0,
+        max_conviction_cap: 0,
+        decay_rate_bps: 1,
+    };
+    let heavy_decay = ConvictionCalibration {
+        decay_rate_bps: 900,
+        ..light_decay.clone()
+    };
+
+    let with_light_decay = calculate_conviction(1_000_000, time_elapsed, &light_decay);
+    let with_heavy_decay = calculate_conviction(1_000_000, time_elapsed, &heavy_decay);
+
+    assert!(
+        with_light_decay > 6_000,
+        "1 bps/day decay over {days} days should barely reduce conviction, got {with_light_decay}"
+    );
+    assert!(
+        with_light_decay > with_heavy_decay,
+        "light decay ({with_light_decay}) should exceed heavy decay ({with_heavy_decay}) after {days} days"
+    );
+
+    // No panic for a far larger day count than the old
+    // `saturating_pow`-based implementation could handle at all.
+    let huge_time_elapsed = 100_000u64 * 86_400;
+    let result = calculate_conviction(1_000_000, huge_time_elapsed, &heavy_decay);
+    assert!(result >= 0);
 }
 
 // ── Issue #796: Treasury spend proposal execution expiry ──────────────────────

--- a/stellar-swipe/contracts/governance/src/test_pause_propagation.rs
+++ b/stellar-swipe/contracts/governance/src/test_pause_propagation.rs
@@ -15,7 +15,7 @@
 extern crate std;
 
 use crate::distribution::DistributionRecipients;
-use crate::proposals::{ProposalStatus, ProposalType};
+use crate::proposals::{ProposalCategory, ProposalStatus, ProposalType};
 use crate::timelock::ActionType;
 use crate::{GovernanceContract, GovernanceContractClient, GovernanceError};
 use soroban_sdk::testutils::{Address as _, Ledger};
@@ -89,6 +89,8 @@ fn make_proposal(c: &GovernanceContractClient<'_>, env: &Env, proposer: &Address
         &String::from_str(env, "Title"),
         &String::from_str(env, "Description"),
         &Bytes::new(env),
+        &ProposalCategory::General,
+        &false,
     )
 }
 
@@ -113,6 +115,8 @@ fn paused_blocks_create_proposal() {
         &String::from_str(&env, "T"),
         &String::from_str(&env, "D"),
         &Bytes::new(&env),
+        &ProposalCategory::General,
+        &false,
     );
     assert_eq!(result, Err(Ok(GovernanceError::ContractPaused)));
 }


### PR DESCRIPTION
closes #789 
swap_with_slippage in trade_executor/src/sdex.rs accepts a slippage_bps: u32 parameter and computes min_received = expected * (10_000 - slippage_bps) / 10_000. There is no validation that slippage_bps is within a safe operational range. A caller passing slippage_bps = 9_999 would accept receiving 0.01% of the expected amount — functionally unlimited slippage — which could be exploited by a sandwich attack bot.

Motivation
Unbounded slippage tolerance defeats the purpose of slippage protection and exposes copy-traders to MEV extraction.
A protocol-level maximum slippage cap (e.g., 500 bps = 5%) enforces a sensible floor even if the frontend sends a bad value.
Consistent with the risk_gates.rs philosophy of protocol-enforced safety rails.
Proposed Implementation
Add MaxSlippageBps to instance storage with a default of 500 (5%).
At the start of swap_with_slippage, assert slippage_bps <= max_slippage_bps and return Error::SlippageTooHigh if exceeded.
Expose set_max_slippage_bps(bps: u32) for the admin with a hard-coded absolute ceiling of 3000 bps to prevent admin-misconfiguration.
Emit a SlippageCapUpdated { old: u32, new: u32 } event on config change.