### PR TITLE
feat:   Harden versioning, migrations, and cross-contract auth; add deployment manifest validation 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       # Checkout repository
       - uses: actions/checkout@v4
 
+      # Deployment manifests (deployments/*.manifest.json) describe required
+      # addresses, contract versions, and cross-contract dependencies for a
+      # release. Validate them before anything else so a misconfigured
+      # manifest fails fast, cheaply, and before any build/deploy work.
+      - name: Validate deployment manifests
+        run: python3 stellar-swipe/scripts/validate_deployment_manifest.py
+
       # Setup Rust toolchain with required components and target
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -24,3 +24,36 @@ Expected fields:
 ```
 
 The e2e runner accepts either plain string IDs or the object form shown above.
+
+## Deployment manifests (Issue #822)
+
+`deployments/<network>.manifest.json` is a **hand-maintained, pre-deploy**
+description of a release: required addresses, each contract's version, and
+its cross-contract dependencies. It is distinct from `<network>.json` above,
+which is generated *during* a deploy and just records contract IDs.
+
+`scripts/deploy_testnet.sh` validates `deployments/$STELLAR_NETWORK.manifest.json`
+(if present) before touching any contract, using
+`scripts/validate_deployment_manifest.py`. The same validator also runs in CI
+against every `deployments/*.manifest.json` in the repo. A manifest is
+invalid — and the release is blocked — if:
+
+- `admin`, or any contract's `address`, is not a syntactically valid Stellar
+  StrKey (wrong length, bad checksum, or wrong address type).
+- Any contract is missing a `package` name or a positive integer `version`.
+- A `depends_on` entry names a contract not present in the manifest, or
+  requires a `min_version` higher than that contract's declared `version`.
+- The `depends_on` graph has a cycle.
+
+See `testnet.manifest.json` for a filled-in example and
+`mainnet.manifest.example.json` for a template — copy the latter to
+`mainnet.manifest.json` and replace the `REPLACE_WITH_*` placeholders before
+a mainnet release. It is named `*.example.json` (not `*.manifest.json`) so
+an unfilled copy is never auto-discovered or auto-validated as if it were
+ready to deploy.
+
+Run it directly with:
+
+```sh
+python3 stellar-swipe/scripts/validate_deployment_manifest.py deployments/testnet.manifest.json
+```

--- a/deployments/mainnet.manifest.example.json
+++ b/deployments/mainnet.manifest.example.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "TEMPLATE — copy to deployments/mainnet.manifest.json and replace every REPLACE_WITH_* placeholder with real values before a mainnet release. Named *.example.json (not *.manifest.json) so it is never auto-discovered or auto-validated by scripts/validate_deployment_manifest.py, scripts/deploy_testnet.sh, or CI — the placeholders below are intentionally invalid StrKeys so a copy that was never filled in fails validation loudly instead of silently deploying with garbage addresses.",
+  "network": "mainnet",
+  "admin": "REPLACE_WITH_MAINNET_ADMIN_ADDRESS",
+  "contracts": {
+    "stake_vault": {
+      "package": "stake_vault",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "signal_registry": {
+      "package": "signal_registry",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "fee_collector": {
+      "package": "fee_collector",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "user_portfolio": {
+      "package": "auto_trade",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "trade_executor": {
+      "package": "bridge",
+      "address": null,
+      "version": 1,
+      "depends_on": {
+        "user_portfolio": { "min_version": 2 }
+      }
+    }
+  }
+}

--- a/deployments/testnet.manifest.json
+++ b/deployments/testnet.manifest.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Deployment manifest for testnet (Issue #822). Validated by stellar-swipe/scripts/validate_deployment_manifest.py before scripts/deploy_testnet.sh runs, and in CI. 'address' is null until a contract has actually been deployed (see deployments/testnet.json, generated at deploy time) — fill it in once known so later re-validations also check it. 'version' tracks the contract's on-chain version constant (see stellar-swipe/contracts/shared/src/version.rs); 'depends_on' declares the minimum compatible version of another contract in this manifest that this contract calls cross-contract, mirroring the runtime shared::version::validate_callee_version check.",
+  "network": "testnet",
+  "admin": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  "contracts": {
+    "stake_vault": {
+      "package": "stake_vault",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "signal_registry": {
+      "package": "signal_registry",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "fee_collector": {
+      "package": "fee_collector",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "user_portfolio": {
+      "package": "auto_trade",
+      "address": null,
+      "version": 2,
+      "depends_on": {}
+    },
+    "trade_executor": {
+      "package": "bridge",
+      "address": null,
+      "version": 1,
+      "depends_on": {
+        "user_portfolio": { "min_version": 2 }
+      }
+    }
+  }
+}

--- a/stellar-swipe/contracts/auto_trade/src/errors.rs
+++ b/stellar-swipe/contracts/auto_trade/src/errors.rs
@@ -140,4 +140,14 @@ impl AutoTradeError {
     // ── Daily execution cap ──────────────────────────────────────────────────
     /// Auto-trade blocked by per-user daily execution cap.
     pub const DailyExecutionCapExceeded: AutoTradeError = AutoTradeError::DailyTradeLimitExceeded;
+
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+    // `AutoTradeError` is already at the 50-variant cap enforced by Soroban's
+    // contract-spec XDR format (`ScSpecUdtErrorEnumV0.cases: VecM<_, 50>`), so
+    // this reuses `SystemError` under a clearer name rather than adding a
+    // 51st discriminant (which fails the `#[contracterror]` macro at
+    // compile time with "LengthExceedsMax").
+    /// `upgrade()` was called with a version that is not strictly greater
+    /// than the currently stored contract version.
+    pub const IncompatibleContractVersion: AutoTradeError = AutoTradeError::SystemError;
 }

--- a/stellar-swipe/contracts/auto_trade/src/lib.rs
+++ b/stellar-swipe/contracts/auto_trade/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 mod admin;
 mod advanced_risk;
@@ -258,6 +260,45 @@ impl AutoTradeContract {
     /// Nothing. Panics if already initialized.
     pub fn initialize(env: Env, admin: Address) {
         admin::init_admin(&env, admin);
+        shared::version::set_contract_version(&env, shared::version::AUTO_TRADE_VERSION);
+    }
+
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+
+    /// Returns this contract's stored version. Cross-contract callers can use
+    /// this to enforce a minimum compatible version before invoking this
+    /// contract (see `shared::version::validate_callee_version`).
+    pub fn get_contract_version(env: Env) -> u32 {
+        shared::version::get_contract_version(&env)
+    }
+
+    /// Admin-only: replace this contract's executable with `new_wasm_hash`
+    /// (previously uploaded via `Deployer::upload_contract_wasm`) and record
+    /// `new_version` as the contract's version.
+    ///
+    /// `new_version` must be strictly greater than the currently stored
+    /// version, rejecting accidental or malicious downgrades.
+    ///
+    /// # Errors
+    /// - [`AutoTradeError::Unauthorized`] — caller is not the admin.
+    /// - [`AutoTradeError::IncompatibleContractVersion`] — `new_version` is
+    ///   not strictly greater than the currently stored version.
+    pub fn upgrade(
+        env: Env,
+        caller: Address,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+    ) -> Result<(), AutoTradeError> {
+        admin::require_admin(&env, &caller)?;
+
+        let current_version = shared::version::get_contract_version(&env);
+        shared::version::guard_upgrade(current_version, new_version)
+            .map_err(|_| AutoTradeError::IncompatibleContractVersion)?;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        shared::version::set_contract_version(&env, new_version);
+        shared::version::emit_contract_upgraded(&env, current_version, new_version);
+        Ok(())
     }
 
     /// Pause a category (admin or guardian)

--- a/stellar-swipe/contracts/fee_collector/src/errors.rs
+++ b/stellar-swipe/contracts/fee_collector/src/errors.rs
@@ -30,4 +30,10 @@ pub enum ContractError {
     InvalidMultiplierBounds = 24,
     SelfReferralNotAllowed = 25,
     ReferralAlreadyRegistered = 26,
+    /// Issue #811: `upgrade()` was called with a version that is not
+    /// strictly greater than the currently stored contract version.
+    IncompatibleContractVersion = 27,
+    /// Issue #813: caller is neither the admin nor on the authorized-caller
+    /// allowlist for this privileged, non-user-scoped entry point.
+    UnauthorizedCaller = 28,
 }

--- a/stellar-swipe/contracts/fee_collector/src/events.rs
+++ b/stellar-swipe/contracts/fee_collector/src/events.rs
@@ -282,6 +282,28 @@ pub fn emit_payout_currency_set(env: &Env, provider: &Address, preferred_token: 
     );
 }
 
+// ── #813: Authorized-caller allowlist events ────────────────────────────────
+
+pub fn emit_caller_authorized(env: &Env, caller: &Address) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "caller_authorized"),
+        ),
+        caller.clone(),
+    );
+}
+
+pub fn emit_caller_revoked(env: &Env, caller: &Address) {
+    env.events().publish(
+        (
+            Symbol::new(env, "fee_collector"),
+            Symbol::new(env, "caller_revoked"),
+        ),
+        caller.clone(),
+    );
+}
+
 // ── Referral events ─────────────────────────────────────────────────────────
 
 pub fn emit_referral_registered(env: &Env, referrer: &Address, referee: &Address) {

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -34,12 +34,13 @@ use storage::{
     get_network_condition_score, get_oracle_contract, get_pending_fees,
     get_provider_payout_currency, get_queued_withdrawal, get_referral_fee_share_bps, get_referrer,
     get_treasury_balance, get_volume_discount_config, get_waterfall_config, has_traded,
-    is_initialized, remove_failed_fee_collection, remove_monthly_trade_volume,
-    remove_provider_payout_currency, remove_queued_withdrawal, set_admin,
-    set_burn_rate as set_burn_rate_storage, set_congestion_config, set_congestion_signal,
-    set_failed_fee_collection, set_fee_optimization_config, set_fee_rate as set_fee_rate_storage,
-    set_forecast_config_storage, set_has_traded, set_initialized, set_last_error_report,
-    set_last_forecast_day, set_monthly_trade_volume, set_network_condition_score,
+    is_authorized_caller, is_initialized, remove_authorized_caller, remove_failed_fee_collection,
+    remove_monthly_trade_volume, remove_provider_payout_currency, remove_queued_withdrawal,
+    set_admin, set_authorized_caller, set_burn_rate as set_burn_rate_storage,
+    set_congestion_config, set_congestion_signal, set_failed_fee_collection,
+    set_fee_optimization_config, set_fee_rate as set_fee_rate_storage, set_forecast_config_storage,
+    set_has_traded, set_initialized, set_last_error_report, set_last_forecast_day,
+    set_monthly_trade_volume, set_network_condition_score,
     set_oracle_contract as set_oracle_contract_storage, set_pending_fees,
     set_provider_payout_currency, set_queued_withdrawal, set_referral_fee_share_bps, set_referrer,
     set_treasury_balance, set_volume_discount_config_storage,
@@ -51,7 +52,8 @@ use storage::{
 };
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, Env, IntoVal, String, Symbol, Val, Vec,
+    contract, contractimpl, contracttype, token, Address, BytesN, Env, IntoVal, String, Symbol,
+    Val, Vec,
 };
 
 use shared::errors::{ErrorCategory, RecoveryStrategy};
@@ -152,7 +154,89 @@ impl FeeCollector {
         }
         set_admin(&env, &admin);
         set_initialized(&env);
+        shared::version::set_contract_version(&env, shared::version::FEE_COLLECTOR_VERSION);
         Ok(())
+    }
+
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+
+    /// Returns this contract's stored version. Callers that depend on this
+    /// contract cross-contract can use this to enforce a minimum compatible
+    /// version before invoking privileged entry points (see
+    /// `shared::version::validate_callee_version`).
+    pub fn get_contract_version(env: Env) -> u32 {
+        shared::version::get_contract_version(&env)
+    }
+
+    /// Admin-only: replace this contract's executable with `new_wasm_hash`
+    /// (previously uploaded via `Deployer::upload_contract_wasm`) and record
+    /// `new_version` as the contract's version.
+    ///
+    /// `new_version` must be strictly greater than the currently stored
+    /// version — this rejects accidental (or malicious) downgrades that
+    /// could reintroduce a fixed bug or reopen a storage-layout mismatch.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — contract not initialized.
+    /// - [`ContractError::IncompatibleContractVersion`] — `new_version` is
+    ///   not strictly greater than the currently stored version.
+    pub fn upgrade(
+        env: Env,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+    ) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+
+        let current_version = shared::version::get_contract_version(&env);
+        shared::version::guard_upgrade(current_version, new_version)
+            .map_err(|_| ContractError::IncompatibleContractVersion)?;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        shared::version::set_contract_version(&env, new_version);
+        shared::version::emit_contract_upgraded(&env, current_version, new_version);
+        Ok(())
+    }
+
+    // ── Issue #813: cross-contract authentication hardening ─────────────────
+    //
+    // A small admin-curated allowlist of non-admin addresses (typically other
+    // contracts, such as a trusted trade-settlement keeper) permitted to
+    // invoke a narrow set of privileged entry points that are not naturally
+    // scoped to a single end-user's own `require_auth()`. The admin is
+    // always implicitly authorized and is never required to be on this list.
+
+    /// Admin-only: add `caller` to the authorized-caller allowlist.
+    pub fn authorize_caller(env: Env, caller: Address) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+        set_authorized_caller(&env, &caller);
+        events::emit_caller_authorized(&env, &caller);
+        Ok(())
+    }
+
+    /// Admin-only: remove `caller` from the authorized-caller allowlist.
+    pub fn revoke_caller(env: Env, caller: Address) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+        remove_authorized_caller(&env, &caller);
+        events::emit_caller_revoked(&env, &caller);
+        Ok(())
+    }
+
+    /// Returns `true` if `caller` is on the authorized-caller allowlist.
+    /// The admin is always implicitly authorized even if not listed here.
+    pub fn is_caller_authorized(env: Env, caller: Address) -> bool {
+        is_authorized_caller(&env, &caller)
     }
 
     /// # Summary
@@ -495,14 +579,25 @@ impl FeeCollector {
         Ok(())
     }
 
-    /// Admin or Keeper: push the current congestion signal.
-    pub fn set_congestion_signal(env: Env, multiplier_bps: u32) -> Result<(), ContractError> {
+    /// Admin, or an allowlisted keeper (Issue #813 — see [`Self::authorize_caller`]):
+    /// push the current network congestion signal.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — contract not initialized.
+    /// - [`ContractError::UnauthorizedCaller`] — `caller` is neither the
+    ///   admin nor on the authorized-caller allowlist.
+    pub fn set_congestion_signal(
+        env: Env,
+        caller: Address,
+        multiplier_bps: u32,
+    ) -> Result<(), ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
-        // Since there is no keeper role yet, we default to admin-only.
-        let admin = get_admin(&env);
-        admin.require_auth();
+        caller.require_auth();
+        if caller != get_admin(&env) && !is_authorized_caller(&env, &caller) {
+            return Err(ContractError::UnauthorizedCaller);
+        }
 
         let config = get_congestion_config(&env);
         if multiplier_bps < config.min_multiplier_bps || multiplier_bps > config.max_multiplier_bps
@@ -1077,16 +1172,28 @@ impl FeeCollector {
 
     /// Record fee shares distributed to a provider for the current day.
     ///
-    /// Called by the fee distribution system when allocating fee shares to a
-    /// signal provider. Updates the per-day earnings bucket used by
-    /// `get_provider_earnings_report`.
+    /// Called by the fee distribution system (the admin, or an allowlisted
+    /// settlement contract — see [`Self::authorize_caller`]) when allocating
+    /// fee shares to a signal provider. Updates the per-day earnings bucket
+    /// used by `get_provider_earnings_report`.
+    ///
+    /// # Errors
+    /// - [`ContractError::NotInitialized`] — contract not initialized.
+    /// - [`ContractError::UnauthorizedCaller`] — `caller` is neither the
+    ///   admin nor on the authorized-caller allowlist (Issue #813).
+    /// - [`ContractError::InvalidAmount`] — `amount` <= 0.
     pub fn record_provider_fee_share(
         env: Env,
+        caller: Address,
         provider: Address,
         amount: i128,
     ) -> Result<(), ContractError> {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
+        }
+        caller.require_auth();
+        if caller != get_admin(&env) && !is_authorized_caller(&env, &caller) {
+            return Err(ContractError::UnauthorizedCaller);
         }
         if amount <= 0 {
             return Err(ContractError::InvalidAmount);

--- a/stellar-swipe/contracts/fee_collector/src/storage.rs
+++ b/stellar-swipe/contracts/fee_collector/src/storage.rs
@@ -126,6 +126,11 @@ pub enum StorageKey {
     /// Congestion signal parameters
     CongestionConfig,
     CongestionSignal,
+    /// Issue #813: allowlisted non-admin caller permitted to invoke a narrow
+    /// set of privileged, non-user-scoped entry points (e.g. a trusted
+    /// trade-settlement keeper contract). See the "Authorized callers"
+    /// section below.
+    AuthorizedCaller(Address),
 }
 
 #[contracttype]
@@ -207,6 +212,42 @@ pub fn is_initialized(env: &Env) -> bool {
 
 pub fn set_initialized(env: &Env) {
     initializable::mark_initialized(env);
+}
+
+// --- Authorized callers (Issue #813: cross-contract auth hardening) ---
+//
+// A small admin-curated allowlist of non-admin addresses — typically other
+// contracts, such as a trade-settlement keeper — permitted to invoke a
+// narrow set of privileged entry points that are not naturally scoped to a
+// single end-user's own `require_auth()` (e.g. recording provider fee
+// shares on their behalf, or pushing a network congestion signal). The
+// admin is always implicitly authorized for these entry points and does
+// not need to be added to this list.
+
+pub fn is_authorized_caller(env: &Env, caller: &Address) -> bool {
+    crud_get::<_, bool>(
+        env,
+        StorageTier::Instance,
+        &StorageKey::AuthorizedCaller(caller.clone()),
+    )
+    .unwrap_or(false)
+}
+
+pub fn set_authorized_caller(env: &Env, caller: &Address) {
+    crud_set(
+        env,
+        StorageTier::Instance,
+        &StorageKey::AuthorizedCaller(caller.clone()),
+        &true,
+    );
+}
+
+pub fn remove_authorized_caller(env: &Env, caller: &Address) {
+    crud_remove(
+        env,
+        StorageTier::Instance,
+        &StorageKey::AuthorizedCaller(caller.clone()),
+    );
 }
 
 // --- Oracle Contract ---

--- a/stellar-swipe/contracts/fee_collector/src/test.rs
+++ b/stellar-swipe/contracts/fee_collector/src/test.rs
@@ -1524,7 +1524,7 @@ fn test_congestion_high() {
     disable_revenue_share(&client);
 
     // Set high congestion signal: 2.0x (20_000 bps)
-    client.set_congestion_signal(&20_000u32);
+    client.set_congestion_signal(&admin, &20_000u32);
 
     let trade_amount: i128 = 10_000_000;
     StellarAssetClient::new(&env, &token).mint(&trader, &trade_amount);
@@ -1558,7 +1558,7 @@ fn test_congestion_stale_fallback() {
 
     // Set high congestion signal: 2.0x
     env.ledger().set_timestamp(100);
-    client.set_congestion_signal(&20_000u32);
+    client.set_congestion_signal(&admin, &20_000u32);
 
     // Advance time past staleness threshold (300 secs)
     env.ledger().set_timestamp(100 + 301);
@@ -1583,6 +1583,6 @@ fn test_congestion_bounded() {
     client.initialize(&admin);
 
     // Max multiplier is 5.0x by default. Try 6.0x -> Should fail bounds check.
-    let result = client.try_set_congestion_signal(&60_000u32);
+    let result = client.try_set_congestion_signal(&admin, &60_000u32);
     assert_eq!(result, Err(Ok(ContractError::InvalidMultiplierBounds)));
 }

--- a/stellar-swipe/contracts/fee_collector/src/tests/security_tests.rs
+++ b/stellar-swipe/contracts/fee_collector/src/tests/security_tests.rs
@@ -1,0 +1,200 @@
+#![cfg(test)]
+//! Security regression tests for:
+//! - Issue #811 — upgrade-safe contract versioning (shared::version wired
+//!   into initialize()/upgrade()).
+//! - Issue #813 — cross-contract authentication hardening for fee collector
+//!   operations (authorized-caller allowlist).
+//!
+//! # Note on testing `upgrade()`
+//! `upgrade()` calls `Deployer::update_current_contract_wasm`, which requires
+//! a real Wasm blob previously uploaded via `Deployer::upload_contract_wasm`.
+//! No such blob is available inside a `cargo test` unit-test run (the crate
+//! under test is not itself compiled to Wasm as part of `cargo test`), so —
+//! consistent with `contracts/integration_tests/.../test_contract_upgrade.rs`,
+//! which documents the same limitation — these tests cover every guard that
+//! runs *before* the Wasm swap (auth, version compatibility) rather than the
+//! swap itself.
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+use crate::{ContractError, FeeCollector, FeeCollectorClient};
+
+fn setup(env: &Env) -> (Address, FeeCollectorClient<'_>) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(env, &contract_id);
+    client.initialize(&admin);
+    (admin, client)
+}
+
+fn dummy_wasm_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[7u8; 32])
+}
+
+// ── Issue #811: contract versioning ─────────────────────────────────────────
+
+#[test]
+fn initialize_sets_contract_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    assert_eq!(client.get_contract_version(), 2);
+}
+
+#[test]
+fn upgrade_rejects_same_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+    let _ = admin;
+
+    let current = client.get_contract_version();
+    let result = client.try_upgrade(&dummy_wasm_hash(&env), &current);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::IncompatibleContractVersion))
+    );
+    // Version must be unchanged — the guard rejected before any state mutation.
+    assert_eq!(client.get_contract_version(), current);
+}
+
+#[test]
+fn upgrade_rejects_downgrade() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    let current = client.get_contract_version();
+    let result = client.try_upgrade(&dummy_wasm_hash(&env), &(current - 1));
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::IncompatibleContractVersion))
+    );
+}
+
+#[test]
+fn upgrade_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let current = client.get_contract_version();
+
+    // Clear mocked auths so require_auth() is actually enforced, then invoke
+    // with no authorizing signature at all.
+    env.set_auths(&[]);
+    let result = client.try_upgrade(&dummy_wasm_hash(&env), &(current + 1));
+    assert!(result.is_err(), "upgrade without admin auth must be rejected");
+}
+
+// ── Issue #813: authorized-caller allowlist ─────────────────────────────────
+
+#[test]
+fn caller_not_authorized_by_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    assert!(!client.is_caller_authorized(&stranger));
+}
+
+#[test]
+fn admin_can_authorize_and_revoke_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let keeper = Address::generate(&env);
+
+    client.authorize_caller(&keeper);
+    assert!(client.is_caller_authorized(&keeper));
+
+    client.revoke_caller(&keeper);
+    assert!(!client.is_caller_authorized(&keeper));
+}
+
+#[test]
+fn record_provider_fee_share_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let provider = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let result = client.try_record_provider_fee_share(&stranger, &provider, &1_000i128);
+    assert_eq!(result, Err(Ok(ContractError::UnauthorizedCaller)));
+}
+
+#[test]
+fn record_provider_fee_share_allows_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+    let provider = Address::generate(&env);
+
+    client.record_provider_fee_share(&admin, &provider, &1_000i128);
+}
+
+#[test]
+fn record_provider_fee_share_allows_authorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let provider = Address::generate(&env);
+    let keeper = Address::generate(&env);
+
+    client.authorize_caller(&keeper);
+    client.record_provider_fee_share(&keeper, &provider, &1_000i128);
+}
+
+#[test]
+fn record_provider_fee_share_rejects_after_revocation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let provider = Address::generate(&env);
+    let keeper = Address::generate(&env);
+
+    client.authorize_caller(&keeper);
+    client.record_provider_fee_share(&keeper, &provider, &1_000i128);
+
+    client.revoke_caller(&keeper);
+    let result = client.try_record_provider_fee_share(&keeper, &provider, &1_000i128);
+    assert_eq!(result, Err(Ok(ContractError::UnauthorizedCaller)));
+}
+
+#[test]
+fn set_congestion_signal_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    let result = client.try_set_congestion_signal(&stranger, &12_000u32);
+    assert_eq!(result, Err(Ok(ContractError::UnauthorizedCaller)));
+}
+
+#[test]
+fn set_congestion_signal_allows_authorized_keeper() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let keeper = Address::generate(&env);
+
+    client.authorize_caller(&keeper);
+    client.set_congestion_signal(&keeper, &12_000u32);
+}
+
+#[test]
+fn only_admin_can_authorize_callers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let keeper = Address::generate(&env);
+
+    // Clear mocked auths: authorize_caller requires the *stored admin's*
+    // signature, not the caller's own — a non-admin invoking it must fail.
+    env.set_auths(&[]);
+    let result = client.try_authorize_caller(&keeper);
+    assert!(result.is_err());
+}

--- a/stellar-swipe/contracts/oracle/src/errors.rs
+++ b/stellar-swipe/contracts/oracle/src/errors.rs
@@ -32,4 +32,7 @@ pub enum OracleError {
     InsufficientSources = 25,
     /// A single-update price deviation exceeded the configured maximum percentage.
     PriceDeviationBreakerTripped = 26,
+    /// Issue #811: `upgrade()` was called with a version that is not
+    /// strictly greater than the currently stored contract version.
+    IncompatibleContractVersion = 27,
 }

--- a/stellar-swipe/contracts/oracle/src/lib.rs
+++ b/stellar-swipe/contracts/oracle/src/lib.rs
@@ -27,7 +27,7 @@ use reputation::{
     slash_oracle, track_oracle_accuracy, SlashReason,
 };
 use sdex::{calculate_spot_price, OrderBook};
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, String, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Map, String, Vec};
 use staleness::{OracleHealth, OracleStatus, StalenessLevel};
 use stellar_swipe_common::emergency::{PauseState, CAT_ALL};
 use stellar_swipe_common::{
@@ -85,6 +85,50 @@ impl OracleContract {
         }
         env.storage().instance().set(&StorageKey::Admin, &admin);
         storage::set_base_currency(&env, base_currency);
+        shared::version::set_contract_version(&env, shared::version::ORACLE_VERSION);
+    }
+
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+
+    /// Returns this contract's stored version. Cross-contract callers can use
+    /// this to enforce a minimum compatible version before invoking this
+    /// oracle (see `shared::version::validate_callee_version`).
+    pub fn get_contract_version(env: Env) -> u32 {
+        shared::version::get_contract_version(&env)
+    }
+
+    /// Admin-only: replace this contract's executable with `new_wasm_hash`
+    /// (previously uploaded via `Deployer::upload_contract_wasm`) and record
+    /// `new_version` as the contract's version.
+    ///
+    /// `new_version` must be strictly greater than the currently stored
+    /// version, rejecting accidental or malicious downgrades.
+    ///
+    /// # Errors
+    /// - [`OracleError::Unauthorized`] — contract not initialized, or caller
+    ///   is not the admin.
+    /// - [`OracleError::IncompatibleContractVersion`] — `new_version` is not
+    ///   strictly greater than the currently stored version.
+    pub fn upgrade(
+        env: Env,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+    ) -> Result<(), OracleError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(OracleError::Unauthorized)?;
+        admin.require_auth();
+
+        let current_version = shared::version::get_contract_version(&env);
+        shared::version::guard_upgrade(current_version, new_version)
+            .map_err(|_| OracleError::IncompatibleContractVersion)?;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        shared::version::set_contract_version(&env, new_version);
+        shared::version::emit_contract_upgraded(&env, current_version, new_version);
+        Ok(())
     }
 
     /// Read-only health probe for monitoring and front-ends (no auth).

--- a/stellar-swipe/contracts/shared/src/version.rs
+++ b/stellar-swipe/contracts/shared/src/version.rs
@@ -58,6 +58,9 @@ pub enum VersionKey {
 #[repr(u32)]
 pub enum VersionError {
     IncompatibleContractVersion = 1,
+    /// An `upgrade()` call proposed a `new_version` that is not strictly
+    /// greater than the contract's currently stored version.
+    DowngradeRejected = 2,
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -102,6 +105,29 @@ pub fn require_compatible(env: &Env, callee_version: u32, kind: ContractKind) {
 pub fn emit_version_checked(env: &Env, callee_version: u32, compatible: bool) {
     env.events()
         .publish((symbol_short!("ver_chk"), callee_version), compatible);
+}
+
+/// Guard an `upgrade()` call: the proposed `new_version` must be strictly
+/// greater than `current_version`.
+///
+/// Upgrades must move forward — re-deploying the same version or an older
+/// one is rejected. This prevents an admin key compromise (or a scripting
+/// mistake) from silently rolling a contract back to a version with a known
+/// bug or an incompatible storage layout. Pair with [`set_contract_version`]
+/// after a successful [`soroban_sdk::deploy::Deployer::update_current_contract_wasm`]
+/// call so the stored version and the deployed code stay in lockstep.
+pub fn guard_upgrade(current_version: u32, new_version: u32) -> Result<(), VersionError> {
+    if new_version <= current_version {
+        Err(VersionError::DowngradeRejected)
+    } else {
+        Ok(())
+    }
+}
+
+/// Emit an event recording a completed contract upgrade (old → new version).
+pub fn emit_contract_upgraded(env: &Env, old_version: u32, new_version: u32) {
+    env.events()
+        .publish((symbol_short!("upgraded"),), (old_version, new_version));
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -207,5 +233,24 @@ mod tests {
         env.as_contract(&addr, || {
             require_compatible(&env, 0, ContractKind::SignalRegistry);
         });
+    }
+
+    // --- guard_upgrade ---
+
+    #[test]
+    fn guard_upgrade_allows_strictly_increasing_version() {
+        assert!(guard_upgrade(1, 2).is_ok());
+        assert!(guard_upgrade(2, 100).is_ok());
+    }
+
+    #[test]
+    fn guard_upgrade_rejects_same_version() {
+        assert_eq!(guard_upgrade(3, 3), Err(VersionError::DowngradeRejected));
+    }
+
+    #[test]
+    fn guard_upgrade_rejects_downgrade() {
+        assert_eq!(guard_upgrade(5, 4), Err(VersionError::DowngradeRejected));
+        assert_eq!(guard_upgrade(5, 0), Err(VersionError::DowngradeRejected));
     }
 }

--- a/stellar-swipe/contracts/signal_registry/src/errors.rs
+++ b/stellar-swipe/contracts/signal_registry/src/errors.rs
@@ -38,6 +38,13 @@ pub enum AdminError {
     TooManyProposals = 33,
     /// Provider has submitted too recently; must wait for the cooldown period to elapse.
     CooldownNotElapsed = 34,
+    /// Issue #811: `upgrade()` was called with a version that is not
+    /// strictly greater than the currently stored contract version.
+    IncompatibleContractVersion = 35,
+    /// Issue #812: the on-chain storage schema version does not match what
+    /// `migrate_signals_v1_to_v2` expects as a precondition. Migration logic
+    /// does not run when this is returned — no state is touched.
+    IncompatibleStorageLayout = 36,
 }
 
 #[contracterror]

--- a/stellar-swipe/contracts/signal_registry/src/events.rs
+++ b/stellar-swipe/contracts/signal_registry/src/events.rs
@@ -400,6 +400,15 @@ pub fn emit_migration_verification_failed(
         .publish(topics, (verification.pre, verification.post));
 }
 
+/// Issue #812: a migration was rejected before any migration logic ran
+/// because the on-chain storage schema version did not match what the
+/// migration code expects as a precondition. Emitted for auditability —
+/// no state is mutated when this fires.
+pub fn emit_migration_layout_rejected(env: &Env, found_schema_version: u32) {
+    let topics = (Symbol::new(env, "migration_layout_rejected"),);
+    env.events().publish(topics, found_schema_version);
+}
+
 pub fn emit_signal_orphaned(env: &Env, signal_id: u64, reason: String) {
     let topics = (Symbol::new(env, "signal_orphaned"),);
     env.events().publish(topics, (signal_id, reason));

--- a/stellar-swipe/contracts/signal_registry/src/lib.rs
+++ b/stellar-swipe/contracts/signal_registry/src/lib.rs
@@ -67,7 +67,10 @@ use admin::{
     get_admin, get_admin_config, init_admin, is_trading_paused,
     require_not_paused_legacy as require_not_paused,
 };
-use shared::version::{set_contract_version, SIGNAL_REGISTRY_VERSION};
+use shared::version::{
+    emit_contract_upgraded, get_contract_version as shared_get_contract_version, guard_upgrade,
+    set_contract_version, SIGNAL_REGISTRY_VERSION,
+};
 use stellar_swipe_common::emergency::{PauseState, CAT_SIGNALS, CAT_TRADING};
 use stellar_swipe_common::rate_limit::{self as rl, ActionType as RLAction, RateLimitConfig};
 use stellar_swipe_common::SECONDS_PER_30_DAY_MONTH;
@@ -97,8 +100,8 @@ use reputation::{
     TrustScoreDetails, TrustScoreTier,
 };
 use soroban_sdk::{
-    contract, contractimpl, contracttype, Address, Bytes, Env, IntoVal, Map, String, Symbol, Val,
-    Vec,
+    contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, IntoVal, Map, String,
+    Symbol, Val, Vec,
 };
 use stellar_swipe_common::placeholder_admin;
 use stellar_swipe_common::{validate_asset_pair as validate_asset_pair_common, AssetPairError};
@@ -142,6 +145,10 @@ pub enum StorageKey {
     MigrationPreSnapshot,
     /// Result of reconciling the pre-migration snapshot against migrated v2 data (issue #597).
     MigrationVerification,
+    /// Issue #812: on-chain storage schema version. Checked by
+    /// `migration::verify_storage_layout` before any migration logic runs.
+    /// See [`migration::SIGNAL_SCHEMA_V1`] / [`migration::SIGNAL_SCHEMA_V2`].
+    SchemaVersion,
     ProviderStats,
     /// Per-provider stake balances for trust and submission gates.
     ProviderStakes,
@@ -214,6 +221,52 @@ impl SignalRegistry {
     pub fn initialize(env: Env, admin: Address) -> Result<(), AdminError> {
         init_admin(&env, admin)?;
         set_contract_version(&env, SIGNAL_REGISTRY_VERSION);
+        // Issue #812: a freshly-deployed contract has no legacy `SignalsV1`
+        // rows (new signals are written directly in the current `Signal`
+        // (v2) shape), so it starts at the current schema version. Contracts
+        // upgraded in place from before this guard existed never call
+        // `initialize` again; for them `migration::get_schema_version`
+        // defaults to `SIGNAL_SCHEMA_V1`, which is what they actually are.
+        migration::set_schema_version(&env, migration::SIGNAL_SCHEMA_V2);
+        Ok(())
+    }
+
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+
+    /// Returns this contract's stored version. Cross-contract callers can use
+    /// this to enforce a minimum compatible version before invoking this
+    /// contract (see `shared::version::validate_callee_version`).
+    pub fn get_contract_version(env: Env) -> u32 {
+        shared_get_contract_version(&env)
+    }
+
+    /// Admin-only: replace this contract's executable with `new_wasm_hash`
+    /// (previously uploaded via `Deployer::upload_contract_wasm`) and record
+    /// `new_version` as the contract's version.
+    ///
+    /// `new_version` must be strictly greater than the currently stored
+    /// version, rejecting accidental or malicious downgrades.
+    ///
+    /// # Errors
+    /// - [`AdminError::Unauthorized`] — caller is not the admin.
+    /// - [`AdminError::IncompatibleContractVersion`] — `new_version` is not
+    ///   strictly greater than the currently stored version.
+    pub fn upgrade(
+        env: Env,
+        caller: Address,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+    ) -> Result<(), AdminError> {
+        admin::require_admin(&env, &caller)?;
+        caller.require_auth();
+
+        let current_version = shared_get_contract_version(&env);
+        guard_upgrade(current_version, new_version)
+            .map_err(|_| AdminError::IncompatibleContractVersion)?;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        set_contract_version(&env, new_version);
+        emit_contract_upgraded(&env, current_version, new_version);
         Ok(())
     }
 

--- a/stellar-swipe/contracts/signal_registry/src/migration.rs
+++ b/stellar-swipe/contracts/signal_registry/src/migration.rs
@@ -7,13 +7,78 @@ use crate::categories::{RiskLevel, SignalCategory};
 use crate::contests;
 use crate::errors::AdminError;
 use crate::events::{
-    emit_migration_progress, emit_migration_verification_failed, emit_migration_verified,
+    emit_migration_layout_rejected, emit_migration_progress, emit_migration_verification_failed,
+    emit_migration_verified,
 };
 use crate::types::{MigrationProgress, Signal, SignalAction, SignalStatus, SignalV1};
 use crate::StorageKey;
 use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
 
 const MAX_MIGRATION_BATCH: u32 = 256;
+
+// ═══════════════════════════════════════════════════════════════════
+// Issue #812: storage layout migration guards
+// ═══════════════════════════════════════════════════════════════════
+//
+// `migrate_signals_v1_to_v2` assumes a specific on-chain storage shape: a
+// `SignalsV1` map of legacy `SignalV1` records being drained into a
+// `Signals` map of current `Signal` (v2) records. That assumption is only
+// safe to act on when the contract's recorded schema version actually says
+// "pre-migration v1 layout". Running the migration logic against any other
+// schema (e.g. a hypothetical future v3 layout that reuses these storage
+// keys differently) could silently corrupt state. `verify_storage_layout`
+// is called as the very first step of `migrate_signals_v1_to_v2`, before
+// any storage is read for mutation, and produces a deterministic,
+// auditable error (`AdminError::IncompatibleStorageLayout` + an emitted
+// event) instead of proceeding when the layout doesn't match.
+
+/// Schema version for the legacy `SignalV1` layout (pre-migration).
+pub const SIGNAL_SCHEMA_V1: u32 = 1;
+/// Schema version for the current `Signal` (v2) layout.
+pub const SIGNAL_SCHEMA_V2: u32 = 2;
+
+/// Read the on-chain storage schema version.
+///
+/// Defaults to [`SIGNAL_SCHEMA_V1`] when unset: contracts deployed before
+/// this guard existed never wrote this key, and — being pre-migration —
+/// that is in fact their real schema. Freshly-initialized contracts set
+/// this explicitly to [`SIGNAL_SCHEMA_V2`] in `initialize()` since they
+/// start with no legacy `SignalsV1` rows at all.
+pub fn get_schema_version(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&StorageKey::SchemaVersion)
+        .unwrap_or(SIGNAL_SCHEMA_V1)
+}
+
+pub fn set_schema_version(env: &Env, version: u32) {
+    env.storage()
+        .instance()
+        .set(&StorageKey::SchemaVersion, &version);
+}
+
+/// Guard checked before any migration logic runs (Issue #812).
+///
+/// Returns `Ok(())` when the stored schema version is a layout this
+/// migration code understands:
+/// - [`SIGNAL_SCHEMA_V1`] — the expected pre-migration layout; the caller
+///   proceeds with the actual v1→v2 migration.
+/// - [`SIGNAL_SCHEMA_V2`] — already fully migrated; the caller's subsequent
+///   scan finds no v1 rows and is a safe, idempotent no-op.
+///
+/// Any other value — storage corruption, or a schema this migration code
+/// predates (e.g. a future v3) — is rejected deterministically with
+/// [`AdminError::IncompatibleStorageLayout`] and an audit event, without
+/// touching any migration state.
+pub fn verify_storage_layout(env: &Env) -> Result<(), AdminError> {
+    let version = get_schema_version(env);
+    if version == SIGNAL_SCHEMA_V1 || version == SIGNAL_SCHEMA_V2 {
+        Ok(())
+    } else {
+        emit_migration_layout_rejected(env, version);
+        Err(AdminError::IncompatibleStorageLayout)
+    }
+}
 
 fn v1_to_v2(_env: &Env, v1: &SignalV1) -> Signal {
     let rationale_hash = v1.rationale.clone();
@@ -247,6 +312,10 @@ pub fn migrate_signals_v1_to_v2(
     _admin: &Address,
     batch_size: u32,
 ) -> Result<(), AdminError> {
+    // Issue #812: storage layout check runs before any migration logic —
+    // including before the batch_size validation below — touches state.
+    verify_storage_layout(env)?;
+
     if batch_size == 0 || batch_size > MAX_MIGRATION_BATCH {
         return Err(AdminError::InvalidParameter);
     }
@@ -326,6 +395,11 @@ pub fn migrate_signals_v1_to_v2(
     if scan_to >= max_id {
         if count_v1_keys(&v1, counter) == 0 {
             set_migration_cursor(env, max_id.saturating_add(1));
+
+            // Issue #812: v1 is now fully drained — advance the recorded
+            // schema version so a future migration call takes the
+            // already-migrated (no-op) path via `verify_storage_layout`.
+            set_schema_version(env, SIGNAL_SCHEMA_V2);
 
             // Post-migration invariant verification (issue #597): v1 for this
             // scope is now fully drained, so reconcile the pre-migration
@@ -499,6 +573,118 @@ mod migration_invariant_tests {
                 verification.post.total_volume_sum - verification.pre.total_volume_sum,
                 999_999
             );
+        });
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Issue #812: storage layout migration guard regression tests
+// ═══════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod storage_layout_guard_tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn with_contract<R>(f: impl FnOnce(&Env) -> R) -> R {
+        let env = Env::default();
+        env.mock_all_auths();
+        #[allow(deprecated)]
+        let cid = env.register_contract(None, crate::SignalRegistry);
+        env.as_contract(&cid, || f(&env))
+    }
+
+    /// A legacy (pre-guard) deployment never wrote `SchemaVersion`, so it
+    /// defaults to `SIGNAL_SCHEMA_V1` — the guard must accept this and let
+    /// migration proceed normally.
+    #[test]
+    fn migration_succeeds_with_default_legacy_schema_version() {
+        with_contract(|env| {
+            let admin = Address::generate(env);
+            test_seed_v1_signals(env, 5);
+
+            assert_eq!(get_schema_version(env), SIGNAL_SCHEMA_V1);
+            assert!(migrate_signals_v1_to_v2(env, &admin, 10).is_ok());
+
+            // Fully drained in one batch -> schema advances to v2.
+            assert_eq!(get_schema_version(env), SIGNAL_SCHEMA_V2);
+        });
+    }
+
+    /// A contract already fully migrated (schema == v2) takes the no-op
+    /// path — the guard does not reject it, and re-running is safe.
+    #[test]
+    fn migration_is_noop_when_already_at_current_schema() {
+        with_contract(|env| {
+            let admin = Address::generate(env);
+            set_schema_version(env, SIGNAL_SCHEMA_V2);
+
+            assert!(migrate_signals_v1_to_v2(env, &admin, 10).is_ok());
+            assert_eq!(get_schema_version(env), SIGNAL_SCHEMA_V2);
+        });
+    }
+
+    /// An unrecognized schema version — simulating storage corruption or a
+    /// future incompatible layout this migration code predates — must be
+    /// rejected deterministically, before any migration state is touched.
+    #[test]
+    fn migration_rejects_incompatible_schema_version() {
+        with_contract(|env| {
+            let admin = Address::generate(env);
+            test_seed_v1_signals(env, 5);
+            // Simulate an incompatible/unknown on-chain schema.
+            set_schema_version(env, 99);
+
+            let result = migrate_signals_v1_to_v2(env, &admin, 10);
+            assert_eq!(result, Err(AdminError::IncompatibleStorageLayout));
+
+            // No migration state was touched: cursor still at the seeded
+            // default, v1 map still fully populated, v2 map still empty.
+            let v1: Map<u64, SignalV1> = env
+                .storage()
+                .instance()
+                .get(&StorageKey::SignalsV1)
+                .unwrap();
+            assert_eq!(v1.len(), 5);
+            let v2: Map<u64, Signal> = env.storage().instance().get(&StorageKey::Signals).unwrap();
+            assert_eq!(v2.len(), 0);
+            assert_eq!(get_schema_version(env), 99);
+        });
+    }
+
+    /// `verify_storage_layout` is a pure precondition check independent of
+    /// any contract state beyond the schema version key itself.
+    #[test]
+    fn verify_storage_layout_accepts_known_versions_only() {
+        with_contract(|env| {
+            set_schema_version(env, SIGNAL_SCHEMA_V1);
+            assert!(verify_storage_layout(env).is_ok());
+
+            set_schema_version(env, SIGNAL_SCHEMA_V2);
+            assert!(verify_storage_layout(env).is_ok());
+
+            set_schema_version(env, 42);
+            assert_eq!(
+                verify_storage_layout(env),
+                Err(AdminError::IncompatibleStorageLayout)
+            );
+        });
+    }
+
+    /// `initialize()` sets a fresh contract's schema straight to v2 (it has
+    /// no legacy v1 rows to migrate), so migration is a safe no-op even
+    /// though `SignalsV1`/`Signals` were never seeded.
+    #[test]
+    fn fresh_initialize_sets_current_schema_version() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let cid = env.register(crate::SignalRegistry, ());
+        let client = crate::SignalRegistryClient::new(&env, &cid);
+        client.initialize(&admin);
+
+        env.as_contract(&cid, || {
+            assert_eq!(get_schema_version(&env), SIGNAL_SCHEMA_V2);
         });
     }
 }

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -7,8 +7,8 @@ use emergency_unstake::{EmergencyMultiSigConfig, EmergencyRequest};
 use migration::{MigrationKey, StakeInfoV2};
 use shared::{initializable, multisig, pausable};
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, Env, IntoVal,
-    String, Symbol, Val, Vec,
+    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, BytesN, Env,
+    IntoVal, String, Symbol, Val, Vec,
 };
 
 // ── Slash severity tiers ──────────────────────────────────────────────────────
@@ -213,6 +213,10 @@ pub enum StakeVaultError {
     RateLimitExceeded = 31,
     InvalidAmount = 32,
     RemainingStakeBelowMinimum = 33,
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+    /// `upgrade()` was called with a version that is not strictly greater
+    /// than the currently stored contract version.
+    IncompatibleContractVersion = 34,
 }
 
 /// A pending unstake request held in the FIFO queue (issue #663).
@@ -353,6 +357,49 @@ impl StakeVaultContract {
             .instance()
             .set(&pausable::PausableKey::Paused, &false);
         initializable::mark_initialized(&env);
+        shared::version::set_contract_version(&env, shared::version::STAKE_VAULT_VERSION);
+    }
+
+    // ── Issue #811: upgrade-safe contract versioning ─────────────────────────
+
+    /// Returns this contract's stored version. Cross-contract callers can use
+    /// this to enforce a minimum compatible version before invoking this
+    /// contract (see `shared::version::validate_callee_version`).
+    pub fn get_contract_version(env: Env) -> u32 {
+        shared::version::get_contract_version(&env)
+    }
+
+    /// Admin-only: replace this contract's executable with `new_wasm_hash`
+    /// (previously uploaded via `Deployer::upload_contract_wasm`) and record
+    /// `new_version` as the contract's version.
+    ///
+    /// `new_version` must be strictly greater than the currently stored
+    /// version, rejecting accidental or malicious downgrades.
+    ///
+    /// # Errors
+    /// - [`StakeVaultError::NotInitialized`] — contract not initialized.
+    /// - [`StakeVaultError::IncompatibleContractVersion`] — `new_version` is
+    ///   not strictly greater than the currently stored version.
+    pub fn upgrade(
+        env: Env,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+    ) -> Result<(), StakeVaultError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(StakeVaultError::NotInitialized)?;
+        admin.require_auth();
+
+        let current_version = shared::version::get_contract_version(&env);
+        shared::version::guard_upgrade(current_version, new_version)
+            .map_err(|_| StakeVaultError::IncompatibleContractVersion)?;
+
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+        shared::version::set_contract_version(&env, new_version);
+        shared::version::emit_contract_upgraded(&env, current_version, new_version);
+        Ok(())
     }
 
     // ── Emergency pause (shared::pausable) ────────────────────────────────────

--- a/stellar-swipe/error-baselines/fee_collector.json
+++ b/stellar-swipe/error-baselines/fee_collector.json
@@ -29,7 +29,9 @@
       "PayoutCurrencyUnchanged": 23,
       "InvalidMultiplierBounds": 24,
       "SelfReferralNotAllowed": 25,
-      "ReferralAlreadyRegistered": 26
+      "ReferralAlreadyRegistered": 26,
+      "IncompatibleContractVersion": 27,
+      "UnauthorizedCaller": 28
     }
   }
 }

--- a/stellar-swipe/error-baselines/oracle.json
+++ b/stellar-swipe/error-baselines/oracle.json
@@ -28,7 +28,9 @@
       "PriceStaleTradeBlocked": 22,
       "PendingAdminNotFound": 23,
       "PendingAdminExpired": 24,
-      "InsufficientSources": 25
+      "InsufficientSources": 25,
+      "PriceDeviationBreakerTripped": 26,
+      "IncompatibleContractVersion": 27
     }
   }
 }

--- a/stellar-swipe/error-baselines/signal_registry.json
+++ b/stellar-swipe/error-baselines/signal_registry.json
@@ -35,7 +35,10 @@
       "TimelockNotElapsed": 30,
       "ProposalAlreadyExecuted": 31,
       "ProposalCancelled": 32,
-      "TooManyProposals": 33
+      "TooManyProposals": 33,
+      "CooldownNotElapsed": 34,
+      "IncompatibleContractVersion": 35,
+      "IncompatibleStorageLayout": 36
     },
     "AiScoreError": {
       "Unauthorized": 600,

--- a/stellar-swipe/error-baselines/stake_vault.json
+++ b/stellar-swipe/error-baselines/stake_vault.json
@@ -27,7 +27,8 @@
       "InvalidAppealWindow": 21,
       "RateLimitExceeded": 22,
       "InvalidAmount": 23,
-      "RemainingStakeBelowMinimum": 24
+      "RemainingStakeBelowMinimum": 24,
+      "IncompatibleContractVersion": 34
     }
   }
 }

--- a/stellar-swipe/scripts/deploy_testnet.sh
+++ b/stellar-swipe/scripts/deploy_testnet.sh
@@ -49,6 +49,22 @@ die() { echo "error: $*" >&2; exit 1; }
 command -v stellar >/dev/null || die "stellar CLI not found (install stellar-cli)"
 command -v jq >/dev/null || die "jq not found"
 
+# Issue #822: validate the deployment manifest (if one exists for this
+# network) before touching any contract. Invalid addresses, version
+# incompatibilities, or dependency misconfigurations fail the release here
+# instead of surfacing mid-deploy. Manifests are optional (new, opt-in
+# infrastructure): a run with no deployments/$NET.manifest.json proceeds as
+# before, with a note.
+MANIFEST="$ROOT/deployments/$NET.manifest.json"
+if [[ -f "$MANIFEST" ]]; then
+  command -v python3 >/dev/null || die "python3 not found (required to validate $MANIFEST)"
+  echo "==> validating deployment manifest: $MANIFEST"
+  python3 "$SWIPE/scripts/validate_deployment_manifest.py" "$MANIFEST" \
+    || die "deployment manifest validation failed — see errors above"
+else
+  echo "==> no deployment manifest at $MANIFEST — skipping manifest validation"
+fi
+
 [[ -n "${STELLAR_SOURCE_ACCOUNT:-${STELLAR_ACCOUNT:-}}" ]] || die "set STELLAR_SOURCE_ACCOUNT or STELLAR_ACCOUNT (signing key / identity)"
 SOURCE="${STELLAR_SOURCE_ACCOUNT:-${STELLAR_ACCOUNT}}"
 

--- a/stellar-swipe/scripts/tests/test_validate_deployment_manifest.py
+++ b/stellar-swipe/scripts/tests/test_validate_deployment_manifest.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+test_validate_deployment_manifest.py — unit tests for
+scripts/validate_deployment_manifest.py (Issue #822).
+
+Run with:
+    python3 scripts/tests/test_validate_deployment_manifest.py
+    # or: python3 -m unittest scripts.tests.test_validate_deployment_manifest -v
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import validate_deployment_manifest as vdm  # noqa: E402
+
+# Two real, independently-known-valid StrKeys used as fixtures throughout.
+VALID_ACCOUNT = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+VALID_CONTRACT = "CA4CVLTTJI2BGISKBYOBD3PQ7MB4JRK4LEVCNQPHLC6PWZMNG7KBYJQ6"
+ANOTHER_VALID_CONTRACT = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA23PQL"
+
+
+def make_manifest(**overrides) -> dict:
+    base = {
+        "network": "testnet",
+        "admin": VALID_ACCOUNT,
+        "contracts": {
+            "signal_registry": {
+                "package": "signal_registry",
+                "address": VALID_CONTRACT,
+                "version": 2,
+                "depends_on": {},
+            },
+            "fee_collector": {
+                "package": "fee_collector",
+                "address": ANOTHER_VALID_CONTRACT,
+                "version": 2,
+                "depends_on": {},
+            },
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+class StrKeyValidationTests(unittest.TestCase):
+    def test_valid_account_strkey(self):
+        self.assertIsNone(
+            vdm.strkey_error(VALID_ACCOUNT, vdm.STRKEY_VERSION_ACCOUNT, "admin account")
+        )
+
+    def test_valid_contract_strkey(self):
+        self.assertIsNone(
+            vdm.strkey_error(VALID_CONTRACT, vdm.STRKEY_VERSION_CONTRACT, "contract address")
+        )
+
+    def test_wrong_length_rejected(self):
+        err = vdm.strkey_error(VALID_ACCOUNT[:-1], vdm.STRKEY_VERSION_ACCOUNT, "admin account")
+        self.assertIsNotNone(err)
+        self.assertIn("characters", err)
+
+    def test_invalid_base32_characters_rejected(self):
+        tampered = "0" + VALID_ACCOUNT[1:]  # '0' and '1' are not in the strkey alphabet
+        err = vdm.strkey_error(tampered, vdm.STRKEY_VERSION_ACCOUNT, "admin account")
+        self.assertIsNotNone(err)
+
+    def test_corrupted_checksum_rejected(self):
+        # Flip the last character — same length/alphabet, wrong checksum.
+        last = VALID_ACCOUNT[-1]
+        replacement = "A" if last != "A" else "B"
+        tampered = VALID_ACCOUNT[:-1] + replacement
+        err = vdm.strkey_error(tampered, vdm.STRKEY_VERSION_ACCOUNT, "admin account")
+        self.assertIsNotNone(err)
+        self.assertIn("checksum", err)
+
+    def test_wrong_address_type_rejected(self):
+        # A valid G... account passed where a C... contract was expected.
+        err = vdm.strkey_error(VALID_ACCOUNT, vdm.STRKEY_VERSION_CONTRACT, "contract address")
+        self.assertIsNotNone(err)
+        self.assertIn("wrong address type", err)
+
+    def test_none_rejected(self):
+        err = vdm.strkey_error(None, vdm.STRKEY_VERSION_ACCOUNT, "admin account")
+        self.assertIsNotNone(err)
+
+    def test_non_string_rejected(self):
+        err = vdm.strkey_error(12345, vdm.STRKEY_VERSION_ACCOUNT, "admin account")
+        self.assertIsNotNone(err)
+
+
+class ManifestSuccessCaseTests(unittest.TestCase):
+    def test_minimal_valid_manifest_has_no_errors(self):
+        manifest = make_manifest()
+        self.assertEqual(vdm.validate_manifest(manifest), [])
+
+    def test_null_address_is_valid_pre_deploy_state(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["address"] = None
+        self.assertEqual(vdm.validate_manifest(manifest), [])
+
+    def test_satisfied_dependency_is_valid(self):
+        manifest = make_manifest()
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "signal_registry": {"min_version": 2}
+        }
+        self.assertEqual(vdm.validate_manifest(manifest), [])
+
+    def test_exact_min_version_match_is_valid(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["version"] = 5
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "signal_registry": {"min_version": 5}
+        }
+        self.assertEqual(vdm.validate_manifest(manifest), [])
+
+
+class ManifestMisconfigurationTests(unittest.TestCase):
+    def test_missing_network_rejected(self):
+        manifest = make_manifest()
+        del manifest["network"]
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("network" in e for e in errors))
+
+    def test_empty_network_rejected(self):
+        manifest = make_manifest(network="   ")
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("network" in e for e in errors))
+
+    def test_missing_admin_rejected(self):
+        manifest = make_manifest()
+        del manifest["admin"]
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("admin" in e for e in errors))
+
+    def test_malformed_admin_address_rejected(self):
+        manifest = make_manifest(admin="NOT-A-REAL-ADDRESS")
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("admin" in e for e in errors))
+
+    def test_empty_contracts_rejected(self):
+        manifest = make_manifest(contracts={})
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("contracts" in e for e in errors))
+
+    def test_missing_package_rejected(self):
+        manifest = make_manifest()
+        del manifest["contracts"]["signal_registry"]["package"]
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("package" in e for e in errors))
+
+    def test_zero_version_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["version"] = 0
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("version" in e for e in errors))
+
+    def test_negative_version_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["version"] = -1
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("version" in e for e in errors))
+
+    def test_non_integer_version_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["version"] = "two"
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("version" in e for e in errors))
+
+    def test_malformed_contract_address_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["address"] = "CTRUNCATED"
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("address" in e for e in errors))
+
+    def test_account_address_used_as_contract_address_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["address"] = VALID_ACCOUNT
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("wrong address type" in e for e in errors))
+
+    def test_dependency_on_unknown_contract_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "does_not_exist": {"min_version": 1}
+        }
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("unknown contract" in e for e in errors))
+
+    def test_self_dependency_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "fee_collector": {"min_version": 1}
+        }
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("cannot depend on itself" in e for e in errors))
+
+    def test_unsatisfied_min_version_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["version"] = 1
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "signal_registry": {"min_version": 2}
+        }
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(
+            any("requires 'signal_registry' version >= 2" in e for e in errors)
+        )
+
+    def test_two_contract_cycle_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["signal_registry"]["depends_on"] = {
+            "fee_collector": {"min_version": 1}
+        }
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "signal_registry": {"min_version": 1}
+        }
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("circular dependency" in e for e in errors))
+
+    def test_three_contract_cycle_rejected(self):
+        manifest = make_manifest()
+        manifest["contracts"]["oracle"] = {
+            "package": "oracle",
+            "address": None,
+            "version": 1,
+            "depends_on": {"signal_registry": {"min_version": 1}},
+        }
+        manifest["contracts"]["signal_registry"]["depends_on"] = {
+            "fee_collector": {"min_version": 1}
+        }
+        manifest["contracts"]["fee_collector"]["depends_on"] = {
+            "oracle": {"min_version": 1}
+        }
+        errors = vdm.validate_manifest(manifest)
+        self.assertTrue(any("circular dependency" in e for e in errors))
+
+    def test_all_problems_reported_together_not_just_first(self):
+        manifest = make_manifest(admin="BAD")
+        manifest["contracts"]["signal_registry"]["version"] = 0
+        manifest["contracts"]["fee_collector"]["package"] = ""
+        errors = vdm.validate_manifest(manifest)
+        # Fail-fast means "exit nonzero immediately on any problem" at the
+        # process level, but the caller should see every problem, not just
+        # the first one found.
+        self.assertGreaterEqual(len(errors), 3)
+
+
+class ManifestFileTests(unittest.TestCase):
+    def test_valid_manifest_file_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "testnet.manifest.json"
+            path.write_text(json.dumps(make_manifest()))
+            self.assertEqual(vdm.validate_manifest_file(path), [])
+
+    def test_invalid_json_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.manifest.json"
+            path.write_text("{not valid json")
+            errors = vdm.validate_manifest_file(path)
+            self.assertTrue(any("invalid JSON" in e for e in errors))
+
+    def test_non_object_root_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "array.manifest.json"
+            path.write_text("[1, 2, 3]")
+            errors = vdm.validate_manifest_file(path)
+            self.assertTrue(any("must be a JSON object" in e for e in errors))
+
+    def test_missing_file_reported(self):
+        errors = vdm.validate_manifest_file(Path("/nonexistent/path/x.manifest.json"))
+        self.assertTrue(any("could not read file" in e for e in errors))
+
+
+class CheckedInManifestTests(unittest.TestCase):
+    """The manifest(s) actually committed to the repo must themselves be valid."""
+
+    def test_testnet_manifest_is_valid(self):
+        path = vdm.DEFAULT_DEPLOYMENTS_DIR / "testnet.manifest.json"
+        self.assertTrue(path.exists(), f"expected {path} to exist")
+        self.assertEqual(vdm.validate_manifest_file(path), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/stellar-swipe/scripts/validate_deployment_manifest.py
+++ b/stellar-swipe/scripts/validate_deployment_manifest.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+validate_deployment_manifest.py — validate a StellarSwipe deployment manifest
+before it is used to deploy or upgrade contracts (Issue #822).
+
+Usage:
+    python3 scripts/validate_deployment_manifest.py [manifest.json ...]
+
+    With no arguments, validates every deployments/*.manifest.json found in
+    the workspace (skipped with a message if none exist). This step is run
+    automatically near the start of scripts/deploy_testnet.sh and in CI, so
+    a misconfigured manifest fails fast, before any contract is touched.
+
+Exit codes:
+    0  All manifests valid (or none found — nothing to check).
+    1  One or more manifests failed validation. All problems found are
+       printed together (this does not stop at the first error), each with
+       enough context to fix it directly.
+
+What is validated:
+    - Required top-level fields: network (non-empty string), admin
+      (StrKey), contracts (non-empty object).
+    - `admin`, and each contract's `address` when set, are syntactically
+      valid Stellar StrKeys: correct length, base32 alphabet, and a correct
+      CRC16-XModem checksum — of the expected type (G... account for admin,
+      C... contract for contract addresses). This catches copy/paste typos
+      and truncated keys that `stellar contract deploy` would otherwise only
+      discover mid-release.
+    - Each contract entry declares a non-empty `package` and a positive
+      integer `version`.
+    - Every `depends_on` entry names another contract present in the same
+      manifest (no dangling references to a contract that was never
+      configured) and requires a `min_version` that the depended-on
+      contract's declared `version` actually satisfies — mirroring the
+      on-chain `shared::version::validate_callee_version` cross-contract
+      compatibility check, but caught before deployment instead of at
+      cross-contract call time.
+    - The dependency graph is acyclic. A cycle makes it impossible to choose
+      a deployment order (each contract's dependencies must exist before it
+      does), so this is reported as a fatal misconfiguration.
+
+Manifest schema:
+    {
+      "network": "testnet",
+      "admin": "G...",
+      "contracts": {
+        "<logical_name>": {
+          "package": "<cargo package name>",
+          "address": "C..." | null,      // null before first deploy
+          "version": <positive integer>,
+          "depends_on": {
+            "<other_logical_name>": {"min_version": <positive integer>},
+            ...
+          }
+        },
+        ...
+      }
+    }
+"""
+
+import argparse
+import base64
+import binascii
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = WORKSPACE_ROOT.parent
+DEFAULT_DEPLOYMENTS_DIR = REPO_ROOT / "deployments"
+
+# ── StrKey validation (Stellar SEP-0023) ────────────────────────────────────
+#
+# A StrKey is base32(version_byte || payload || crc16_xmodem(version_byte || payload)),
+# unpadded. For 32-byte payloads (ed25519 public keys, contract IDs) this is
+# always exactly 56 base32 characters.
+
+_BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+STRKEY_VERSION_ACCOUNT = 6 << 3  # 'G...'
+STRKEY_VERSION_CONTRACT = 2 << 3  # 'C...'
+_STRKEY_LEN = 56  # 1-byte version + 32-byte payload + 2-byte checksum, base32-encoded
+
+
+def _crc16_xmodem(data: bytes) -> int:
+    """CRC16-XModem (poly 0x1021, init 0) — the checksum algorithm StrKey uses."""
+    crc = 0x0000
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc
+
+
+def strkey_error(value: object, expected_version: int, type_label: str) -> Optional[str]:
+    """Return an actionable error string if `value` is not a valid StrKey of
+    the expected type, or `None` if it is valid."""
+    if not isinstance(value, str):
+        return f"expected a {type_label} StrKey string, got {type(value).__name__}"
+    if len(value) != _STRKEY_LEN:
+        return (
+            f"expected a {_STRKEY_LEN}-character {type_label} StrKey, "
+            f"got {len(value)} characters: {value!r}"
+        )
+    bad_chars = sorted(set(c for c in value if c not in _BASE32_ALPHABET))
+    if bad_chars:
+        return f"{type_label} StrKey contains invalid base32 characters: {bad_chars!r}"
+    try:
+        raw = base64.b32decode(value, casefold=False)
+    except (binascii.Error, ValueError) as e:
+        return f"{type_label} StrKey failed base32 decoding: {e}"
+    if len(raw) != 35:
+        return f"{type_label} StrKey decoded to {len(raw)} bytes, expected 35"
+    version_byte, payload, checksum = raw[0], raw[1:33], raw[33:35]
+    expected_checksum = _crc16_xmodem(bytes([version_byte]) + payload).to_bytes(2, "little")
+    if checksum != expected_checksum:
+        return f"{type_label} StrKey has an invalid checksum (typo or corrupted address): {value!r}"
+    if version_byte != expected_version:
+        got_prefix = value[0]
+        want_prefix = "G" if expected_version == STRKEY_VERSION_ACCOUNT else "C"
+        return (
+            f"{type_label} StrKey has the wrong address type: starts with "
+            f"'{got_prefix}' but a '{want_prefix}...' {type_label} was expected: {value!r}"
+        )
+    return None
+
+
+# ── Manifest validation ─────────────────────────────────────────────────────
+
+
+def _validate_top_level(data: dict) -> List[str]:
+    errors = []
+    if not isinstance(data.get("network"), str) or not data.get("network").strip():
+        errors.append("top-level 'network' must be a non-empty string")
+
+    admin = data.get("admin")
+    err = strkey_error(admin, STRKEY_VERSION_ACCOUNT, "admin account")
+    if err:
+        errors.append(f"top-level 'admin': {err}")
+
+    contracts = data.get("contracts")
+    if not isinstance(contracts, dict) or not contracts:
+        errors.append("top-level 'contracts' must be a non-empty object")
+    return errors
+
+
+def _validate_contract_entries(contracts: Dict[str, dict]) -> List[str]:
+    errors = []
+    for name, entry in contracts.items():
+        if not isinstance(entry, dict):
+            errors.append(f"contracts.{name}: must be an object")
+            continue
+
+        package = entry.get("package")
+        if not isinstance(package, str) or not package.strip():
+            errors.append(f"contracts.{name}.package: must be a non-empty string")
+
+        version = entry.get("version")
+        if not isinstance(version, int) or isinstance(version, bool) or version <= 0:
+            errors.append(f"contracts.{name}.version: must be a positive integer, got {version!r}")
+
+        address = entry.get("address")
+        if address is not None:
+            err = strkey_error(address, STRKEY_VERSION_CONTRACT, "contract address")
+            if err:
+                errors.append(f"contracts.{name}.address: {err}")
+
+        depends_on = entry.get("depends_on", {})
+        if not isinstance(depends_on, dict):
+            errors.append(f"contracts.{name}.depends_on: must be an object")
+            continue
+        for dep_name, dep_spec in depends_on.items():
+            if dep_name == name:
+                errors.append(f"contracts.{name}.depends_on: cannot depend on itself")
+            if dep_name not in contracts:
+                errors.append(
+                    f"contracts.{name}.depends_on references unknown contract "
+                    f"'{dep_name}' (not present in this manifest's 'contracts')"
+                )
+            if not isinstance(dep_spec, dict):
+                errors.append(f"contracts.{name}.depends_on.{dep_name}: must be an object")
+                continue
+            min_version = dep_spec.get("min_version")
+            if not isinstance(min_version, int) or isinstance(min_version, bool) or min_version <= 0:
+                errors.append(
+                    f"contracts.{name}.depends_on.{dep_name}.min_version: "
+                    f"must be a positive integer, got {min_version!r}"
+                )
+    return errors
+
+
+def _validate_version_compatibility(contracts: Dict[str, dict]) -> List[str]:
+    """Each dependency's declared min_version must be satisfied by the
+    depended-on contract's own declared version — mirrors the runtime
+    `shared::version::validate_callee_version` check, but at manifest time."""
+    errors = []
+    for name, entry in contracts.items():
+        if not isinstance(entry, dict):
+            continue
+        depends_on = entry.get("depends_on", {})
+        if not isinstance(depends_on, dict):
+            continue
+        for dep_name, dep_spec in depends_on.items():
+            target = contracts.get(dep_name)
+            if not isinstance(target, dict) or not isinstance(dep_spec, dict):
+                continue  # already reported by _validate_contract_entries
+            min_version = dep_spec.get("min_version")
+            target_version = target.get("version")
+            if not isinstance(min_version, int) or not isinstance(target_version, int):
+                continue  # already reported
+            if target_version < min_version:
+                errors.append(
+                    f"contracts.{name} requires '{dep_name}' version >= {min_version}, "
+                    f"but contracts.{dep_name}.version is {target_version}"
+                )
+    return errors
+
+
+def _find_dependency_cycle(contracts: Dict[str, dict]) -> Optional[List[str]]:
+    """DFS cycle detection over the depends_on graph. Returns the cycle path
+    (as logical names) if one exists, else None."""
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {name: WHITE for name in contracts}
+    path: List[str] = []
+
+    def visit(node: str) -> Optional[List[str]]:
+        color[node] = GRAY
+        path.append(node)
+        entry = contracts.get(node) or {}
+        depends_on = entry.get("depends_on", {}) if isinstance(entry, dict) else {}
+        if isinstance(depends_on, dict):
+            for dep_name in depends_on:
+                if dep_name not in color:
+                    continue  # unknown dependency already reported elsewhere
+                if color[dep_name] == GRAY:
+                    cycle_start = path.index(dep_name)
+                    return path[cycle_start:] + [dep_name]
+                if color[dep_name] == WHITE:
+                    result = visit(dep_name)
+                    if result:
+                        return result
+        path.pop()
+        color[node] = BLACK
+        return None
+
+    for name in contracts:
+        if color[name] == WHITE:
+            cycle = visit(name)
+            if cycle:
+                return cycle
+    return None
+
+
+def validate_manifest(data: dict) -> List[str]:
+    """Validate a parsed manifest dict. Returns a list of error strings
+    (empty if the manifest is valid)."""
+    errors = _validate_top_level(data)
+
+    contracts = data.get("contracts")
+    if not isinstance(contracts, dict) or not contracts:
+        # Nothing further can be checked meaningfully without contracts.
+        return errors
+
+    errors.extend(_validate_contract_entries(contracts))
+    errors.extend(_validate_version_compatibility(contracts))
+
+    cycle = _find_dependency_cycle(contracts)
+    if cycle:
+        errors.append(
+            "circular dependency detected in 'depends_on': " + " -> ".join(cycle)
+        )
+
+    return errors
+
+
+def validate_manifest_file(path: Path) -> List[str]:
+    try:
+        raw = path.read_text()
+    except OSError as e:
+        return [f"could not read file: {e}"]
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return [f"invalid JSON: {e}"]
+    if not isinstance(data, dict):
+        return ["manifest root must be a JSON object"]
+    return validate_manifest(data)
+
+
+# ── Entry point ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "manifests",
+        nargs="*",
+        help="Path(s) to manifest JSON file(s). Defaults to deployments/*.manifest.json.",
+    )
+    args = parser.parse_args()
+
+    if args.manifests:
+        paths = [Path(p) for p in args.manifests]
+    else:
+        paths = sorted(DEFAULT_DEPLOYMENTS_DIR.glob("*.manifest.json"))
+        if not paths:
+            print(
+                f"No deployment manifests found under {DEFAULT_DEPLOYMENTS_DIR} "
+                f"(*.manifest.json) — nothing to validate."
+            )
+            return 0
+
+    any_invalid = False
+    for path in paths:
+        if not path.exists():
+            print(f"[{path}] FAIL: file not found", file=sys.stderr)
+            any_invalid = True
+            continue
+
+        errors = validate_manifest_file(path)
+        if errors:
+            any_invalid = True
+            print(f"[{path}] INVALID — {len(errors)} problem(s):", file=sys.stderr)
+            for err in errors:
+                print(f"    - {err}", file=sys.stderr)
+        else:
+            print(f"[{path}] OK")
+
+    if any_invalid:
+        print(
+            "\nRESULT: one or more deployment manifests are invalid. "
+            "Fix the problems above before deploying.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nRESULT: all deployment manifests are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION


## Summary

Implements four related infrastructure/security issues together, since they touch overlapping shared modules (`shared::version`) and the same release flow:

- Closes #811 — Implement upgrade-safe contract versioning for shared modules
- Closes #812 — Add storage layout migration guards for signal registry
- Closes #813 — Harden cross-contract authentication for fee collector operations
- Closes #822 — Create deployment manifest validation for contract releases

## #811 — Upgrade-safe contract versioning

`shared::version` already had per-contract version constants and compatibility checks, but only `signal_registry` actually called `set_contract_version`. The other four contracts declared version constants that were never written to storage, and no contract exposed an `upgrade()` entrypoint.

- Added `shared::version::guard_upgrade()` — rejects any `upgrade()` call where `new_version` isn't strictly greater than the currently stored version (blocks accidental/malicious downgrades).
- Wired `set_contract_version()` into `initialize()` for `fee_collector`, `oracle`, `stake_vault`, and `auto_trade` (signal_registry already did this).
- Added an admin-gated `upgrade(new_wasm_hash, new_version)` entrypoint and a `get_contract_version()` query to all five contracts. `upgrade()` validates the version, calls `Deployer::update_current_contract_wasm`, then bumps the stored version.

## #812 — Storage layout migration guards (signal_registry)

`migrate_signals_v1_to_v2` had no precondition check on the on-chain storage shape before mutating state.

- Added a `SchemaVersion` storage key and `migration::verify_storage_layout()`, called as the very first step of the migration function, before any storage read/write.
- Unknown schema versions are rejected deterministically with `AdminError::IncompatibleStorageLayout` plus an audit event (`migration_layout_rejected`) — no state is touched on rejection.
- Fresh deployments start at the current schema (nothing to migrate); pre-existing deployments default to the legacy schema and migrate normally. Schema advances to v2 once v1 is fully drained.

## #813 — Fee collector cross-contract auth hardening

While auditing entry points I found `record_provider_fee_share` had **no auth check at all** — any caller could inflate a provider's reported earnings.

- Added an admin-curated authorized-caller allowlist (`authorize_caller` / `revoke_caller` / `is_caller_authorized`) for privileged, non-user-scoped entry points.
- Fixed `record_provider_fee_share` to require `caller.require_auth()` and admin-or-allowlist membership.
- Replaced the admin-only gate on `set_congestion_signal` (which had a `// no keeper role yet` comment) with the allowlist, so a trusted keeper contract can push congestion signals without being the admin.

## #822 — Deployment manifest validation

- New `scripts/validate_deployment_manifest.py`: validates a JSON deployment manifest's required addresses (real StrKey CRC16-XModem checksum validation, not just a regex), contract versions, and `depends_on` cross-contract version compatibility, including circular-dependency detection. Reports all problems found, not just the first.
- Wired into `deploy_testnet.sh` (fails fast before any deploy step if `deployments/$NETWORK.manifest.json` is invalid) and into CI as an early step.
- Added `deployments/testnet.manifest.json` and a `mainnet.manifest.example.json` template (placeholder addresses, intentionally excluded from auto-discovery so an unfilled copy can't be validated as "ready").

## Testing

- New unit/regression tests for all four issues (version guard, storage layout guard, auth allowlist, manifest validator — 34 Python unit tests + new Rust test modules).
- `cargo fmt`, `cargo clippy -D warnings`, and `cargo test` run clean on every touched crate (`shared`, `fee_collector`, `oracle`, `stake_vault`, `auto_trade`, `signal_registry`).