### PR TITLE
Cap unstake queue size in stake_vault to prevent DoS

### DIFF
--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -62,6 +62,10 @@ const LARGE_WITHDRAWAL_TIMELOCK_SECS: u64 = 3_600;
 /// Set to SILVER tier (500M = 5 * 10^8 stroops).
 const LARGE_WITHDRAWAL_THRESHOLD: i128 = 500_000_000;
 
+/// Default cap on the number of pending entries in the unstake queue (issue #786).
+/// Bounds instance storage growth and per-call compute cost of `queue_unstake`.
+const DEFAULT_MAX_UNSTAKE_QUEUE_SIZE: u32 = 200;
+
 pub const GOLD_TIER_STAKE: i128 = 1_000_000_000;
 pub const SILVER_TIER_STAKE: i128 = GOLD_TIER_STAKE / 2;
 pub const BRONZE_TIER_STAKE: i128 = GOLD_TIER_STAKE / 10;
@@ -140,6 +144,8 @@ pub enum StorageKey {
     UnstakeQueueEntry(u64),
     /// Ticket number assigned to a queued user (for position lookup).
     UserUnstakeTicket(Address),
+    /// Admin-configurable cap on unstake queue length (issue #786, default 200).
+    MaxUnstakeQueueSize,
     // ── Issue #754: Multi-sig emergency early-unstake ──────────────────────────
     /// N-of-M multi-sig configuration for emergency early unstakes.
     EmergencyMultiSigConfig,
@@ -213,6 +219,8 @@ pub enum StakeVaultError {
     RateLimitExceeded = 31,
     InvalidAmount = 32,
     RemainingStakeBelowMinimum = 33,
+    /// Unstake queue is at or above its configured maximum size (issue #786).
+    QueueFull = 34,
 }
 
 /// A pending unstake request held in the FIFO queue (issue #663).
@@ -1890,6 +1898,15 @@ impl StakeVaultContract {
             .get(&StorageKey::UnstakeQueueHead)
             .unwrap_or(0);
 
+        let max_queue_size: u32 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::MaxUnstakeQueueSize)
+            .unwrap_or(DEFAULT_MAX_UNSTAKE_QUEUE_SIZE);
+        if tail.saturating_sub(head) >= max_queue_size as u64 {
+            return Err(StakeVaultError::QueueFull);
+        }
+
         let ticket = tail;
         let queue_position = tail.saturating_sub(head);
 
@@ -1921,12 +1938,54 @@ impl StakeVaultContract {
         Ok(ticket)
     }
 
+    /// Sets the maximum number of pending entries allowed in the unstake queue.
+    ///
+    /// Admin-only. Lowering the cap below the current queue length does not
+    /// affect already-queued entries; it only blocks new `queue_unstake` calls
+    /// until the queue drains back under the new cap. Emits `queue_size_updated`.
+    pub fn set_max_unstake_queue_size(env: Env, size: u32) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(StakeVaultError::NotInitialized)?;
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&StorageKey::MaxUnstakeQueueSize, &size);
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                Symbol::new(&env, "stake_vault"),
+                Symbol::new(&env, "queue_size_updated"),
+            ),
+            (size,),
+        );
+        Ok(())
+    }
+
+    /// Returns the configured maximum unstake queue length (defaults to 200).
+    pub fn get_max_unstake_queue_size(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&StorageKey::MaxUnstakeQueueSize)
+            .unwrap_or(DEFAULT_MAX_UNSTAKE_QUEUE_SIZE)
+    }
+
     /// Process up to `limit` queued unstake requests in FIFO order.
     ///
     /// Requests are processed from the queue head. A request that fails (e.g.
     /// due to a time-lock or locked stake) is left at the head; processing stops
     /// so strict FIFO ordering is preserved. The caller should retry later once
     /// the blocking condition is resolved.
+    ///
+    /// Recommended invocation frequency: call at least as often as the queue
+    /// approaches `MaxUnstakeQueueSize` (e.g. keyed off `unstake_queued` events
+    /// or periodic polling of `get_queue_position`), since `queue_unstake` starts
+    /// rejecting new entries once the queue is at or above the configured cap.
     ///
     /// Returns the number of requests successfully processed.
     pub fn process_unstake_queue(env: Env, limit: u32) -> Result<u32, StakeVaultError> {

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -2168,3 +2168,129 @@ mod slash_appeal_tests {
         assert_eq!(client.get_minimum_stake(), 1_000_000);
     }
 }
+
+// ── Issue #786: Unstake queue size cap ──────────────────────────────────────────
+
+mod unstake_queue_cap_tests {
+    use crate::{
+        migration::{MigrationKey, StakeInfoV2},
+        StakeVaultContract, StakeVaultContractClient, StakeVaultError,
+    };
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Map};
+
+    fn sac_token(env: &Env, admin: &Address) -> Address {
+        env.register_stellar_asset_contract_v2(admin.clone())
+            .address()
+    }
+
+    fn seed(env: &Env, contract_id: &Address, staker: &Address, balance: i128) {
+        env.as_contract(contract_id, || {
+            let mut stakes: Map<Address, StakeInfoV2> = env
+                .storage()
+                .persistent()
+                .get(&MigrationKey::StakesV2)
+                .unwrap_or_else(|| Map::new(env));
+            stakes.set(
+                staker.clone(),
+                StakeInfoV2 {
+                    balance,
+                    locked_until: 0,
+                    last_updated: env.ledger().timestamp(),
+                },
+            );
+            env.storage()
+                .persistent()
+                .set(&MigrationKey::StakesV2, &stakes);
+        });
+    }
+
+    fn setup() -> (Env, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let signal_registry = Address::generate(&env);
+        let token = sac_token(&env, &admin);
+        let vault_id = env.register(StakeVaultContract, ());
+        StakeVaultContractClient::new(&env, &vault_id).initialize(&admin, &token, &signal_registry);
+        (env, vault_id, token, admin, signal_registry)
+    }
+
+    #[test]
+    fn default_max_queue_size_is_two_hundred() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(client.get_max_unstake_queue_size(), 200);
+    }
+
+    #[test]
+    fn enqueue_below_cap_succeeds() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        client.set_max_unstake_queue_size(&2);
+
+        let staker_a = Address::generate(&env);
+        let staker_b = Address::generate(&env);
+        seed(&env, &vault_id, &staker_a, 1_000_000);
+        seed(&env, &vault_id, &staker_b, 1_000_000);
+
+        assert_eq!(client.queue_unstake(&staker_a), 0);
+        assert_eq!(client.queue_unstake(&staker_b), 1);
+    }
+
+    #[test]
+    fn enqueue_at_cap_is_rejected() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        client.set_max_unstake_queue_size(&2);
+
+        let staker_a = Address::generate(&env);
+        let staker_b = Address::generate(&env);
+        let staker_c = Address::generate(&env);
+        seed(&env, &vault_id, &staker_a, 1_000_000);
+        seed(&env, &vault_id, &staker_b, 1_000_000);
+        seed(&env, &vault_id, &staker_c, 1_000_000);
+
+        client.queue_unstake(&staker_a);
+        client.queue_unstake(&staker_b);
+
+        // Queue is now at the cap (2 entries) — the next enqueue must be rejected.
+        let result = client.try_queue_unstake(&staker_c);
+        assert_eq!(result, Err(Ok(StakeVaultError::QueueFull)));
+    }
+
+    #[test]
+    fn lowering_cap_below_current_length_keeps_existing_entries_but_blocks_new_ones() {
+        let (env, vault_id, token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        client.set_max_unstake_queue_size(&5);
+
+        let staker_a = Address::generate(&env);
+        let staker_b = Address::generate(&env);
+        let staker_c = Address::generate(&env);
+        seed(&env, &vault_id, &staker_a, 1_000_000);
+        seed(&env, &vault_id, &staker_b, 1_000_000);
+        seed(&env, &vault_id, &staker_c, 1_000_000);
+
+        client.queue_unstake(&staker_a);
+        client.queue_unstake(&staker_b);
+        client.queue_unstake(&staker_c);
+
+        // Lower the cap below the current queue length (3).
+        client.set_max_unstake_queue_size(&2);
+
+        // Existing entries are untouched — positions still resolve correctly.
+        assert_eq!(client.get_queue_position(&staker_a), Some(0));
+        assert_eq!(client.get_queue_position(&staker_b), Some(1));
+        assert_eq!(client.get_queue_position(&staker_c), Some(2));
+
+        // A brand-new enqueue is rejected while the queue sits above the new cap.
+        let staker_d = Address::generate(&env);
+        seed(&env, &vault_id, &staker_d, 1_000_000);
+        let result = client.try_queue_unstake(&staker_d);
+        assert_eq!(result, Err(Ok(StakeVaultError::QueueFull)));
+
+        // The existing entries still process normally despite being over the new cap.
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &3_000_000);
+        assert_eq!(client.process_unstake_queue(&3), 3);
+    }
+}


### PR DESCRIPTION
## Summary

`queue_unstake` in `stake_vault/src/lib.rs` had no upper bound on the FIFO unstake queue. An attacker could call it repeatedly with tiny amounts to grow instance storage past Soroban's 64KB limit, permanently bricking `process_unstake_queue` for every user and exhausting the per-transaction compute budget during processing.

This adds an admin-configurable cap on the queue length:
- `MaxUnstakeQueueSize` storage key, default **200** entries.
- `queue_unstake` now returns the new `StakeVaultError::QueueFull` once the queue is at or above the cap.
- `set_max_unstake_queue_size(size: u32)` — admin-only (respects the existing multisig gate), emits a `queue_size_updated` event with the new size.
- `get_max_unstake_queue_size()` — read-only accessor.
- Extended the `process_unstake_queue` doc comment with guidance on invocation frequency relative to queue depth.

## Context / behavior

- Before: `queue_unstake` always succeeded for any staker with a positive balance, regardless of queue length.
- After: once `tail - head >= MaxUnstakeQueueSize`, `queue_unstake` panics with `QueueFull` instead of writing another entry. Lowering the cap below the current queue length does not touch already-queued entries — it only blocks new enqueues until the queue drains back under the cap (verified by a dedicated test).

## Testing

Added `unstake_queue_cap_tests` in `stake_vault/src/tests.rs` covering the issue's acceptance criteria:
- enqueue below cap succeeds
- enqueue exactly at cap is rejected with `QueueFull`
- lowering the cap below the current queue length leaves existing entries intact (positions still resolve, they still process via `process_unstake_queue`) while rejecting new enqueues
- default cap reads back as 200

Ran the full crate suite: `cargo test -p stake_vault` — all tests pass except two pre-existing failures in `slash_appeal_tests` (`appeal_slash_emits_slash_appealed_event`, `resolve_appeal_reverse_emits_appeal_resolved_event`) that are already failing on `main` prior to this change (verified via `git stash` against a clean checkout) and are unrelated to this fix.

Closes #786