### PR TITLE
stake_vault: route resolve_appeal through multisig approval

### DIFF
--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -286,6 +286,9 @@ mod action {
     pub const SET_MINIMUM_STAKE_DURATION: u8 = 3;
     pub const CONFIGURE_SLASH_TIERS: u8 = 4;
     pub const SET_APPEAL_WINDOW: u8 = 5;
+    /// Issue #818: resolving a slash appeal burns or restores real funds and
+    /// must be routed through multi-sig like every other sensitive admin action.
+    pub const RESOLVE_APPEAL: u8 = 6;
 }
 
 fn encode_action(env: &Env, tag: u8, data: &[u8]) -> Bytes {
@@ -748,6 +751,17 @@ impl StakeVaultContract {
                     .instance()
                     .set(&StorageKey::AppealWindowSecs, &window);
             }
+            action::RESOLVE_APPEAL => {
+                let mut buf = [0u8; 8];
+                let mut i = 0;
+                while i < 8 {
+                    buf[i] = payload.get(1 + i as u32).unwrap_or(0);
+                    i += 1;
+                }
+                let slash_id = u64::from_le_bytes(buf);
+                let uphold = payload.get(9).unwrap_or(0) != 0;
+                Self::do_resolve_appeal(&env, slash_id, uphold)?;
+            }
             _ => return Err(StakeVaultError::Unauthorized),
         }
 
@@ -764,6 +778,107 @@ impl StakeVaultContract {
 
     fn do_unpause(env: &Env) -> Result<(), StakeVaultError> {
         pausable::set_paused(env, false);
+        Ok(())
+    }
+
+    /// Core slash-appeal resolution logic, shared by the single-admin
+    /// `resolve_appeal` entrypoint (used when no multi-sig config is set)
+    /// and the multi-sig `execute_action` dispatch (used once one is).
+    fn do_resolve_appeal(env: &Env, slash_id: u64, uphold: bool) -> Result<(), StakeVaultError> {
+        // Load slash record.
+        let record: SlashRecord = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::SlashRecord(slash_id))
+            .ok_or(StakeVaultError::SlashNotFound)?;
+
+        // Load appeal record.
+        let mut appeal: SlashAppeal = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::SlashAppeal(slash_id))
+            .ok_or(StakeVaultError::SlashNotFound)?;
+
+        if appeal.status != AppealStatus::Pending {
+            return Err(StakeVaultError::AppealAlreadyResolved);
+        }
+
+        // Retrieve held funds (only present when an appeal window is configured
+        // and the slash_stake did not burn immediately).
+        let held: i128 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::SlashedFundsHeld(slash_id))
+            .unwrap_or(0);
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::StakeToken)
+            .ok_or(StakeVaultError::NotInitialized)?;
+
+        if uphold {
+            appeal.status = AppealStatus::Upheld;
+            // Slash confirmed — burn the held funds now.
+            if held > 0 {
+                env.storage()
+                    .persistent()
+                    .remove(&StorageKey::SlashedFundsHeld(slash_id));
+                token::Client::new(env, &token).burn(&env.current_contract_address(), &held);
+            }
+        } else {
+            // Reversed — tokens are still in the vault; credit provider's stake.
+            appeal.status = AppealStatus::Reversed;
+
+            let amount_to_restore = if held > 0 { held } else { record.slash_amount };
+
+            let mut stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
+                .storage()
+                .persistent()
+                .get(&MigrationKey::StakesV2)
+                .unwrap_or_else(|| soroban_sdk::Map::new(env));
+
+            let current_info = stakes.get(record.provider.clone()).unwrap_or(StakeInfoV2 {
+                balance: 0,
+                locked_until: 0,
+                last_updated: 0,
+            });
+
+            let restored_balance = current_info.balance.saturating_add(amount_to_restore);
+            let now = env.ledger().timestamp();
+
+            stakes.set(
+                record.provider.clone(),
+                StakeInfoV2 {
+                    balance: restored_balance,
+                    locked_until: current_info.locked_until,
+                    last_updated: now,
+                },
+            );
+            env.storage()
+                .persistent()
+                .set(&MigrationKey::StakesV2, &stakes);
+
+            if held > 0 {
+                env.storage()
+                    .persistent()
+                    .remove(&StorageKey::SlashedFundsHeld(slash_id));
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&StorageKey::SlashAppeal(slash_id), &appeal);
+
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                Symbol::new(env, "stake_vault"),
+                Symbol::new(env, "appeal_resolved"),
+            ),
+            (slash_id, uphold, record.provider),
+        );
+
         Ok(())
     }
 
@@ -1562,7 +1677,19 @@ impl StakeVaultContract {
     ///
     /// Resolving an appeal that does not exist or has already been resolved
     /// returns an error.
+    ///
+    /// Resolution determines whether slashed funds are burned or returned to
+    /// the provider, so — like every other privileged mutation in this
+    /// contract — it must be routed through multi-sig approval
+    /// (`propose_action` / `approve_action` / `execute_action` with
+    /// [`action::RESOLVE_APPEAL`]) once a multi-sig config is set. See issue
+    /// #818: this entrypoint previously stayed admin-only even after
+    /// `set_multisig_config` was configured, letting a single admin key
+    /// bypass the approval flow that every sibling admin entrypoint enforces.
     pub fn resolve_appeal(env: Env, slash_id: u64, uphold: bool) -> Result<(), StakeVaultError> {
+        if multisig::get_config(&env).is_some() {
+            return Err(StakeVaultError::RequiresMultisig);
+        }
         let admin: Address = env
             .storage()
             .instance()
@@ -1570,101 +1697,7 @@ impl StakeVaultContract {
             .ok_or(StakeVaultError::NotInitialized)?;
         admin.require_auth();
 
-        // Load slash record.
-        let record: SlashRecord = env
-            .storage()
-            .persistent()
-            .get(&StorageKey::SlashRecord(slash_id))
-            .ok_or(StakeVaultError::SlashNotFound)?;
-
-        // Load appeal record.
-        let mut appeal: SlashAppeal = env
-            .storage()
-            .persistent()
-            .get(&StorageKey::SlashAppeal(slash_id))
-            .ok_or(StakeVaultError::SlashNotFound)?;
-
-        if appeal.status != AppealStatus::Pending {
-            return Err(StakeVaultError::AppealAlreadyResolved);
-        }
-
-        // Retrieve held funds (only present when an appeal window is configured
-        // and the slash_stake did not burn immediately).
-        let held: i128 = env
-            .storage()
-            .persistent()
-            .get(&StorageKey::SlashedFundsHeld(slash_id))
-            .unwrap_or(0);
-
-        let token: Address = env
-            .storage()
-            .instance()
-            .get(&StorageKey::StakeToken)
-            .ok_or(StakeVaultError::NotInitialized)?;
-
-        if uphold {
-            appeal.status = AppealStatus::Upheld;
-            // Slash confirmed — burn the held funds now.
-            if held > 0 {
-                env.storage()
-                    .persistent()
-                    .remove(&StorageKey::SlashedFundsHeld(slash_id));
-                token::Client::new(&env, &token).burn(&env.current_contract_address(), &held);
-            }
-        } else {
-            // Reversed — tokens are still in the vault; credit provider's stake.
-            appeal.status = AppealStatus::Reversed;
-
-            let amount_to_restore = if held > 0 { held } else { record.slash_amount };
-
-            let mut stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
-                .storage()
-                .persistent()
-                .get(&MigrationKey::StakesV2)
-                .unwrap_or_else(|| soroban_sdk::Map::new(&env));
-
-            let current_info = stakes.get(record.provider.clone()).unwrap_or(StakeInfoV2 {
-                balance: 0,
-                locked_until: 0,
-                last_updated: 0,
-            });
-
-            let restored_balance = current_info.balance.saturating_add(amount_to_restore);
-            let now = env.ledger().timestamp();
-
-            stakes.set(
-                record.provider.clone(),
-                StakeInfoV2 {
-                    balance: restored_balance,
-                    locked_until: current_info.locked_until,
-                    last_updated: now,
-                },
-            );
-            env.storage()
-                .persistent()
-                .set(&MigrationKey::StakesV2, &stakes);
-
-            if held > 0 {
-                env.storage()
-                    .persistent()
-                    .remove(&StorageKey::SlashedFundsHeld(slash_id));
-            }
-        }
-
-        env.storage()
-            .persistent()
-            .set(&StorageKey::SlashAppeal(slash_id), &appeal);
-
-        #[allow(deprecated)]
-        env.events().publish(
-            (
-                Symbol::new(&env, "stake_vault"),
-                Symbol::new(&env, "appeal_resolved"),
-            ),
-            (slash_id, uphold, record.provider),
-        );
-
-        Ok(())
+        Self::do_resolve_appeal(&env, slash_id, uphold)
     }
 
     /// Returns the [`SlashRecord`] for the given `slash_id`, or `None`.

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -2167,4 +2167,135 @@ mod slash_appeal_tests {
         client.set_minimum_stake(&1_000_000i128);
         assert_eq!(client.get_minimum_stake(), 1_000_000);
     }
+
+    // ── Issue #818: resolve_appeal must go through multi-sig ──────────────────
+    //
+    // Prior to this fix, `resolve_appeal` was the only privileged mutation in
+    // this contract that stayed admin-only even after `set_multisig_config`
+    // was set: it decides whether slashed funds are burned or restored, yet
+    // it skipped the `multisig::get_config(...).is_some()` guard every
+    // sibling entrypoint (pause, unpause, set_minimum_stake,
+    // set_minimum_stake_duration, configure_slash_tiers, set_appeal_window)
+    // enforces, and had no corresponding `action::*` tag wired into
+    // `execute_action`. A single admin key could therefore bypass approval
+    // entirely for a fund-moving decision.
+
+    /// Sets up a slash with a pending appeal, then enables multi-sig.
+    /// Returns (env, vault_id, provider, initial_balance, signers).
+    fn resolve_appeal_multisig_setup() -> (Env, Address, Address, i128, Vec<Address>) {
+        let (env, vault_id, token, admin, signal_registry) = setup();
+        let provider = Address::generate(&env);
+        let initial: i128 = 1_000_000;
+
+        StellarAssetClient::new(&env, &token).mint(&vault_id, &initial);
+        seed(&env, &vault_id, &provider, initial);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        // Appeal window must be configured while still in single-admin mode.
+        client.set_appeal_window(&86_400u64);
+
+        client.slash_stake(
+            &signal_registry,
+            &provider,
+            &SlashSeverity::Minor,
+            &Symbol::new(&env, "violation"),
+        );
+        client.appeal_slash(
+            &provider,
+            &0u64,
+            &String::from_str(&env, "ipfs://Qm_evidence"),
+        );
+
+        // Now enable multi-sig — resolve_appeal must be gated from here on.
+        let signer_a = Address::generate(&env);
+        let signer_b = Address::generate(&env);
+        let signer_c = Address::generate(&env);
+        let signers = soroban_sdk::vec![&env, signer_a, signer_b, signer_c];
+        let cfg = MultisigConfig {
+            signers: signers.clone(),
+            threshold: 2,
+            proposal_timeout_secs: 86_400,
+        };
+        client.set_multisig_config(&admin, &Some(cfg));
+
+        (env, vault_id, provider, initial, signers)
+    }
+
+    fn encode_resolve_appeal_payload(env: &Env, slash_id: u64, uphold: bool) -> Bytes {
+        let mut data = [0u8; 9];
+        data[0..8].copy_from_slice(&slash_id.to_le_bytes());
+        data[8] = if uphold { 1 } else { 0 };
+        encode_action(env, action::RESOLVE_APPEAL, &data)
+    }
+
+    #[test]
+    fn resolve_appeal_returns_requires_multisig_when_configured() {
+        let (env, vault_id, _provider, _initial, _signers) = resolve_appeal_multisig_setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        // Direct admin call must now be rejected — this is the gap being fixed.
+        let result = client.try_resolve_appeal(&0u64, &true);
+        assert_eq!(result, Err(Ok(StakeVaultError::RequiresMultisig)));
+    }
+
+    #[test]
+    fn execute_resolve_appeal_before_threshold_rejected() {
+        let (env, vault_id, _provider, _initial, signers) = resolve_appeal_multisig_setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        let payload = encode_resolve_appeal_payload(&env, 0u64, false);
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+
+        // Only 1 approval (the proposer's); threshold is 2.
+        let result = client.try_execute_action(&signers.get(0).unwrap(), &id);
+        assert_eq!(result, Err(Ok(StakeVaultError::Unauthorized)));
+
+        // Appeal must remain untouched while the proposal is unresolved.
+        let appeal = client.get_slash_appeal(&0u64).unwrap();
+        assert_eq!(appeal.status, AppealStatus::Pending);
+    }
+
+    #[test]
+    fn propose_approve_execute_resolve_appeal_restores_stake_after_threshold() {
+        let (env, vault_id, provider, initial, signers) = resolve_appeal_multisig_setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        // Minor severity slashed 5 % (50_000); reversal must restore it in full.
+        assert_eq!(client.get_stake(&provider), initial - 50_000);
+
+        let payload = encode_resolve_appeal_payload(&env, 0u64, false);
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        let count = client.approve_action(&signers.get(1).unwrap(), &id);
+        assert_eq!(count, 2);
+
+        client.execute_action(&signers.get(0).unwrap(), &id);
+
+        assert_eq!(
+            client.get_stake(&provider),
+            initial,
+            "stake must be fully restored once the multisig-approved reversal executes"
+        );
+        let appeal = client.get_slash_appeal(&0u64).unwrap();
+        assert_eq!(appeal.status, AppealStatus::Reversed);
+
+        // Re-executing the same proposal must fail (already-executed guard).
+        let result = client.try_execute_action(&signers.get(0).unwrap(), &id);
+        assert_eq!(result, Err(Ok(StakeVaultError::EmergencyRequestNotFound)));
+    }
+
+    #[test]
+    fn propose_approve_execute_resolve_appeal_uphold_burns_funds() {
+        let (env, vault_id, provider, initial, signers) = resolve_appeal_multisig_setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        let payload = encode_resolve_appeal_payload(&env, 0u64, true);
+        let id = client.propose_action(&signers.get(0).unwrap(), &payload);
+        let _ = client.approve_action(&signers.get(1).unwrap(), &id);
+        client.execute_action(&signers.get(0).unwrap(), &id);
+
+        let appeal = client.get_slash_appeal(&0u64).unwrap();
+        assert_eq!(appeal.status, AppealStatus::Upheld);
+        // Provider's stake stays reduced by the slash (funds were burned, not restored).
+        assert_eq!(client.get_stake(&provider), initial - 50_000);
+    }
 }


### PR DESCRIPTION
Closes #818

## Summary

Issue #818 asks for the multisig approval flow to be hardened so admin-sensitive actions can't bypass it. This PR fixes one concrete gap in `stake_vault`: `resolve_appeal` — the entrypoint that decides whether a slashed provider's funds are burned or restored — was the only privileged mutation in the contract that stayed admin-only even after `set_multisig_config` was enabled.

This is a scoped fix for that one entrypoint, not a rewrite of the multisig system.

## The gap (before/after)

`stake_vault/src/lib.rs` already has a consistent pattern: every sensitive admin entrypoint (`pause`, `unpause`, `set_minimum_stake`, `set_minimum_stake_duration`, `configure_slash_tiers`, `set_appeal_window`) checks `multisig::get_config(&env).is_some()` and returns `StakeVaultError::RequiresMultisig` when multisig is configured, forcing the caller through `propose_action` / `approve_action` / `execute_action`. Each of those actions also has a tag in the `action` module and a matching arm in `execute_action`.

`resolve_appeal` was missing from both:
- It had no `multisig::get_config(...)` guard, so a single admin key could call it directly and burn or restore funds even with multisig enabled and a threshold configured.
- There was no `action::RESOLVE_APPEAL` tag and no arm in `execute_action`'s dispatch, so there was no way to route it through the approval flow even if you wanted to.

**Before:** with multisig configured (threshold 2 of 3), a single admin call to `resolve_appeal(slash_id, uphold)` succeeded and immediately burned or restored funds — no second approval required.

**After:** `resolve_appeal` now returns `StakeVaultError::RequiresMultisig` once multisig is configured. Resolving an appeal must go through `propose_action` → `approve_action` (until threshold is met) → `execute_action` with the new `action::RESOLVE_APPEAL` tag, which decodes `(slash_id: u64, uphold: bool)` from the payload and calls the same resolution logic (extracted into a shared `do_resolve_appeal` helper so both code paths behave identically and are auditable in one place).

## Testing

Added to `stake_vault/src/tests.rs` (`tests::slash_appeal_tests` module):
- `resolve_appeal_returns_requires_multisig_when_configured` — direct admin call is now rejected once multisig is configured (proves the bypass is closed).
- `execute_resolve_appeal_before_threshold_rejected` — executing before the approval threshold is met is rejected and the appeal stays `Pending`.
- `propose_approve_execute_resolve_appeal_restores_stake_after_threshold` — full propose/approve/execute flow reverses a slash and restores the provider's stake only after 2-of-3 approval; re-executing the same proposal is rejected.
- `propose_approve_execute_resolve_appeal_uphold_burns_funds` — same flow for the uphold branch (funds stay burned, stake stays reduced).

Command run:
```
cargo test -p stake_vault
```
Result: 96 passed, 2 failed. The 2 failures (`appeal_slash_emits_slash_appealed_event`, `resolve_appeal_reverse_emits_appeal_resolved_event`) are pre-existing on `main` — verified by stashing this change and re-running the same two tests against unmodified `main`, where they fail identically. They are unrelated to this change (event-assertion issue, not multisig-related) and are not touched by this PR.

Also ran `cargo build -p stake_vault` — succeeds with no warnings/errors introduced.

## Scope note

This does not audit or change every contract in the repo. It fixes the one concrete, verifiable bypass found in `stake_vault::resolve_appeal`. `pause`, `unpause`, `set_minimum_stake`, `set_minimum_stake_duration`, `configure_slash_tiers`, and `set_appeal_window` in the same contract already enforced multisig correctly and were used as the reference pattern for this fix.