### PR TITLE
fix(fee_collector): wire shared circuit-breaker pause into fund-moving entry points

### DIFF
--- a/stellar-swipe/contracts/fee_collector/src/errors.rs
+++ b/stellar-swipe/contracts/fee_collector/src/errors.rs
@@ -30,4 +30,7 @@ pub enum ContractError {
     InvalidMultiplierBounds = 24,
     SelfReferralNotAllowed = 25,
     ReferralAlreadyRegistered = 26,
+    /// The contract is paused (see `shared::pausable`); privileged and
+    /// fund-moving entry points reject calls until an admin resumes it.
+    ContractPaused = 27,
 }

--- a/stellar-swipe/contracts/fee_collector/src/lib.rs
+++ b/stellar-swipe/contracts/fee_collector/src/lib.rs
@@ -55,6 +55,7 @@ use soroban_sdk::{
 };
 
 use shared::errors::{ErrorCategory, RecoveryStrategy};
+use shared::pausable;
 use stellar_swipe_common::Asset;
 use stellar_swipe_common::SECONDS_PER_DAY;
 
@@ -153,6 +154,49 @@ impl FeeCollector {
         set_admin(&env, &admin);
         set_initialized(&env);
         Ok(())
+    }
+
+    // ── Emergency pause (shared::pausable, Issue #821) ───────────────────────
+    //
+    // fee_collector moves real funds on `collect_fee`, `batch_collect_fees`,
+    // `claim_fees`, `queue_withdrawal`, `withdraw_treasury_fees` and
+    // `distribute_waterfall`. Before this change none of those entry points
+    // consulted `shared::pausable`, so a protocol-wide emergency pause (as
+    // used by stake_vault, signal_registry, oracle, governance and
+    // auto_trade) left fee_collector fully operational — an inconsistency
+    // with the circuit-breaker guarantee described in issue #821.
+
+    /// Pause fund-moving operations. Admin auth required.
+    pub fn pause(env: Env) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+        pausable::set_paused(&env, true);
+        Ok(())
+    }
+
+    /// Resume fund-moving operations. Admin auth required.
+    pub fn unpause(env: Env) -> Result<(), ContractError> {
+        if !is_initialized(&env) {
+            return Err(ContractError::NotInitialized);
+        }
+        let admin = get_admin(&env);
+        admin.require_auth();
+        pausable::set_paused(&env, false);
+        Ok(())
+    }
+
+    /// Returns `true` when the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        pausable::is_paused(&env)
+    }
+
+    /// Guard used by fund-moving entry points; translates the shared
+    /// sentinel error into [`ContractError::ContractPaused`].
+    fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+        pausable::require_not_paused(env).map_err(|_| ContractError::ContractPaused)
     }
 
     /// # Summary
@@ -305,6 +349,7 @@ impl FeeCollector {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
+        Self::require_not_paused(&env)?;
         let admin = get_admin(&env);
         admin.require_auth();
         if amount <= 0 {
@@ -365,6 +410,7 @@ impl FeeCollector {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
+        Self::require_not_paused(&env)?;
         let admin = get_admin(&env);
         admin.require_auth();
 
@@ -770,6 +816,7 @@ impl FeeCollector {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
+        Self::require_not_paused(&env)?;
         trader.require_auth();
 
         if trade_amount <= 0 {
@@ -953,6 +1000,7 @@ impl FeeCollector {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
+        Self::require_not_paused(&env)?;
         let mut auth_args: Vec<Val> = Vec::new(&env);
         auth_args.push_back(provider.clone().into_val(&env));
         auth_args.push_back(token.clone().into_val(&env));
@@ -1258,6 +1306,7 @@ impl FeeCollector {
         if !is_initialized(&env) {
             return Err(ContractError::NotInitialized);
         }
+        Self::require_not_paused(&env)?;
         let admin = get_admin(&env);
         admin.require_auth();
 

--- a/stellar-swipe/contracts/fee_collector/src/test.rs
+++ b/stellar-swipe/contracts/fee_collector/src/test.rs
@@ -1586,3 +1586,172 @@ fn test_congestion_bounded() {
     let result = client.try_set_congestion_signal(&60_000u32);
     assert_eq!(result, Err(Ok(ContractError::InvalidMultiplierBounds)));
 }
+
+// ---------------------------------------------------------------------------
+// Emergency pause / circuit breaker (Issue #821)
+//
+// fee_collector previously had no connection to `shared::pausable` at all,
+// so an admin pausing the protocol during an incident could not stop
+// fee_collector from continuing to move funds via `collect_fee`,
+// `claim_fees` and `withdraw_treasury_fees` while every other contract
+// (stake_vault, signal_registry, oracle, governance, auto_trade) obeyed the
+// shared pause flag. These tests prove the gap is closed for the
+// fund-moving entry points and that normal operation resumes after unpause.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fresh_contract_is_not_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_pause_blocks_withdraw_treasury_fees_then_unpause_allows_it() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (recipient, token, _contract_id, client) = setup(&env, 1000i128);
+
+    env.ledger().set_timestamp(0);
+    client.queue_withdrawal(&recipient, &token, &1000i128);
+    env.ledger().set_timestamp(86400);
+
+    // Admin pauses the contract (shared circuit breaker).
+    client.pause();
+    assert!(client.is_paused());
+
+    // Before the fix this call would have succeeded even while paused.
+    let result = client.try_withdraw_treasury_fees(&recipient, &token, &1000i128);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::ContractPaused)),
+        "paused contract must reject withdraw_treasury_fees with a clear error"
+    );
+    assert_eq!(client.treasury_balance(&token), 1000i128, "no funds should move while paused");
+
+    // Resume: the previously queued withdrawal succeeds again.
+    client.unpause();
+    assert!(!client.is_paused());
+    client.withdraw_treasury_fees(&recipient, &token, &1000i128);
+    assert_eq!(client.treasury_balance(&token), 0i128);
+    assert_eq!(TokenClient::new(&env, &token).balance(&recipient), 1000i128);
+}
+
+#[test]
+fn test_pause_blocks_queue_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (recipient, token, _contract_id, client) = setup(&env, 1000i128);
+
+    client.pause();
+    let result = client.try_queue_withdrawal(&recipient, &token, &1000i128);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+
+    client.unpause();
+    client.queue_withdrawal(&recipient, &token, &1000i128);
+}
+
+#[test]
+fn test_pause_blocks_collect_fee_then_unpause_allows_it() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let trader = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let (oracle_id, asset) = setup_oracle(&env, 10_000_000);
+    client.set_oracle_contract(&oracle_id);
+
+    StellarAssetClient::new(&env, &token).mint(&trader, &(2_000 * 10_000_000));
+    mark_trader_has_traded(&env, &contract_id, &trader);
+
+    client.pause();
+    let result = client.try_collect_fee(&trader, &token, &(1_000 * 10_000_000), &asset);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::ContractPaused)),
+        "paused contract must reject collect_fee with a clear error"
+    );
+
+    client.unpause();
+    let fee = client.collect_fee(&trader, &token, &(1_000 * 10_000_000), &asset);
+    assert!(fee > 0, "collect_fee must work normally again after unpause");
+}
+
+#[test]
+fn test_pause_blocks_claim_fees_then_unpause_allows_it() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let amount: i128 = 1_000_000;
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    StellarAssetClient::new(&env, &token_id).mint(&contract_id, &amount);
+    env.as_contract(&contract_id, || {
+        set_pending_fees(&env, &provider, &token_id, amount);
+    });
+
+    client.pause();
+    let result = client.try_claim_fees(&provider, &token_id);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+
+    client.unpause();
+    let claimed = client.claim_fees(&provider, &token_id);
+    assert_eq!(claimed, amount);
+}
+
+#[test]
+fn test_pause_requires_admin_auth() {
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+    use soroban_sdk::IntoVal;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(FeeCollector, ());
+    let client = FeeCollectorClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let non_admin = Address::generate(&env);
+    let sub_invokes: &[MockAuthInvoke] = &[];
+    let mock_invoke = MockAuthInvoke {
+        contract: &contract_id,
+        fn_name: "pause",
+        args: ().into_val(&env),
+        sub_invokes,
+    };
+    let mock_auth = MockAuth {
+        address: &non_admin,
+        invoke: &mock_invoke,
+    };
+    let result = client.mock_auths(&[mock_auth]).try_pause();
+    assert!(result.is_err(), "non-admin must not be able to pause");
+    assert!(!client.is_paused());
+}


### PR DESCRIPTION
Closes #821

## Summary

Issue #821 asks for consistent circuit-breaker/pause semantics across all contracts. This PR fixes **one concrete gap**, not full cross-contract consistency — reviewers should treat this as a targeted fix, not a claim that every contract now behaves identically under pause.

`contracts/shared/src/pausable.rs` already defines the canonical pause primitive (`is_paused` / `set_paused` / `require_not_paused`), and `stake_vault`, `signal_registry`, `oracle`, `governance`, and `auto_trade` all already gate their privileged/fund-moving entry points on it. `fee_collector`, however, had **zero** references to pause/emergency anywhere in its crate — despite already depending on the `shared` crate — even though it moves real funds via `collect_fee`, `batch_collect_fees`, `claim_fees`, `queue_withdrawal`, `withdraw_treasury_fees`, and `distribute_waterfall`. An admin pausing the protocol during an incident had no way to stop `fee_collector` from continuing to collect fees, pay out provider claims, or execute treasury withdrawals, while every other contract obeyed the pause flag — exactly the inconsistency the issue describes.

## What changed

- Added `FeeCollector::pause` / `unpause` / `is_paused` admin-gated entry points backed by `shared::pausable::{set_paused, is_paused}`, mirroring the existing `stake_vault` pattern.
- Added `ContractError::ContractPaused` (fee_collector's own error enum, consistent with how other contracts surface the shared pause sentinel).
- Added a `require_not_paused` guard and wired it into fee_collector's fund-moving entry points:
  - `collect_fee_with_recovery` — the shared internal path used by `collect_fee`, `batch_collect_fees`, and `retry_failed_fee_collection`, so all three are covered.
  - `claim_fees`
  - `queue_withdrawal`
  - `withdraw_treasury_fees`
  - `distribute_waterfall`

Not touched (explicitly out of scope for this fix): pure config/admin setters that don't move funds (`set_fee_rate`, `set_burn_rate`, `set_congestion_config`, etc.) and other contracts' pause implementations — those weren't part of the identified gap.

## Before / after behavior

- **Before:** with the protocol paused via any other contract's `pause()`, `fee_collector.claim_fees(...)`, `fee_collector.collect_fee(...)`, and `fee_collector.withdraw_treasury_fees(...)` all still succeeded and moved funds — there was no way to stop them.
- **After:** once `fee_collector.pause()` is called by the admin, those same calls return `Err(ContractError::ContractPaused)` and no tokens move. Calling `fee_collector.unpause()` restores normal behavior — previously queued withdrawals still execute, `collect_fee` and `claim_fees` work again.

## Testing

Added integration tests in `contracts/fee_collector/src/test.rs` proving the pause → reject → resume → succeed flow for each gated entry point, plus an auth check:

- `test_fresh_contract_is_not_paused`
- `test_pause_blocks_withdraw_treasury_fees_then_unpause_allows_it`
- `test_pause_blocks_queue_withdrawal`
- `test_pause_blocks_collect_fee_then_unpause_allows_it`
- `test_pause_blocks_claim_fees_then_unpause_allows_it`
- `test_pause_requires_admin_auth`

Ran, scoped to the touched crate:

```
cargo build -p fee_collector
cargo test -p fee_collector
```

Result: `test result: ok. 83 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out` (includes the 6 new pause tests plus all pre-existing fee_collector tests, unaffected). Also ran a full `cargo build` across the workspace to confirm nothing else broke.
