### PR TITLE
Apply lock-duration multiplier to stake_vault voting power

### DIFF
--- a/stellar-swipe/contracts/shared/src/event_topics.rs
+++ b/stellar-swipe/contracts/shared/src/event_topics.rs
@@ -78,6 +78,7 @@ pub const TOPIC_STAKE_EMERGENCY_REQ: fn() -> Symbol = || Symbol::short("emgreq")
 pub const TOPIC_STAKE_EMERGENCY_APPROVED: fn() -> Symbol = || Symbol::short("emgappr");
 pub const TOPIC_STAKE_EMERGENCY_EXPIRED: fn() -> Symbol = || Symbol::short("emgexp");
 pub const TOPIC_STAKE_EMERGENCY_EXECUTED: fn() -> Symbol = || Symbol::short("emgexec");
+pub const TOPIC_STAKE_LOCK_MULTIPLIER: fn() -> Symbol = || Symbol::short("lockmult");
 
 #[cfg(test)]
 mod tests {
@@ -153,5 +154,6 @@ mod tests {
         let _ = TOPIC_STAKE_EMERGENCY_APPROVED();
         let _ = TOPIC_STAKE_EMERGENCY_EXPIRED();
         let _ = TOPIC_STAKE_EMERGENCY_EXECUTED();
+        let _ = TOPIC_STAKE_LOCK_MULTIPLIER();
     }
 }

--- a/stellar-swipe/contracts/stake_vault/src/events.rs
+++ b/stellar-swipe/contracts/stake_vault/src/events.rs
@@ -185,6 +185,15 @@ pub struct EvtBatchAppealsResolved {
     pub processed_count: u32,
 }
 
+/// Issue #787: lock-duration-weighted voting-power multiplier tiers.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EvtLockMultiplierTierUpdated {
+    pub schema_version: u32,
+    pub weeks: u32,
+    pub bps: u32,
+}
+
 // ── Emergency multi-sig unstake events (issue #754) ───────────────────────────
 
 #[contracttype]
@@ -448,6 +457,17 @@ pub fn emit_batch_appeals_resolved(env: &Env, processed_count: u32) {
         EvtBatchAppealsResolved {
             schema_version: SCHEMA_VERSION,
             processed_count,
+        },
+    );
+}
+
+pub fn emit_lock_multiplier_tier_updated(env: &Env, weeks: u32, bps: u32) {
+    env.events().publish(
+        (contract_topic(env), topics::TOPIC_STAKE_LOCK_MULTIPLIER()),
+        EvtLockMultiplierTierUpdated {
+            schema_version: SCHEMA_VERSION,
+            weeks,
+            bps,
         },
     );
 }

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -50,6 +50,73 @@ impl SlashTierConfig {
 
 const BPS_DENOMINATOR: i128 = 10_000;
 
+// ── Issue #787: stake duration-weighted voting power ──────────────────────────
+
+/// Seconds in a week, used to convert a stake's remaining lock time into the
+/// whole-week buckets that `LockMultiplierTier` thresholds are expressed in.
+const SECS_PER_WEEK: u64 = 604_800;
+
+/// Upper bound on an admin-configured lock-multiplier tier (100x), well above
+/// the default max tier (2x) while still keeping `balance * bps` comfortably
+/// clear of `i128` overflow for realistic stake sizes.
+const MAX_LOCK_MULTIPLIER_BPS: u32 = 1_000_000;
+
+/// Admin-configurable voting-power multiplier tier (issue #787).
+///
+/// While a stake's remaining lock time (`locked_until - now`) is at least
+/// `weeks`, its voting power is multiplied by `bps` basis points
+/// (`10_000` = 1x). The highest-`bps` tier whose `weeks` threshold is met by
+/// the remaining lock time applies.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LockMultiplierTier {
+    pub weeks: u32,
+    pub bps: u32,
+}
+
+/// Default lock-multiplier tiers, used until an admin configures custom ones
+/// via `set_lock_multiplier_tier`.
+fn default_lock_multiplier_tiers(env: &Env) -> Vec<LockMultiplierTier> {
+    let mut tiers = Vec::new(env);
+    tiers.push_back(LockMultiplierTier {
+        weeks: 1,
+        bps: 10_000, // 1x
+    });
+    tiers.push_back(LockMultiplierTier {
+        weeks: 4,
+        bps: 12_500, // 1.25x
+    });
+    tiers.push_back(LockMultiplierTier {
+        weeks: 12,
+        bps: 20_000, // 2x
+    });
+    tiers
+}
+
+/// Returns the multiplier (basis points) for a stake with `remaining_secs`
+/// left on its lock. `0` means the remaining duration does not meet even the
+/// smallest configured tier (equivalent to the pre-#787 "still within the
+/// eligibility lock" zero-voting-power behaviour).
+fn lock_multiplier_bps_for_remaining(tiers: &Vec<LockMultiplierTier>, remaining_secs: u64) -> u32 {
+    let remaining_weeks = (remaining_secs / SECS_PER_WEEK) as u32;
+    let mut applicable_bps: u32 = 0;
+    for tier in tiers.iter() {
+        if remaining_weeks >= tier.weeks && tier.bps > applicable_bps {
+            applicable_bps = tier.bps;
+        }
+    }
+    applicable_bps
+}
+
+/// Applies a basis-point multiplier to `balance`, saturating instead of
+/// overflowing for pathologically large inputs.
+fn apply_multiplier_bps(balance: i128, bps: u32) -> i128 {
+    balance
+        .checked_mul(bps as i128)
+        .and_then(|v| v.checked_div(BPS_DENOMINATOR))
+        .unwrap_or(i128::MAX)
+}
+
 /// Temporary-storage key for the reentrancy lock on `withdraw_stake`.
 const EXECUTION_LOCK: &str = "WithdrawLock";
 
@@ -185,6 +252,11 @@ pub enum StorageKey {
     /// Admin-configurable large-withdrawal time-lock duration (seconds).
     /// Falls back to `LARGE_WITHDRAWAL_TIMELOCK_SECS` when unset.
     WithdrawalCooldownSecs,
+    // ── Issue #787: stake duration-weighted voting power ───────────────────────
+    /// Admin-configurable table mapping a remaining-lock-duration threshold
+    /// (in whole weeks) to a voting-power multiplier (basis points).
+    /// Falls back to the built-in default tiers when unset.
+    LockMultiplierTiers,
 }
 
 #[contracterror]
@@ -251,6 +323,10 @@ pub enum StakeVaultError {
     /// `upgrade()` was called with a version that is not strictly greater
     /// than the currently stored contract version.
     IncompatibleContractVersion = 34,
+    // ── Issue #787: stake duration-weighted voting power ─────────────────────
+    /// `set_lock_multiplier_tier` was called with `weeks == 0` or a `bps`
+    /// value outside `[BPS_DENOMINATOR, MAX_LOCK_MULTIPLIER_BPS]`.
+    InvalidLockMultiplierTier = 35,
 }
 
 /// A pending unstake request held in the FIFO queue (issue #663).
@@ -588,6 +664,15 @@ impl StakeVaultContract {
     ///   locked before being eligible to count toward voting power ✓
     /// - Top-up deposits to an existing stake tracked separately so only the new
     ///   portion is subject to the fresh lock ✓
+    ///
+    /// ## Lock-duration-weighted multiplier (Issue #787)
+    /// Once locked, a stake's remaining lock time (`locked_until - now`) is
+    /// looked up against the configured `LockMultiplierTier` table
+    /// (`get_lock_multiplier_tiers`) and the balance is scaled by the
+    /// matching tier's basis points. A remaining duration below the smallest
+    /// configured tier keeps the pre-existing zero-voting-power behaviour; a
+    /// stake with no lock, or whose lock has fully elapsed, always counts at
+    /// the 1x baseline.
     pub fn get_voting_power(env: Env, staker: Address) -> i128 {
         let stakes: soroban_sdk::Map<Address, StakeInfoV2> = env
             .storage()
@@ -605,14 +690,68 @@ impl StakeVaultContract {
         }
 
         let now = env.ledger().timestamp();
-        if now < info.locked_until {
-            // Stake is still within the minimum duration lock window.
-            // Voting power is 0 until the lock expires.
-            return 0;
+        if info.locked_until == 0 || now >= info.locked_until {
+            // No lock, or the lock has fully elapsed — baseline 1x.
+            return info.balance;
         }
 
-        // Lock has elapsed — full balance counts as voting power.
-        info.balance
+        // Still locked — apply the tiered multiplier for the remaining duration.
+        let remaining = info.locked_until - now;
+        let tiers = Self::get_lock_multiplier_tiers(env.clone());
+        let bps = lock_multiplier_bps_for_remaining(&tiers, remaining);
+        if bps == 0 {
+            return 0;
+        }
+        apply_multiplier_bps(info.balance, bps)
+    }
+
+    // ── Admin: configure lock-duration voting-power multiplier tiers ───────────
+
+    /// Returns the configured lock-multiplier tiers, or the built-in defaults
+    /// (1 week = 1x, 4 weeks = 1.25x, 12 weeks = 2x) if none have been set.
+    pub fn get_lock_multiplier_tiers(env: Env) -> Vec<LockMultiplierTier> {
+        env.storage()
+            .instance()
+            .get(&StorageKey::LockMultiplierTiers)
+            .unwrap_or_else(|| default_lock_multiplier_tiers(&env))
+    }
+
+    /// Admin-only: set (or update) the voting-power multiplier for stakes
+    /// whose remaining lock time is at least `weeks`, in basis points
+    /// (`10_000` = 1x). `bps` must be in `[10_000, MAX_LOCK_MULTIPLIER_BPS]` —
+    /// a lock can never be worth less than the unlocked baseline.
+    pub fn set_lock_multiplier_tier(env: Env, weeks: u32, bps: u32) -> Result<(), StakeVaultError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(StakeVaultError::NotInitialized)?;
+        admin.require_auth();
+
+        if weeks == 0 || bps < BPS_DENOMINATOR as u32 || bps > MAX_LOCK_MULTIPLIER_BPS {
+            return Err(StakeVaultError::InvalidLockMultiplierTier);
+        }
+
+        let existing = Self::get_lock_multiplier_tiers(env.clone());
+        let mut updated_tiers: Vec<LockMultiplierTier> = Vec::new(&env);
+        let mut replaced = false;
+        for tier in existing.iter() {
+            if tier.weeks == weeks {
+                updated_tiers.push_back(LockMultiplierTier { weeks, bps });
+                replaced = true;
+            } else {
+                updated_tiers.push_back(tier);
+            }
+        }
+        if !replaced {
+            updated_tiers.push_back(LockMultiplierTier { weeks, bps });
+        }
+
+        env.storage()
+            .instance()
+            .set(&StorageKey::LockMultiplierTiers, &updated_tiers);
+        events::emit_lock_multiplier_tier_updated(&env, weeks, bps);
+        Ok(())
     }
 
     // ── Admin: configure minimum stake duration ────────────────────────────────

--- a/stellar-swipe/contracts/stake_vault/src/tests.rs
+++ b/stellar-swipe/contracts/stake_vault/src/tests.rs
@@ -1126,6 +1126,150 @@ mod slash_severity_tests {
         assert_eq!(client.withdraw_stake(&staker), amount);
     }
 
+    // ── Issue #787: lock-duration-weighted voting power multiplier ───────────
+
+    fn seed_locked(
+        env: &Env,
+        contract_id: &Address,
+        staker: &Address,
+        balance: i128,
+        locked_until: u64,
+    ) {
+        env.as_contract(contract_id, || {
+            let mut stakes: Map<Address, StakeInfoV2> = env
+                .storage()
+                .persistent()
+                .get(&MigrationKey::StakesV2)
+                .unwrap_or_else(|| Map::new(env));
+            stakes.set(
+                staker.clone(),
+                StakeInfoV2 {
+                    balance,
+                    locked_until,
+                    last_updated: 0,
+                },
+            );
+            env.storage()
+                .persistent()
+                .set(&MigrationKey::StakesV2, &stakes);
+        });
+    }
+
+    const SECS_PER_WEEK: u64 = 604_800;
+
+    #[test]
+    fn default_lock_multiplier_tiers_are_returned_when_unset() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        let tiers = client.get_lock_multiplier_tiers();
+        assert_eq!(tiers.len(), 3);
+        assert_eq!(tiers.get(0).unwrap().weeks, 1);
+        assert_eq!(tiers.get(0).unwrap().bps, 10_000);
+        assert_eq!(tiers.get(1).unwrap().weeks, 4);
+        assert_eq!(tiers.get(1).unwrap().bps, 12_500);
+        assert_eq!(tiers.get(2).unwrap().weeks, 12);
+        assert_eq!(tiers.get(2).unwrap().bps, 20_000);
+    }
+
+    /// (a) No lock at all — voting power counts at the 1x baseline.
+    #[test]
+    fn voting_power_no_lock_is_baseline_1x() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let staker = Address::generate(&env);
+        seed_locked(&env, &vault_id, &staker, 1_000_000, 0);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(client.get_voting_power(&staker), 1_000_000);
+    }
+
+    /// (b) Mid-tier lock (4 weeks remaining) applies the 1.25x multiplier.
+    #[test]
+    fn voting_power_mid_tier_multiplier_applied() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let staker = Address::generate(&env);
+        let now = env.ledger().timestamp();
+        seed_locked(&env, &vault_id, &staker, 1_000_000, now + 4 * SECS_PER_WEEK);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(client.get_voting_power(&staker), 1_250_000);
+    }
+
+    /// (c) Max-tier lock (12 weeks remaining) applies the 2x multiplier.
+    #[test]
+    fn voting_power_max_tier_multiplier_applied() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let staker = Address::generate(&env);
+        let now = env.ledger().timestamp();
+        seed_locked(
+            &env,
+            &vault_id,
+            &staker,
+            1_000_000,
+            now + 12 * SECS_PER_WEEK,
+        );
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(client.get_voting_power(&staker), 2_000_000);
+    }
+
+    /// (d) An expired lock (even one that once qualified for a high tier)
+    /// falls back to the 1x baseline rather than retaining its multiplier.
+    #[test]
+    fn voting_power_expired_lock_falls_back_to_1x() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let staker = Address::generate(&env);
+        env.ledger().with_mut(|l| l.timestamp = 20 * SECS_PER_WEEK);
+        let now = env.ledger().timestamp();
+        seed_locked(&env, &vault_id, &staker, 1_000_000, now - 1);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(client.get_voting_power(&staker), 1_000_000);
+    }
+
+    /// A remaining lock duration below the smallest configured tier keeps the
+    /// pre-#787 zero-voting-power behaviour (still-vesting eligibility lock).
+    #[test]
+    fn voting_power_below_smallest_tier_stays_zero() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let staker = Address::generate(&env);
+        let now = env.ledger().timestamp();
+        seed_locked(&env, &vault_id, &staker, 1_000_000, now + 3 * 86_400);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        assert_eq!(client.get_voting_power(&staker), 0);
+    }
+
+    #[test]
+    fn set_lock_multiplier_tier_rejects_invalid_weeks_or_bps() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+
+        assert_eq!(
+            client.try_set_lock_multiplier_tier(&0, &15_000),
+            Err(Ok(StakeVaultError::InvalidLockMultiplierTier))
+        );
+        assert_eq!(
+            client.try_set_lock_multiplier_tier(&4, &9_999),
+            Err(Ok(StakeVaultError::InvalidLockMultiplierTier))
+        );
+    }
+
+    #[test]
+    fn set_lock_multiplier_tier_updates_existing_tier_and_affects_voting_power() {
+        let (env, vault_id, _token, _admin, _registry) = setup();
+        let staker = Address::generate(&env);
+        let now = env.ledger().timestamp();
+        seed_locked(&env, &vault_id, &staker, 1_000_000, now + 4 * SECS_PER_WEEK);
+
+        let client = StakeVaultContractClient::new(&env, &vault_id);
+        // Raise the 4-week tier from the default 1.25x to 1.5x in place.
+        client.set_lock_multiplier_tier(&4, &15_000);
+
+        let tiers = client.get_lock_multiplier_tiers();
+        assert_eq!(tiers.len(), 3);
+        assert_eq!(client.get_voting_power(&staker), 1_500_000);
+    }
+
     // ── Issue #563: require_auth_for_args ─────────────────────────────────
 
     /// Auth scoped to (staker, amount=0) is rejected when the staker has a

--- a/stellar-swipe/docs/events.md
+++ b/stellar-swipe/docs/events.md
@@ -382,3 +382,11 @@ appeal also still emits its own `apresolv` event.
 | `emgexp` | `staker: Address` |
 | `emgexec` | `staker: Address`, `gross: i128`, `penalty: i128`, `net: i128` |
 | `amount` | `i128` | Amount released |
+
+### `lockmult` (issue #787)
+Emitted when admin sets or updates a lock-duration voting-power multiplier tier.
+
+| Field | Type | Description |
+|---|---|---|
+| `weeks` | `u32` | Minimum remaining lock duration (in whole weeks) this tier applies to |
+| `bps` | `u32` | Voting-power multiplier in basis points (`10_000` = 1x) |


### PR DESCRIPTION
Closes #787

Providers who lock stake for longer now earn more voting power per token instead of being weighted the same as a minimal lock.

- `get_voting_power` looks up the stake's remaining lock time against an admin-configurable tier table and scales the balance by the matching multiplier (default: 1 week = 1x, 4 weeks = 1.25x, 12 weeks = 2x).
- A remaining duration below the smallest tier keeps the existing zero-voting-power behavior; a stake with no lock or an elapsed lock counts at the 1x baseline.
- Added `set_lock_multiplier_tier(weeks, bps)`, admin-only, to configure/update tiers, and `get_lock_multiplier_tiers` to read them.
- `partial_unstake` and `withdraw_stake` are untouched — the multiplier only affects voting power, not the underlying balance.
- Unit tests cover no lock, mid-tier, max-tier, and expired-lock cases, plus admin tier configuration.