### PR TITLE
Verify unique error discriminants across signal_registry

### DIFF
--- a/stellar-swipe/contracts/signal_registry/src/community_voting.rs
+++ b/stellar-swipe/contracts/signal_registry/src/community_voting.rs
@@ -75,16 +75,19 @@ pub struct DisputeRecord {
     pub appeal_submitted_at: u64,
 }
 
+/// Issue #782: renumbered from 1-6, which collided with `AdminError`
+/// (also 1-36) — two different failure conditions decoded to the same
+/// contract-wide `u32` error code.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum DisputeError {
-    Unauthorized = 1,
-    DisputeNotFound = 2,
-    DisputeNotOpen = 3,
-    AppealAlreadySubmitted = 4,
-    AppealNotPending = 5,
-    AppealWindowNotElapsed = 6,
+    Unauthorized = 1600,
+    DisputeNotFound = 1601,
+    DisputeNotOpen = 1602,
+    AppealAlreadySubmitted = 1603,
+    AppealNotPending = 1604,
+    AppealWindowNotElapsed = 1605,
 }
 
 #[contracttype]

--- a/stellar-swipe/contracts/signal_registry/src/errors.rs
+++ b/stellar-swipe/contracts/signal_registry/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::community_voting::DisputeError;
 use soroban_sdk::contracterror;
 
 #[contracterror]
@@ -47,14 +48,17 @@ pub enum AdminError {
     IncompatibleStorageLayout = 36,
 }
 
+/// Issue #782: renumbered from 600-603, which collided with `ComboError`
+/// (600-613) — two different failure conditions decoded to the same
+/// contract-wide `u32` error code.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum AiScoreError {
-    Unauthorized = 600,
-    OracleNotConfigured = 601,
-    InvalidScore = 602,
-    SignalNotFound = 603,
+    Unauthorized = 1500,
+    OracleNotConfigured = 1501,
+    InvalidScore = 1502,
+    SignalNotFound = 1503,
 }
 
 #[contracterror]
@@ -281,3 +285,207 @@ pub enum SignalCancelError {
     /// The configured minimum signal lifetime has not yet elapsed; cancellation rejected.
     LifetimeNotElapsed = 1303,
 }
+
+// ── Issue #782: compile-time discriminant uniqueness ───────────────────────────
+//
+// Soroban encodes every `#[contracterror]` value as a single contract-wide
+// `u32` on-chain — there is no enum-level tag recoverable from a raw error
+// code by an off-chain client. Two variants sharing a numeric value (even
+// across different enums) are therefore indistinguishable once decoded.
+// This asserts every discriminant across every `#[contracterror]` enum in
+// the crate — including `DisputeError`, defined in `community_voting.rs` —
+// is unique, at compile time.
+const ALL_ERROR_CODES: &[u32] = &[
+    // AdminError
+    AdminError::Unauthorized as u32,
+    AdminError::AlreadyInitialized as u32,
+    AdminError::NotInitialized as u32,
+    AdminError::InvalidParameter as u32,
+    AdminError::TradingPaused as u32,
+    AdminError::PauseExpired as u32,
+    AdminError::InvalidFeeRate as u32,
+    AdminError::InvalidRiskParameter as u32,
+    AdminError::InsufficientSignatures as u32,
+    AdminError::DuplicateSigner as u32,
+    AdminError::InvalidAssetPair as u32,
+    AdminError::CannotFollowSelf as u32,
+    AdminError::RateLimitExceeded as u32,
+    AdminError::SignalLimitExceeded as u32,
+    AdminError::InvalidTimestamp as u32,
+    AdminError::ScheduleTooFarFuture as u32,
+    AdminError::ScheduleLimitReached as u32,
+    AdminError::ScheduleNotFound as u32,
+    AdminError::NotScheduleOwner as u32,
+    AdminError::CircuitBreakerTriggered as u32,
+    AdminError::StakeBelowMinimum as u32,
+    AdminError::PendingAdminNotFound as u32,
+    AdminError::PendingAdminExpired as u32,
+    AdminError::ReentrancyDetected as u32,
+    AdminError::RequiresMultisigApproval as u32,
+    AdminError::ProposalNotFound as u32,
+    AdminError::AlreadyApproved as u32,
+    AdminError::ProposalNotApproved as u32,
+    AdminError::TimelockNotElapsed as u32,
+    AdminError::ProposalAlreadyExecuted as u32,
+    AdminError::ProposalCancelled as u32,
+    AdminError::TooManyProposals as u32,
+    AdminError::CooldownNotElapsed as u32,
+    AdminError::IncompatibleContractVersion as u32,
+    AdminError::IncompatibleStorageLayout as u32,
+    // AiScoreError
+    AiScoreError::Unauthorized as u32,
+    AiScoreError::OracleNotConfigured as u32,
+    AiScoreError::InvalidScore as u32,
+    AiScoreError::SignalNotFound as u32,
+    // FeeError
+    FeeError::TradeTooSmall as u32,
+    FeeError::FeeRoundedToZero as u32,
+    FeeError::ArithmeticOverflow as u32,
+    FeeError::InvalidAmount as u32,
+    FeeError::InvalidProviderAddress as u32,
+    // SocialError
+    SocialError::CannotFollowSelf as u32,
+    // PerformanceError
+    PerformanceError::SignalNotFound as u32,
+    PerformanceError::InvalidPrice as u32,
+    PerformanceError::DivisionByZero as u32,
+    PerformanceError::InvalidVolume as u32,
+    PerformanceError::SignalExpired as u32,
+    PerformanceError::NoExecutions as u32,
+    PerformanceError::TradingPaused as u32,
+    PerformanceError::OraclePriceStale as u32,
+    PerformanceError::OraclePriceMissing as u32,
+    PerformanceError::OraclePriceOutOfBounds as u32,
+    // TemplateError
+    TemplateError::TemplateNotFound as u32,
+    TemplateError::Unauthorized as u32,
+    TemplateError::PrivateTemplate as u32,
+    TemplateError::MissingVariable as u32,
+    TemplateError::InvalidTemplate as u32,
+    TemplateError::InvalidAction as u32,
+    TemplateError::InvalidExpiry as u32,
+    // ImportError
+    ImportError::InvalidFormat as u32,
+    ImportError::InvalidAssetPair as u32,
+    ImportError::InvalidPrice as u32,
+    ImportError::InvalidAction as u32,
+    ImportError::InvalidRationale as u32,
+    ImportError::InvalidExpiry as u32,
+    ImportError::BatchSizeExceeded as u32,
+    ImportError::EmptyData as u32,
+    ImportError::ParseError as u32,
+    // CollaborationError
+    CollaborationError::NotCoAuthor as u32,
+    CollaborationError::AlreadyApproved as u32,
+    CollaborationError::InvalidContributions as u32,
+    CollaborationError::NotCollaborative as u32,
+    CollaborationError::PendingApproval as u32,
+    // ExportError
+    ExportError::UnsupportedFormat as u32,
+    ExportError::NoDataInRange as u32,
+    ExportError::ExportTooLarge as u32,
+    // ComboError
+    ComboError::ComboNotFound as u32,
+    ComboError::SignalNotFound as u32,
+    ComboError::NotSignalOwner as u32,
+    ComboError::InvalidWeights as u32,
+    ComboError::WeightOverflow as u32,
+    ComboError::NoComponents as u32,
+    ComboError::TooManyComponents as u32,
+    ComboError::SignalNotActive as u32,
+    ComboError::ComponentSignalExpired as u32,
+    ComboError::InvalidConditionReference as u32,
+    ComboError::ComboNotActive as u32,
+    ComboError::InvalidAmount as u32,
+    ComboError::TradingPaused as u32,
+    ComboError::CircuitBreakerTriggered as u32,
+    // ContestError
+    ContestError::ContestNotFound as u32,
+    ContestError::InvalidTimeRange as u32,
+    ContestError::InvalidPrizePool as u32,
+    ContestError::ContestNotEnded as u32,
+    ContestError::AlreadyFinalized as u32,
+    ContestError::NotQualified as u32,
+    ContestError::TradingPaused as u32,
+    ContestError::CircuitBreakerTriggered as u32,
+    ContestError::RandomnessNotAvailable as u32,
+    // VersioningError
+    VersioningError::NotSignalOwner as u32,
+    VersioningError::CannotUpdateInactive as u32,
+    VersioningError::MaxUpdatesReached as u32,
+    VersioningError::UpdateCooldown as u32,
+    VersioningError::SignalExpired as u32,
+    VersioningError::InvalidPrice as u32,
+    VersioningError::InvalidExpiry as u32,
+    VersioningError::VersionNotFound as u32,
+    // CrossChainError
+    CrossChainError::SignalAlreadyExists as u32,
+    CrossChainError::SignalNotFound as u32,
+    CrossChainError::VerificationFailed as u32,
+    CrossChainError::InvalidProof as u32,
+    CrossChainError::AddressNotRegistered as u32,
+    CrossChainError::InvalidSyncStatus as u32,
+    CrossChainError::NotSignalOwner as u32,
+    // SignalEditError
+    SignalEditError::EditWindowClosed as u32,
+    SignalEditError::FieldNotEditable as u32,
+    SignalEditError::SignalAlreadyCopied as u32,
+    SignalEditError::SignalNotFound as u32,
+    SignalEditError::NotSignalOwner as u32,
+    SignalEditError::InvalidConfidence as u32,
+    SignalEditError::TradingPaused as u32,
+    // SignalOutcomeError
+    SignalOutcomeError::Unauthorized as u32,
+    SignalOutcomeError::SignalNotFound as u32,
+    SignalOutcomeError::SignalNotClosed as u32,
+    SignalOutcomeError::OutcomeAlreadyRecorded as u32,
+    // SubmissionError
+    SubmissionError::NoStake as u32,
+    SubmissionError::BelowMinimumStake as u32,
+    SubmissionError::InvalidAssetPair as u32,
+    SubmissionError::InvalidPrice as u32,
+    SubmissionError::EmptyRationale as u32,
+    SubmissionError::DuplicateSignal as u32,
+    SubmissionError::MissingRationale as u32,
+    SubmissionError::PriceUnreasonable as u32,
+    // SignalValidationError
+    SignalValidationError::InvalidAssetPair as u32,
+    SignalValidationError::InvalidPrice as u32,
+    SignalValidationError::EmptyRationale as u32,
+    SignalValidationError::RationaleTooLong as u32,
+    SignalValidationError::InvalidExpiry as u32,
+    SignalValidationError::TooManyTags as u32,
+    SignalValidationError::DailyLimitExceeded as u32,
+    // SignalCancelError
+    SignalCancelError::NotFound as u32,
+    SignalCancelError::NotOwner as u32,
+    SignalCancelError::NotActive as u32,
+    SignalCancelError::LifetimeNotElapsed as u32,
+    // DisputeError (defined in community_voting.rs)
+    DisputeError::Unauthorized as u32,
+    DisputeError::DisputeNotFound as u32,
+    DisputeError::DisputeNotOpen as u32,
+    DisputeError::AppealAlreadySubmitted as u32,
+    DisputeError::AppealNotPending as u32,
+    DisputeError::AppealWindowNotElapsed as u32,
+];
+
+const fn has_duplicate(codes: &[u32]) -> bool {
+    let mut i = 0;
+    while i < codes.len() {
+        let mut j = i + 1;
+        while j < codes.len() {
+            if codes[i] == codes[j] {
+                return true;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    false
+}
+
+const _: () = assert!(
+    !has_duplicate(ALL_ERROR_CODES),
+    "duplicate #[contracterror] discriminant detected across signal_registry error enums"
+);

--- a/stellar-swipe/error-baselines/signal_registry.json
+++ b/stellar-swipe/error-baselines/signal_registry.json
@@ -41,10 +41,10 @@
       "IncompatibleStorageLayout": 36
     },
     "AiScoreError": {
-      "Unauthorized": 600,
-      "OracleNotConfigured": 601,
-      "InvalidScore": 602,
-      "SignalNotFound": 603
+      "Unauthorized": 1500,
+      "OracleNotConfigured": 1501,
+      "InvalidScore": 1502,
+      "SignalNotFound": 1503
     },
     "FeeError": {
       "TradeTooSmall": 100,
@@ -170,13 +170,28 @@
       "MissingRationale": 1206,
       "PriceUnreasonable": 1207
     },
+    "SignalCancelError": {
+      "NotFound": 1300,
+      "NotOwner": 1301,
+      "NotActive": 1302,
+      "LifetimeNotElapsed": 1303
+    },
+    "SignalValidationError": {
+      "InvalidAssetPair": 1400,
+      "InvalidPrice": 1401,
+      "EmptyRationale": 1402,
+      "RationaleTooLong": 1403,
+      "InvalidExpiry": 1404,
+      "TooManyTags": 1405,
+      "DailyLimitExceeded": 1406
+    },
     "DisputeError": {
-      "Unauthorized": 1,
-      "DisputeNotFound": 2,
-      "DisputeNotOpen": 3,
-      "AppealAlreadySubmitted": 4,
-      "AppealNotPending": 5,
-      "AppealWindowNotElapsed": 6
+      "Unauthorized": 1600,
+      "DisputeNotFound": 1601,
+      "DisputeNotOpen": 1602,
+      "AppealAlreadySubmitted": 1603,
+      "AppealNotPending": 1604,
+      "AppealWindowNotElapsed": 1605
     }
   }
 }


### PR DESCRIPTION
Closes #782

Every `#[contracterror]` enum in `signal_registry` already had explicit `u32` discriminants, but two pairs collided: `AiScoreError` (600-603) with `ComboError` (600-613), and `DisputeError` (1-6, defined in `community_voting.rs`) with `AdminError` (also 1-36). Soroban encodes contract errors as a single crate-wide `u32` with no enum-level tag, so a client decoding a raw error code couldn't tell these apart.

- Renumbered `AiScoreError` to 1500-1503 and `DisputeError` to 1600-1605 (only symbolic references existed, no hardcoded numeric literals elsewhere).
- Added a const-evaluated compile-time assertion in `errors.rs` that checks every discriminant across every error enum in the crate for uniqueness.
- Updated `error-baselines/signal_registry.json` to match, and added the `SignalValidationError`/`SignalCancelError` entries that were missing from it.

Followed the repo's existing `error-baselines/*.json` + discriminant-stability convention rather than `abi-baselines/` (which is for WASM export/spec-hash snapshots, not error codes).