### PR TITLE
feat: portfolio risk metrics, token metadata validation, deploy regis…

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -57,3 +57,35 @@ Run it directly with:
 ```sh
 python3 stellar-swipe/scripts/validate_deployment_manifest.py deployments/testnet.manifest.json
 ```
+
+## Contract registry (Issue #881)
+
+`deployments/registry.json` is the canonical, versioned answer to "which
+contract is deployed at which address, on which network". It complements the
+manifests above: a manifest describes what a release *should* contain, the
+registry records what is actually live.
+
+Each network entry carries its passphrase, RPC URL, the manifest it was
+validated against, a `deployed_at` timestamp, and one `{ address, version }`
+entry per contract. `address` is `null` until that contract has been deployed.
+
+Read it through `scripts/deployment_registry.ts` rather than parsing it by hand,
+so a missing deployment fails loudly instead of yielding `null` downstream:
+
+```sh
+cd scripts
+npx tsx deployment_registry.ts list testnet          # all contracts on a network
+npx tsx deployment_registry.ts get testnet stake_vault   # one address, exits non-zero if undeployed
+```
+
+From TypeScript:
+
+```ts
+import { loadRegistry, getContractId } from "./deployment_registry.ts";
+
+const stakeVault = getContractId(loadRegistry(), "testnet", "stake_vault");
+```
+
+`recordDeployment(network, contract, address)` writes a freshly deployed address
+back into the registry and stamps `deployed_at`, so deploy scripts keep the file
+current instead of leaving addresses scattered across per-run state files.

--- a/deployments/registry.json
+++ b/deployments/registry.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Canonical contract address registry (Issue #881). One entry per network, generated/updated at deploy time from deployments/<network>.json and validated against deployments/<network>.manifest.json. Tooling and operators should read this file (via scripts/deployment_registry.ts) instead of grepping ad-hoc state files. 'address' is null until the contract has been deployed on that network.",
+  "schema_version": 1,
+  "networks": {
+    "testnet": {
+      "network_passphrase": "Test SDF Network ; September 2015",
+      "rpc_url": "https://soroban-testnet.stellar.org",
+      "manifest": "deployments/testnet.manifest.json",
+      "deployed_at": null,
+      "contracts": {
+        "stake_vault": { "address": null, "version": 2 },
+        "signal_registry": { "address": null, "version": 2 },
+        "fee_collector": { "address": null, "version": 2 },
+        "user_portfolio": { "address": null, "version": 2 },
+        "trade_executor": { "address": null, "version": 1 }
+      }
+    },
+    "mainnet": {
+      "network_passphrase": "Public Global Stellar Network ; September 2015",
+      "rpc_url": "https://soroban-rpc.mainnet.stellar.gateway.fm",
+      "manifest": "deployments/mainnet.manifest.example.json",
+      "deployed_at": null,
+      "contracts": {
+        "stake_vault": { "address": null, "version": 2 },
+        "signal_registry": { "address": null, "version": 2 },
+        "fee_collector": { "address": null, "version": 2 },
+        "user_portfolio": { "address": null, "version": 2 },
+        "trade_executor": { "address": null, "version": 1 }
+      }
+    }
+  }
+}

--- a/docs/event_replay.md
+++ b/docs/event_replay.md
@@ -1,0 +1,47 @@
+# Event replay (Issue #882)
+
+Reconstructing protocol state from historical on-chain events, for debugging
+and for validating upgrades against what actually happened on chain.
+
+## Pipeline
+
+1. `scripts/replay_events.ts` — fetch raw Soroban events from an RPC endpoint.
+2. `scripts/test_event_parsing.ts` — parse them into the native JSON shape
+   (see `scripts/sample_parsed_events_testnet.json`).
+3. `scripts/replay_state.ts` — fold that parsed stream into a state snapshot.
+
+```sh
+cd scripts
+npx tsx replay_state.ts sample_parsed_events_testnet.json
+```
+
+## What the snapshot contains
+
+| Field | Reconstructed from |
+| --- | --- |
+| `stakes` | `staked` / `unstaked` |
+| `signals` | `trade_executed` (count and cumulative volume per signal) |
+| `feesCollected` | `fee_collected` |
+| `lastOraclePrice` | `oracle_price_submitted` |
+| `unhandledEvents` | any event name with no reducer yet |
+
+Amounts are `bigint`; `serialize()` renders them as decimal strings so a
+snapshot can be diffed or committed as JSON.
+
+## Determinism
+
+Events are sorted by ledger (then event id) before folding, so a page returned
+out of order by the RPC replays to the same snapshot. `unhandledEvents` makes
+coverage gaps visible instead of silently dropping events — when a contract
+gains a new event, add a reducer case and it disappears from that list.
+
+## Fixture test
+
+`scripts/fixtures/replay_events_fixture.json` is a known-good event stream with
+a deliberately out-of-order ledger and one unhandled event name. The replay is
+asserted against its expected snapshot:
+
+```sh
+cd scripts
+npx tsx --test replay_state.test.ts
+```

--- a/scripts/deployment_registry.ts
+++ b/scripts/deployment_registry.ts
@@ -1,0 +1,117 @@
+/**
+ * Deployment registry reader (Issue #881).
+ *
+ * `deployments/registry.json` is the single source of truth for "which contract
+ * is deployed where". Scripts and operators resolve addresses through this
+ * module instead of reaching into per-deploy state files.
+ *
+ * CLI:
+ *   npx tsx deployment_registry.ts list testnet
+ *   npx tsx deployment_registry.ts get testnet stake_vault
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REGISTRY_PATH = resolve(REPO_ROOT, "deployments/registry.json");
+
+export interface ContractEntry {
+  address: string | null;
+  version: number;
+}
+
+export interface NetworkEntry {
+  network_passphrase: string;
+  rpc_url: string;
+  manifest: string;
+  deployed_at: string | null;
+  contracts: Record<string, ContractEntry>;
+}
+
+export interface Registry {
+  schema_version: number;
+  networks: Record<string, NetworkEntry>;
+}
+
+export function loadRegistry(path: string = REGISTRY_PATH): Registry {
+  const registry = JSON.parse(readFileSync(path, "utf8")) as Registry;
+  if (registry.schema_version !== 1) {
+    throw new Error(
+      `Unsupported registry schema_version ${registry.schema_version} (expected 1)`,
+    );
+  }
+  return registry;
+}
+
+export function getNetwork(registry: Registry, network: string): NetworkEntry {
+  const entry = registry.networks[network];
+  if (!entry) {
+    const known = Object.keys(registry.networks).join(", ");
+    throw new Error(`Unknown network "${network}". Known networks: ${known}`);
+  }
+  return entry;
+}
+
+/** Resolves a deployed contract address, throwing if it has not been deployed yet. */
+export function getContractId(
+  registry: Registry,
+  network: string,
+  contract: string,
+): string {
+  const entry = getNetwork(registry, network).contracts[contract];
+  if (!entry) {
+    throw new Error(`Contract "${contract}" is not in the ${network} registry`);
+  }
+  if (!entry.address) {
+    throw new Error(
+      `Contract "${contract}" has no address on ${network} — deploy it first, then run \`record\``,
+    );
+  }
+  return entry.address;
+}
+
+/** Records a freshly deployed address back into the registry. */
+export function recordDeployment(
+  network: string,
+  contract: string,
+  address: string,
+  path: string = REGISTRY_PATH,
+): void {
+  const registry = loadRegistry(path);
+  const networkEntry = getNetwork(registry, network);
+  const contractEntry = networkEntry.contracts[contract];
+  if (!contractEntry) {
+    throw new Error(`Contract "${contract}" is not in the ${network} registry`);
+  }
+  contractEntry.address = address;
+  networkEntry.deployed_at = new Date().toISOString();
+  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function main(): void {
+  const [command, network, contract] = process.argv.slice(2);
+  const registry = loadRegistry();
+
+  switch (command) {
+    case "list": {
+      const entry = getNetwork(registry, network);
+      console.log(`${network} (${entry.rpc_url})`);
+      for (const [name, { address, version }] of Object.entries(entry.contracts)) {
+        console.log(`  ${name.padEnd(16)} v${version}  ${address ?? "<not deployed>"}`);
+      }
+      break;
+    }
+    case "get":
+      console.log(getContractId(registry, network, contract));
+      break;
+    default:
+      console.error("usage: deployment_registry.ts <list|get> <network> [contract]");
+      process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/fixtures/replay_events_fixture.json
+++ b/scripts/fixtures/replay_events_fixture.json
@@ -1,0 +1,86 @@
+{
+  "comment": "Known-good parsed event fixture for replay_state.ts (Issue #882). Deliberately includes an out-of-order ledger and an unhandled event name so the replay stays deterministic and reports gaps in coverage.",
+  "events": [
+    {
+      "id": "0000000100/000000001/000/0000000",
+      "ledger": 100,
+      "txHash": "aa",
+      "contractId": "CSTAKE",
+      "eventName": "staked",
+      "topicsNative": ["staked"],
+      "dataNative": { "staker": "GALICE", "amount": "1000" }
+    },
+    {
+      "id": "0000000101/000000001/000/0000000",
+      "ledger": 101,
+      "txHash": "bb",
+      "contractId": "CSTAKE",
+      "eventName": "staked",
+      "topicsNative": ["staked"],
+      "dataNative": { "staker": "GBOB", "amount": "2500" }
+    },
+    {
+      "id": "0000000103/000000001/000/0000000",
+      "ledger": 103,
+      "txHash": "dd",
+      "contractId": "CTRADE",
+      "eventName": "trade_executed",
+      "topicsNative": ["trade_executed"],
+      "dataNative": { "signal_id": "7", "executor": "GBOB", "roi": "1200", "volume": "5000" }
+    },
+    {
+      "id": "0000000102/000000001/000/0000000",
+      "ledger": 102,
+      "txHash": "cc",
+      "contractId": "CSTAKE",
+      "eventName": "unstaked",
+      "topicsNative": ["unstaked"],
+      "dataNative": { "staker": "GALICE", "amount": "400" }
+    },
+    {
+      "id": "0000000104/000000001/000/0000000",
+      "ledger": 104,
+      "txHash": "ee",
+      "contractId": "CTRADE",
+      "eventName": "trade_executed",
+      "topicsNative": ["trade_executed"],
+      "dataNative": { "signal_id": "7", "executor": "GALICE", "roi": "900", "volume": "1500" }
+    },
+    {
+      "id": "0000000105/000000001/000/0000000",
+      "ledger": 105,
+      "txHash": "ff",
+      "contractId": "CFEE",
+      "eventName": "fee_collected",
+      "topicsNative": ["fee_collected"],
+      "dataNative": { "amount": "65" }
+    },
+    {
+      "id": "0000000106/000000001/000/0000000",
+      "ledger": 106,
+      "txHash": "gg",
+      "contractId": "CORACLE",
+      "eventName": "oracle_price_submitted",
+      "topicsNative": ["oracle_price_submitted"],
+      "dataNative": { "oracle": "GORACLE", "price": "1000000" }
+    },
+    {
+      "id": "0000000107/000000001/000/0000000",
+      "ledger": 107,
+      "txHash": "hh",
+      "contractId": "CORACLE",
+      "eventName": "oracle_price_submitted",
+      "topicsNative": ["oracle_price_submitted"],
+      "dataNative": { "oracle": "GORACLE", "price": "1050000" }
+    },
+    {
+      "id": "0000000108/000000001/000/0000000",
+      "ledger": 108,
+      "txHash": "ii",
+      "contractId": "CPORTFOLIO",
+      "eventName": "badge_awarded",
+      "topicsNative": ["badge_awarded"],
+      "dataNative": { "user": "GALICE", "badge": "3" }
+    }
+  ]
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test:events": "npx tsx test_event_parsing.ts",
     "replay-events": "npx tsx replay_events.ts",
+    "replay-state": "npx tsx replay_state.ts",
+    "test:replay": "npx tsx --test replay_state.test.ts",
+    "registry": "npx tsx deployment_registry.ts",
     "fund": "npx tsx testnet_utils.ts fund",
     "monitor": "npx tsx monitor.ts",
     "test:regression": "cd .. && npx tsx --test tests/regression/index.test.ts"

--- a/scripts/replay_state.test.ts
+++ b/scripts/replay_state.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Fixture tests for the event replay reducer (Issue #882).
+ *
+ * Run: npx tsx --test replay_state.test.ts
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { replay, replayFile, serialize, type ParsedEvent } from "./replay_state.ts";
+
+const FIXTURE = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures/replay_events_fixture.json",
+);
+
+test("empty event stream replays to an empty snapshot", () => {
+  const state = replay([]);
+  assert.equal(state.lastLedger, 0);
+  assert.equal(state.appliedEvents, 0);
+  assert.deepEqual(state.stakes, {});
+  assert.equal(state.feesCollected, 0n);
+  assert.equal(state.lastOraclePrice, null);
+});
+
+test("fixture replays to the known state snapshot", () => {
+  const state = replayFile(FIXTURE);
+
+  assert.equal(state.lastLedger, 108);
+  assert.equal(state.appliedEvents, 8); // 9 events, badge_awarded is unhandled
+  assert.deepEqual(state.stakes, { GALICE: 600n, GBOB: 2500n });
+  assert.deepEqual(state.signals, { "7": { trades: 2, volume: 6500n } });
+  assert.equal(state.feesCollected, 65n);
+  assert.equal(state.lastOraclePrice, 1_050_000n);
+});
+
+test("unhandled event names are reported, not silently dropped", () => {
+  const state = replayFile(FIXTURE);
+  assert.deepEqual(state.unhandledEvents, ["badge_awarded"]);
+});
+
+test("out-of-order events replay deterministically", () => {
+  const events = (JSON.parse(readFileSync(FIXTURE, "utf8")) as { events: ParsedEvent[] })
+    .events;
+
+  const forward = replay(events);
+  const reversed = replay([...events].reverse());
+  assert.equal(serialize(forward), serialize(reversed));
+});
+
+test("snapshot serializes bigints as decimal strings", () => {
+  const state = replayFile(FIXTURE);
+  const json = JSON.parse(serialize(state));
+  assert.equal(json.stakes.GALICE, "600");
+  assert.equal(json.feesCollected, "65");
+});

--- a/scripts/replay_state.ts
+++ b/scripts/replay_state.ts
@@ -1,0 +1,147 @@
+/**
+ * Event replay → state reconstruction (Issue #882).
+ *
+ * `replay_events.ts` fetches and parses raw Soroban events. This module takes
+ * that parsed stream and folds it into a coherent state snapshot: per-user
+ * stakes, per-signal trade stats, collected fees and the latest oracle price.
+ * The reducer is pure and deterministic, so a fixture of events always replays
+ * to the same snapshot — which is what the fixture test asserts.
+ *
+ * CLI:
+ *   npx tsx replay_state.ts sample_parsed_events_testnet.json
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export interface ParsedEvent {
+  id: string;
+  ledger: number;
+  txHash: string;
+  contractId: string;
+  eventName: string;
+  topicsNative: unknown[];
+  dataNative: Record<string, string | number>;
+}
+
+export interface StateSnapshot {
+  /** Ledger of the last event folded in. */
+  lastLedger: number;
+  /** Number of events applied (events with unknown names are skipped). */
+  appliedEvents: number;
+  /** Event names seen but not handled by any reducer. */
+  unhandledEvents: string[];
+  /** Staked balance per account. */
+  stakes: Record<string, bigint>;
+  /** Executed trade count and cumulative volume per signal. */
+  signals: Record<string, { trades: number; volume: bigint }>;
+  /** Total fees collected. */
+  feesCollected: bigint;
+  /** Most recent oracle price, or null if none was seen. */
+  lastOraclePrice: bigint | null;
+}
+
+function emptySnapshot(): StateSnapshot {
+  return {
+    lastLedger: 0,
+    appliedEvents: 0,
+    unhandledEvents: [],
+    stakes: {},
+    signals: {},
+    feesCollected: 0n,
+    lastOraclePrice: null,
+  };
+}
+
+function big(value: string | number | undefined): bigint {
+  return value === undefined ? 0n : BigInt(value);
+}
+
+function str(value: string | number | undefined): string {
+  return value === undefined ? "" : String(value);
+}
+
+/** Folds a single parsed event into `state`. Returns false if unhandled. */
+function apply(state: StateSnapshot, event: ParsedEvent): boolean {
+  const data = event.dataNative ?? {};
+
+  switch (event.eventName) {
+    case "staked": {
+      const who = str(data.staker ?? data.user);
+      state.stakes[who] = (state.stakes[who] ?? 0n) + big(data.amount);
+      return true;
+    }
+    case "unstaked": {
+      const who = str(data.staker ?? data.user);
+      state.stakes[who] = (state.stakes[who] ?? 0n) - big(data.amount);
+      return true;
+    }
+    case "trade_executed": {
+      const signalId = str(data.signal_id);
+      const entry = state.signals[signalId] ?? { trades: 0, volume: 0n };
+      entry.trades += 1;
+      entry.volume += big(data.volume);
+      state.signals[signalId] = entry;
+      return true;
+    }
+    case "fee_collected": {
+      state.feesCollected += big(data.amount ?? data.fee);
+      return true;
+    }
+    case "oracle_price_submitted": {
+      state.lastOraclePrice = big(data.price);
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Replays parsed events into a state snapshot. Events are sorted by ledger
+ * first so an out-of-order page from the RPC still replays deterministically.
+ */
+export function replay(events: ParsedEvent[]): StateSnapshot {
+  const state = emptySnapshot();
+  const unhandled = new Set<string>();
+
+  const ordered = [...events].sort(
+    (a, b) => a.ledger - b.ledger || a.id.localeCompare(b.id),
+  );
+
+  for (const event of ordered) {
+    if (apply(state, event)) {
+      state.appliedEvents += 1;
+    } else {
+      unhandled.add(event.eventName);
+    }
+    state.lastLedger = Math.max(state.lastLedger, event.ledger);
+  }
+
+  state.unhandledEvents = [...unhandled].sort();
+  return state;
+}
+
+/** Reads a parsed-event dump (the shape written by `test_event_parsing.ts`). */
+export function replayFile(path: string): StateSnapshot {
+  const dump = JSON.parse(readFileSync(path, "utf8")) as { events: ParsedEvent[] };
+  return replay(dump.events ?? []);
+}
+
+/** JSON-safe rendering of a snapshot (bigints become decimal strings). */
+export function serialize(state: StateSnapshot): string {
+  return JSON.stringify(
+    state,
+    (_key, value) => (typeof value === "bigint" ? value.toString() : value),
+    2,
+  );
+}
+
+function main(): void {
+  const path = process.argv[2] ?? "sample_parsed_events_testnet.json";
+  console.log(serialize(replayFile(path)));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/stellar-swipe/contracts/common/src/lib.rs
+++ b/stellar-swipe/contracts/common/src/lib.rs
@@ -29,6 +29,8 @@ pub mod replay_protection;
 pub mod retry_backoff;
 /// Generic CRUD helpers to replace per-contract storage boilerplate (Issue #579).
 pub mod storage_crud;
+/// Token metadata and decimal validation shared by deposit/withdraw paths (Issue #880).
+pub mod token_metadata;
 pub mod ttl_manager;
 
 pub use amm_bridge::{

--- a/stellar-swipe/contracts/common/src/token_metadata.rs
+++ b/stellar-swipe/contracts/common/src/token_metadata.rs
@@ -1,0 +1,200 @@
+//! Token metadata and decimal validation (Issue #880).
+//!
+//! Deposits, withdrawals and reward math must agree on what a "unit" of an
+//! asset is. Stellar classic assets are 7-decimal, but Soroban token contracts
+//! may declare anything up to [`MAX_DECIMALS`]. Entrypoints validate metadata
+//! once, up front, with [`validate`] and then use [`rescale`] to convert an
+//! amount between the token's own precision and the protocol's internal
+//! [`PROTOCOL_DECIMALS`] precision.
+
+use soroban_sdk::{contracttype, String};
+
+/// Decimals used for all internal accounting (Stellar classic precision).
+pub const PROTOCOL_DECIMALS: u32 = 7;
+
+/// Largest decimal exponent the protocol will accept from a token contract.
+/// Above this, rescaling to protocol precision cannot be done without
+/// overflowing `i128` for realistic balances.
+pub const MAX_DECIMALS: u32 = 18;
+
+/// Stellar asset code length bounds.
+const SYMBOL_MIN_LEN: u32 = 1;
+const SYMBOL_MAX_LEN: u32 = 12;
+const NAME_MAX_LEN: u32 = 64;
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TokenMetadataError {
+    /// `decimals` exceeds [`MAX_DECIMALS`].
+    UnsupportedDecimals,
+    /// Symbol is empty or longer than 12 characters.
+    InvalidSymbol,
+    /// Name is empty or longer than 64 characters.
+    InvalidName,
+    /// Metadata does not match the value previously registered for this asset.
+    MetadataMismatch,
+}
+
+/// Metadata as reported by a token contract.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenMetadata {
+    pub symbol: String,
+    pub name: String,
+    pub decimals: u32,
+}
+
+/// Validates token metadata before it is used for accounting.
+pub fn validate(metadata: &TokenMetadata) -> Result<(), TokenMetadataError> {
+    if metadata.decimals > MAX_DECIMALS {
+        return Err(TokenMetadataError::UnsupportedDecimals);
+    }
+    let symbol_len = metadata.symbol.len();
+    if symbol_len < SYMBOL_MIN_LEN || symbol_len > SYMBOL_MAX_LEN {
+        return Err(TokenMetadataError::InvalidSymbol);
+    }
+    let name_len = metadata.name.len();
+    if name_len == 0 || name_len > NAME_MAX_LEN {
+        return Err(TokenMetadataError::InvalidName);
+    }
+    Ok(())
+}
+
+/// Validates `observed` and checks it still matches what was registered for the
+/// asset. Re-reading metadata on every entrypoint is what catches a token that
+/// changed its decimals between a deposit and the matching withdrawal.
+pub fn validate_matches(
+    observed: &TokenMetadata,
+    registered: &TokenMetadata,
+) -> Result<(), TokenMetadataError> {
+    validate(observed)?;
+    if observed != registered {
+        return Err(TokenMetadataError::MetadataMismatch);
+    }
+    Ok(())
+}
+
+/// Converts `amount` from `from_decimals` precision to `to_decimals` precision.
+///
+/// Scaling down truncates toward zero — the protocol never rounds in the user's
+/// favour. Returns `None` on overflow so callers surface an error rather than
+/// silently wrapping.
+pub fn rescale(amount: i128, from_decimals: u32, to_decimals: u32) -> Option<i128> {
+    if from_decimals > MAX_DECIMALS || to_decimals > MAX_DECIMALS {
+        return None;
+    }
+    if from_decimals == to_decimals {
+        return Some(amount);
+    }
+    if to_decimals > from_decimals {
+        let factor = 10i128.checked_pow(to_decimals - from_decimals)?;
+        amount.checked_mul(factor)
+    } else {
+        let factor = 10i128.checked_pow(from_decimals - to_decimals)?;
+        Some(amount / factor)
+    }
+}
+
+/// Converts an amount in the token's own precision to protocol precision.
+pub fn to_protocol_amount(amount: i128, token_decimals: u32) -> Option<i128> {
+    rescale(amount, token_decimals, PROTOCOL_DECIMALS)
+}
+
+/// Converts an internal protocol amount back to the token's own precision.
+pub fn from_protocol_amount(amount: i128, token_decimals: u32) -> Option<i128> {
+    rescale(amount, PROTOCOL_DECIMALS, token_decimals)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::Env;
+
+    fn metadata(env: &Env, symbol: &str, name: &str, decimals: u32) -> TokenMetadata {
+        TokenMetadata {
+            symbol: String::from_str(env, symbol),
+            name: String::from_str(env, name),
+            decimals,
+        }
+    }
+
+    #[test]
+    fn accepts_well_formed_metadata() {
+        let env = Env::default();
+        assert!(validate(&metadata(&env, "USDC", "USD Coin", 7)).is_ok());
+        assert!(validate(&metadata(&env, "XLM", "Stellar Lumens", 7)).is_ok());
+        assert!(validate(&metadata(&env, "WETH", "Wrapped Ether", 18)).is_ok());
+    }
+
+    #[test]
+    fn rejects_unsupported_decimals() {
+        let env = Env::default();
+        assert_eq!(
+            validate(&metadata(&env, "BAD", "Too Precise", 19)),
+            Err(TokenMetadataError::UnsupportedDecimals)
+        );
+    }
+
+    #[test]
+    fn rejects_bad_symbol_and_name() {
+        let env = Env::default();
+        assert_eq!(
+            validate(&metadata(&env, "", "Empty Symbol", 7)),
+            Err(TokenMetadataError::InvalidSymbol)
+        );
+        assert_eq!(
+            validate(&metadata(&env, "WAYTOOLONGCODE", "Long Symbol", 7)),
+            Err(TokenMetadataError::InvalidSymbol)
+        );
+        assert_eq!(
+            validate(&metadata(&env, "OK", "", 7)),
+            Err(TokenMetadataError::InvalidName)
+        );
+    }
+
+    #[test]
+    fn detects_metadata_drift() {
+        let env = Env::default();
+        let registered = metadata(&env, "USDC", "USD Coin", 7);
+        let same = metadata(&env, "USDC", "USD Coin", 7);
+        let drifted = metadata(&env, "USDC", "USD Coin", 6);
+
+        assert!(validate_matches(&same, &registered).is_ok());
+        assert_eq!(
+            validate_matches(&drifted, &registered),
+            Err(TokenMetadataError::MetadataMismatch)
+        );
+    }
+
+    #[test]
+    fn rescale_is_identity_at_equal_precision() {
+        assert_eq!(rescale(1_234, 7, 7), Some(1_234));
+    }
+
+    #[test]
+    fn rescale_up_and_down() {
+        // 1.0 token at 6 decimals -> 7 decimals
+        assert_eq!(to_protocol_amount(1_000_000, 6), Some(10_000_000));
+        // 1.0 token at 18 decimals -> 7 decimals
+        assert_eq!(
+            to_protocol_amount(1_000_000_000_000_000_000, 18),
+            Some(10_000_000)
+        );
+        // Round-trip back out
+        assert_eq!(from_protocol_amount(10_000_000, 6), Some(1_000_000));
+    }
+
+    #[test]
+    fn rescale_truncates_toward_zero() {
+        // Sub-unit dust is dropped, never rounded up.
+        assert_eq!(to_protocol_amount(1_999, 18), Some(0));
+        assert_eq!(rescale(-15, 8, 7), Some(-1));
+    }
+
+    #[test]
+    fn rescale_rejects_overflow_and_bad_decimals() {
+        assert_eq!(rescale(i128::MAX, 7, 18), None);
+        assert_eq!(rescale(1, 0, 19), None);
+        assert_eq!(rescale(1, 19, 7), None);
+    }
+}

--- a/stellar-swipe/contracts/user_portfolio/src/lib.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/lib.rs
@@ -13,6 +13,7 @@ mod portfolio_tests;
 mod position_tags;
 mod preferences;
 mod queries;
+mod risk_metrics;
 mod storage;
 mod subscriptions;
 mod watchlist;
@@ -2715,9 +2716,7 @@ mod exposure_cap_tests {
         let user = Address::generate(&env);
 
         // Set cap of 5_000 for asset 1.
-        client
-            .set_asset_exposure_cap(&user, &1u32, &5_000i128)
-            .unwrap();
+        client.set_asset_exposure_cap(&user, &1u32, &5_000i128);
 
         // Trade 3_000 — within cap.
         let result = client.try_open_position_with_cap_check(&user, &1u32, &100i128, &3_000i128);
@@ -2734,9 +2733,7 @@ mod exposure_cap_tests {
         let client = UserPortfolioClient::new(&env, &contract_id);
         let user = Address::generate(&env);
 
-        client
-            .set_asset_exposure_cap(&user, &1u32, &2_000i128)
-            .unwrap();
+        client.set_asset_exposure_cap(&user, &1u32, &2_000i128);
 
         // 3_000 > 2_000 cap → must be rejected.
         let result = client.try_open_position_with_cap_check(&user, &1u32, &100i128, &3_000i128);
@@ -2765,15 +2762,11 @@ mod exposure_cap_tests {
         let client = UserPortfolioClient::new(&env, &contract_id);
         let user = Address::generate(&env);
 
-        client
-            .set_asset_exposure_cap(&user, &1u32, &1_000i128)
-            .unwrap();
+        client.set_asset_exposure_cap(&user, &1u32, &1_000i128);
         assert_eq!(client.get_asset_exposure_cap(&user, &1u32), Some(1_000));
 
         // Raise the cap.
-        client
-            .set_asset_exposure_cap(&user, &1u32, &5_000i128)
-            .unwrap();
+        client.set_asset_exposure_cap(&user, &1u32, &5_000i128);
         assert_eq!(client.get_asset_exposure_cap(&user, &1u32), Some(5_000));
 
         // Remove the cap entirely.

--- a/stellar-swipe/contracts/user_portfolio/src/risk_metrics.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/risk_metrics.rs
@@ -1,0 +1,209 @@
+//! Portfolio risk exposure and concentration metrics (Issue #879).
+//!
+//! Pure, allocation-free helpers that turn a user's per-asset exposures into
+//! risk metrics: total exposure, the largest single-asset share, and a
+//! Herfindahl-Hirschman concentration index. The metrics are derived from the
+//! exposures already tracked by [`crate::exposure_cap`], so they stay correct
+//! after any state transition that updates exposure — there is no separate
+//! cached copy to fall out of sync.
+//!
+//! Shares and the index are expressed in basis points (10_000 bps = 100%).
+//! Enforcement of a per-asset cap remains in `exposure_cap`; the concentration
+//! limit here is a portfolio-level check layered on top of it.
+
+use soroban_sdk::{contracttype, Env, Vec};
+
+/// Basis-point denominator (100%).
+pub const BPS_DENOMINATOR: i128 = 10_000;
+
+/// Risk metrics derived from a user's per-asset exposures.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RiskMetrics {
+    /// Sum of all per-asset exposures.
+    pub total_exposure: i128,
+    /// Exposure of the single largest position.
+    pub largest_exposure: i128,
+    /// Largest position as a share of the total, in basis points.
+    pub largest_share_bps: u32,
+    /// Herfindahl-Hirschman index in basis points: 10_000 for a single asset,
+    /// 10_000 / n for n equally sized positions. Higher means more concentrated.
+    pub concentration_bps: u32,
+    /// Number of non-zero positions.
+    pub position_count: u32,
+}
+
+impl RiskMetrics {
+    /// An empty portfolio: no exposure, no concentration.
+    pub fn empty() -> Self {
+        RiskMetrics {
+            total_exposure: 0,
+            largest_exposure: 0,
+            largest_share_bps: 0,
+            concentration_bps: 0,
+            position_count: 0,
+        }
+    }
+}
+
+/// `part / total` expressed in basis points.
+///
+/// Both operands are halved until the numerator fits, so a portfolio near
+/// `i128::MAX` still yields a meaningful share instead of a saturated one.
+fn share_bps(mut part: i128, mut total: i128) -> i128 {
+    const LIMIT: i128 = i128::MAX / BPS_DENOMINATOR;
+    while part > LIMIT {
+        part /= 2;
+        total /= 2;
+    }
+    if total <= 0 {
+        return 0;
+    }
+    part * BPS_DENOMINATOR / total
+}
+
+/// Computes risk metrics from a user's per-asset exposures.
+///
+/// Negative and zero exposures are ignored — only non-zero long exposure
+/// contributes to concentration. An empty (or all-zero) portfolio yields
+/// [`RiskMetrics::empty`], never a division by zero.
+pub fn compute(_env: &Env, exposures: &Vec<i128>) -> RiskMetrics {
+    let mut total: i128 = 0;
+    let mut largest: i128 = 0;
+    let mut count: u32 = 0;
+
+    for exposure in exposures.iter() {
+        if exposure <= 0 {
+            continue;
+        }
+        total = total.saturating_add(exposure);
+        if exposure > largest {
+            largest = exposure;
+        }
+        count += 1;
+    }
+
+    if total == 0 {
+        return RiskMetrics::empty();
+    }
+
+    let mut hhi: i128 = 0;
+    for exposure in exposures.iter() {
+        if exposure <= 0 {
+            continue;
+        }
+        let share = share_bps(exposure, total);
+        hhi = hhi.saturating_add(share * share / BPS_DENOMINATOR);
+    }
+
+    RiskMetrics {
+        total_exposure: total,
+        largest_exposure: largest,
+        largest_share_bps: share_bps(largest, total) as u32,
+        concentration_bps: hhi.min(BPS_DENOMINATOR) as u32,
+        position_count: count,
+    }
+}
+
+/// Returns `true` when no single position exceeds `max_share_bps` of the
+/// portfolio. An empty portfolio is always within limit.
+pub fn is_within_concentration_limit(metrics: &RiskMetrics, max_share_bps: u32) -> bool {
+    metrics.largest_share_bps <= max_share_bps
+}
+
+/// Largest exposure that may be added to `asset_exposure` without pushing it
+/// past `max_share_bps` of the resulting portfolio. Returns 0 when the position
+/// is already at or over the limit.
+pub fn headroom(total_exposure: i128, asset_exposure: i128, max_share_bps: u32) -> i128 {
+    let max_bps = max_share_bps as i128;
+    if max_bps == 0 || max_bps >= BPS_DENOMINATOR {
+        return if max_bps == 0 { 0 } else { i128::MAX };
+    }
+    // asset + x <= max_bps/10_000 * (total + x)  =>  x <= (max_bps*total - 10_000*asset) / (10_000 - max_bps)
+    let numerator = max_bps.saturating_mul(total_exposure) - BPS_DENOMINATOR * asset_exposure;
+    if numerator <= 0 {
+        return 0;
+    }
+    numerator / (BPS_DENOMINATOR - max_bps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{vec, Env};
+
+    #[test]
+    fn empty_portfolio_has_no_risk() {
+        let env = Env::default();
+        let metrics = compute(&env, &vec![&env]);
+        assert_eq!(metrics, RiskMetrics::empty());
+        assert!(is_within_concentration_limit(&metrics, 0));
+    }
+
+    #[test]
+    fn zero_exposures_are_ignored() {
+        let env = Env::default();
+        let metrics = compute(&env, &vec![&env, 0i128, 0i128]);
+        assert_eq!(metrics.total_exposure, 0);
+        assert_eq!(metrics.position_count, 0);
+    }
+
+    #[test]
+    fn single_position_is_fully_concentrated() {
+        let env = Env::default();
+        let metrics = compute(&env, &vec![&env, 1_000i128]);
+        assert_eq!(metrics.total_exposure, 1_000);
+        assert_eq!(metrics.largest_share_bps, 10_000);
+        assert_eq!(metrics.concentration_bps, 10_000);
+        assert_eq!(metrics.position_count, 1);
+    }
+
+    #[test]
+    fn equal_positions_split_concentration() {
+        let env = Env::default();
+        let metrics = compute(&env, &vec![&env, 250i128, 250i128, 250i128, 250i128]);
+        assert_eq!(metrics.largest_share_bps, 2_500);
+        assert_eq!(metrics.concentration_bps, 2_500); // 10_000 / 4
+        assert_eq!(metrics.position_count, 4);
+    }
+
+    #[test]
+    fn skewed_portfolio_trips_the_limit() {
+        let env = Env::default();
+        let metrics = compute(&env, &vec![&env, 900i128, 50i128, 50i128]);
+        assert_eq!(metrics.largest_share_bps, 9_000);
+        assert!(!is_within_concentration_limit(&metrics, 5_000));
+        assert!(is_within_concentration_limit(&metrics, 9_000));
+    }
+
+    #[test]
+    fn negative_exposures_do_not_contribute() {
+        let env = Env::default();
+        let metrics = compute(&env, &vec![&env, 100i128, -100i128]);
+        assert_eq!(metrics.total_exposure, 100);
+        assert_eq!(metrics.position_count, 1);
+    }
+
+    #[test]
+    fn headroom_respects_the_limit() {
+        // 50% limit, 100 total, 20 already in the asset:
+        // 20 + x <= 0.5 * (100 + x)  =>  x <= 60
+        assert_eq!(headroom(100, 20, 5_000), 60);
+        // Already over the limit.
+        assert_eq!(headroom(100, 80, 5_000), 0);
+        // Degenerate limits.
+        assert_eq!(headroom(100, 0, 0), 0);
+        assert_eq!(headroom(100, 0, 10_000), i128::MAX);
+    }
+
+    #[test]
+    fn large_exposures_do_not_overflow() {
+        let env = Env::default();
+        let big = i128::MAX / 4;
+        let metrics = compute(&env, &vec![&env, big, big]);
+        // Shares are scaled down before dividing at this magnitude, so allow a
+        // one-bps rounding difference rather than a saturated garbage value.
+        assert!(metrics.largest_share_bps.abs_diff(5_000) <= 1);
+        assert!(metrics.concentration_bps <= 10_000);
+    }
+}


### PR DESCRIPTION
…try, event replay

Closes #879: add `user_portfolio::risk_metrics` — total exposure, largest position share and an HHI concentration index in basis points, derived from the exposures already tracked by `exposure_cap` so metrics stay correct after any state transition. Includes a `headroom` helper and tests covering empty, equal, skewed and extreme-magnitude portfolios.

Closes #880: add `common::token_metadata` — symbol/name/decimal validation, a `validate_matches` drift check, and `rescale`/`to_protocol_amount` decimal conversion that truncates toward zero and returns None on overflow rather than wrapping. Tests cover valid, unsupported and mismatched metadata.

Closes #881: add `deployments/registry.json` as the canonical contract address registry plus `scripts/deployment_registry.ts` to read and update it (`list`/`get` CLI, `getContractId`, `recordDeployment`). Documented in deployments/README.md alongside the existing manifests.

Closes #882: add `scripts/replay_state.ts`, folding parsed events into a state snapshot (stakes, per-signal trade stats, fees, latest oracle price). Events are ledger-sorted so out-of-order RPC pages replay deterministically, and unhandled event names are reported instead of dropped. Validated against scripts/fixtures/replay_events_fixture.json; documented in docs/event_replay.md.

Also drops four `.unwrap()` calls on unit-returning client methods in exposure_cap_tests, which were failing to compile and blocked the user_portfolio test suite from building at all.