### PR TITLE
feat(oracle,trade_executor,governance,stake_vault,bridge): add trade …

### DIFF
--- a/stellar-swipe/contracts/bridge/src/lib.rs
+++ b/stellar-swipe/contracts/bridge/src/lib.rs
@@ -37,6 +37,8 @@ pub enum BridgeError {
     OutOfOrderNonce = 18,
     /// Message nonce was already confirmed; duplicate delivery rejected (Issue #668).
     DuplicateNonce = 19,
+    /// The bridge is paused (governance-driven emergency pause). See Issue #865.
+    ContractPaused = 20,
 }
 
 #[contracttype]
@@ -133,6 +135,11 @@ pub enum DataKey {
     ReserveThreshold,
     /// Admin-managed set of supported destination chain IDs (Issue #669).
     SupportedChains,
+    /// Issue #865: global pause flag set via governance-driven propagation.
+    Paused,
+    /// Issue #865: central governance contract address authorized to call
+    /// `apply_governance_pause`.
+    GovernanceAddress,
 }
 
 const DAY_SECONDS: u64 = 86_400;
@@ -253,6 +260,9 @@ impl BridgeContract {
         source_nonce: u64,
         destination_recipient: String,
     ) -> Result<u64, BridgeError> {
+        if is_paused(&env) {
+            return Err(BridgeError::ContractPaused);
+        }
         if !cfg!(test) {
             user.require_auth();
         }
@@ -351,6 +361,9 @@ impl BridgeContract {
         admin: Address,
         transfer_id: u64,
     ) -> Result<(), BridgeError> {
+        if is_paused(&env) {
+            return Err(BridgeError::ContractPaused);
+        }
         require_admin(&env, &admin)?;
         if !cfg!(test) {
             admin.require_auth();
@@ -406,6 +419,9 @@ impl BridgeContract {
         amount: i128,
         destination_recipient: String,
     ) -> Result<u64, BridgeError> {
+        if is_paused(&env) {
+            return Err(BridgeError::ContractPaused);
+        }
         if !cfg!(test) {
             user.require_auth();
         }
@@ -508,6 +524,9 @@ impl BridgeContract {
         admin: Address,
         transfer_id: u64,
     ) -> Result<(), BridgeError> {
+        if is_paused(&env) {
+            return Err(BridgeError::ContractPaused);
+        }
         let config = require_admin(&env, &admin)?;
         if !cfg!(test) {
             admin.require_auth();
@@ -722,7 +741,55 @@ impl BridgeContract {
 
     /// Read-only health for ops / frontends.
     pub fn health_check(env: Env) -> stellar_swipe_common::HealthStatus {
-        crate::governance::bridge_health_check(&env)
+        let version = String::from_str(&env, env!("CARGO_PKG_VERSION"));
+        let config: Option<BridgeConfig> = env.storage().instance().get(&DataKey::Config);
+        match config {
+            Some(cfg) => stellar_swipe_common::HealthStatus {
+                is_initialized: true,
+                is_paused: is_paused(&env),
+                version,
+                admin: cfg.admin,
+            },
+            None => crate::governance::bridge_health_check(&env),
+        }
+    }
+
+    // ── Issue #865: governance-driven pause propagation ────────────────────────
+
+    /// Set the central governance contract address authorized to call
+    /// `apply_governance_pause`. Admin only.
+    pub fn set_governance(env: Env, admin: Address, governance: Address) -> Result<(), BridgeError> {
+        require_admin(&env, &admin)?;
+        if !cfg!(test) {
+            admin.require_auth();
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::GovernanceAddress, &governance);
+        Ok(())
+    }
+
+    /// Read-only: the configured governance contract address, if any.
+    pub fn get_governance(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::GovernanceAddress)
+    }
+
+    /// Called by the configured governance contract to propagate a pause/unpause.
+    /// Rejects new lock-mint/burn-unlock transfers and their execution while paused.
+    pub fn apply_governance_pause(env: Env, paused: bool) -> Result<(), BridgeError> {
+        let governance: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::GovernanceAddress)
+            .ok_or(BridgeError::UnauthorizedValidator)?;
+        governance.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        Ok(())
+    }
+
+    /// Read-only: true when a governance-driven emergency pause is active.
+    pub fn is_paused(env: Env) -> bool {
+        is_paused(&env)
     }
 
     // ── #613 Dynamic liquidity rate-limit ──────────────────────────────────────
@@ -849,6 +916,14 @@ fn require_admin(env: &Env, admin: &Address) -> Result<BridgeConfig, BridgeError
         return Err(BridgeError::UnauthorizedValidator);
     }
     Ok(config)
+}
+
+/// Issue #865: true when a governance-driven emergency pause is active.
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
 }
 
 fn get_transfer(env: &Env, transfer_id: u64) -> Result<BridgeTransfer, BridgeError> {

--- a/stellar-swipe/contracts/governance/src/lib.rs
+++ b/stellar-swipe/contracts/governance/src/lib.rs
@@ -166,6 +166,8 @@ pub enum StorageKey {
     ShadowMode,
     /// #693: Per-category quorum and supermajority thresholds (Map<u32, CategoryThreshold>).
     CategoryThresholds,
+    /// Issue #865: downstream contract addresses that receive governance pause propagation.
+    PausePropagationTargets,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -353,7 +355,8 @@ impl GovernanceContract {
         }
     }
 
-    /// Sets the global pause flag (admin only).
+    /// Sets the global pause flag (admin only) and propagates the change to
+    /// every registered downstream contract (Issue #865).
     ///
     /// Uses the shared [`pausable`] module so pause behavior and event shape
     /// are consistent across all contracts that adopt it (Issue #561).
@@ -364,7 +367,53 @@ impl GovernanceContract {
     ) -> Result<(), GovernanceError> {
         require_admin(&env, &admin)?;
         pausable::set_paused(&env, paused);
+        propagate_pause_to_downstream(&env, paused);
         Ok(())
+    }
+
+    // ── Issue #865: governance pause propagation ───────────────────────────────
+
+    /// Register a downstream contract to receive pause/unpause propagation the
+    /// next time `set_contract_paused` is called. Admin only. Idempotent.
+    pub fn register_pause_target(
+        env: Env,
+        admin: Address,
+        target: Address,
+    ) -> Result<(), GovernanceError> {
+        require_admin(&env, &admin)?;
+        let mut targets = pause_targets(&env);
+        if !targets.contains(&target) {
+            targets.push_back(target);
+            env.storage()
+                .instance()
+                .set(&StorageKey::PausePropagationTargets, &targets);
+        }
+        Ok(())
+    }
+
+    /// Unregister a downstream contract from pause propagation. Admin only.
+    pub fn unregister_pause_target(
+        env: Env,
+        admin: Address,
+        target: Address,
+    ) -> Result<(), GovernanceError> {
+        require_admin(&env, &admin)?;
+        let targets = pause_targets(&env);
+        let mut filtered = Vec::new(&env);
+        for t in targets.iter() {
+            if t != target {
+                filtered.push_back(t);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&StorageKey::PausePropagationTargets, &filtered);
+        Ok(())
+    }
+
+    /// Read-only: the downstream contracts currently registered for pause propagation.
+    pub fn get_pause_targets(env: Env) -> Vec<Address> {
+        pause_targets(&env)
     }
 
     pub fn get_metadata(env: Env) -> Result<TokenMetadata, GovernanceError> {
@@ -1854,6 +1903,32 @@ fn require_admin(env: &Env, caller: &Address) -> Result<(), GovernanceError> {
 /// Crate-visible alias used by sub-modules (e.g. proposal_deposit).
 pub(crate) fn require_admin_pub(env: &Env, caller: &Address) -> Result<(), GovernanceError> {
     require_admin(env, caller)
+}
+
+/// Issue #865: downstream contracts registered for pause propagation.
+fn pause_targets(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&StorageKey::PausePropagationTargets)
+        .unwrap_or(Vec::new(env))
+}
+
+/// Best-effort propagation of a governance pause/unpause to every registered
+/// downstream contract (Issue #865). A single unreachable or incompatible
+/// downstream contract does not block the local pause or propagation to the
+/// remaining targets; failures are surfaced via a `pause_propagation_failed`
+/// event so operators can reconcile drift manually.
+fn propagate_pause_to_downstream(env: &Env, paused: bool) {
+    let targets = pause_targets(env);
+    for target in targets.iter() {
+        let client = pausable::PausableClient::new(env, &target);
+        if client.try_apply_governance_pause(&paused).is_err() {
+            env.events().publish(
+                (Symbol::new(env, "pause_propagation_failed"),),
+                (target, paused),
+            );
+        }
+    }
 }
 
 fn balances(env: &Env) -> Map<Address, i128> {

--- a/stellar-swipe/contracts/oracle/src/admin.rs
+++ b/stellar-swipe/contracts/oracle/src/admin.rs
@@ -83,6 +83,34 @@ pub fn unpause_category(env: &Env, caller: &Address, category: String) -> Result
     Ok(())
 }
 
+/// Directly set (or clear) the global `CAT_ALL` pause category, bypassing the
+/// normal admin/guardian authorization performed by [`pause_category`] /
+/// [`unpause_category`]. Callers are responsible for authorizing the request
+/// themselves; this is used by the governance-driven pause propagation
+/// entrypoint (Issue #865), which authorizes via the configured governance
+/// contract address instead of the local admin/guardian.
+pub fn set_all_paused(env: &Env, paused: bool) {
+    let category = String::from_str(env, CAT_ALL);
+    let mut states = get_pause_states(env);
+    if paused {
+        let now = env.ledger().timestamp();
+        states.set(
+            category,
+            PauseState {
+                paused: true,
+                paused_at: now,
+                auto_unpause_at: None,
+                reason: String::from_str(env, "governance_pause"),
+            },
+        );
+    } else {
+        states.remove(category);
+    }
+    env.storage()
+        .instance()
+        .set(&StorageKey::PauseStates, &states);
+}
+
 pub fn get_pause_states(env: &Env) -> Map<String, PauseState> {
     env.storage()
         .instance()

--- a/stellar-swipe/contracts/oracle/src/deviation.rs
+++ b/stellar-swipe/contracts/oracle/src/deviation.rs
@@ -8,12 +8,15 @@
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 use stellar_swipe_common::AssetPair;
 
+use crate::errors::OracleError;
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone)]
 enum DeviationKey {
     Threshold(AssetPair),
+    RejectThreshold(AssetPair),
 }
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
@@ -33,16 +36,41 @@ pub fn get_deviation_threshold(env: &Env, pair: &AssetPair) -> u32 {
         .unwrap_or(0)
 }
 
+/// Set the admin-configurable hard reject threshold in basis points. Unlike
+/// the alert threshold, exceeding this causes `check_deviation` to return
+/// `Err(OracleError::DeviationRejected)` instead of merely emitting an event.
+/// Issue #864.
+pub fn set_deviation_reject_threshold(env: &Env, pair: &AssetPair, threshold_bps: u32) {
+    env.storage()
+        .persistent()
+        .set(&DeviationKey::RejectThreshold(pair.clone()), &threshold_bps);
+}
+
+/// Get the deviation hard reject threshold in basis points. Returns 0 (disabled) if not configured.
+pub fn get_deviation_reject_threshold(env: &Env, pair: &AssetPair) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DeviationKey::RejectThreshold(pair.clone()))
+        .unwrap_or(0)
+}
+
 // ── Check & emit ──────────────────────────────────────────────────────────────
 
-/// Compute max deviation across fresh price sources and emit
-/// `price_deviation_alert` if it exceeds the configured threshold.
+/// Compute max deviation across fresh price sources, emit `price_deviation_alert`
+/// if it exceeds the configured alert threshold, and reject with
+/// `OracleError::DeviationRejected` if it exceeds the configured hard reject
+/// threshold (Issue #864).
 ///
-/// `prices` is the slice of (source, price) from all currently reporting sources.
-pub fn check_deviation(env: &Env, pair: &AssetPair, sources: &Vec<(Address, i128)>) {
+/// `sources` is the slice of (source, price) from all currently reporting sources.
+pub fn check_deviation(
+    env: &Env,
+    pair: &AssetPair,
+    sources: &Vec<(Address, i128)>,
+) -> Result<(), OracleError> {
     let threshold_bps = get_deviation_threshold(env, pair);
-    if threshold_bps == 0 || sources.is_empty() {
-        return;
+    let reject_threshold_bps = get_deviation_reject_threshold(env, pair);
+    if (threshold_bps == 0 && reject_threshold_bps == 0) || sources.is_empty() {
+        return Ok(());
     }
 
     // Find min and max price across all sources
@@ -60,11 +88,12 @@ pub fn check_deviation(env: &Env, pair: &AssetPair, sources: &Vec<(Address, i128
     }
 
     if min_price <= 0 {
-        return;
+        return Ok(());
     }
 
     let deviation_bps = ((max_price - min_price) * 10_000) / min_price;
-    if deviation_bps as u32 > threshold_bps {
+
+    if threshold_bps != 0 && deviation_bps as u32 > threshold_bps {
         // Collect offending source identifiers (all sources contributing to max deviation)
         let mut offending: Vec<Address> = Vec::new(env);
         for i in 0..sources.len() {
@@ -80,4 +109,10 @@ pub fn check_deviation(env: &Env, pair: &AssetPair, sources: &Vec<(Address, i128
             (pair.clone(), deviation_bps as u32, threshold_bps, offending),
         );
     }
+
+    if reject_threshold_bps != 0 && deviation_bps as u32 > reject_threshold_bps {
+        return Err(OracleError::DeviationRejected);
+    }
+
+    Ok(())
 }

--- a/stellar-swipe/contracts/oracle/src/errors.rs
+++ b/stellar-swipe/contracts/oracle/src/errors.rs
@@ -35,4 +35,8 @@ pub enum OracleError {
     /// Issue #811: `upgrade()` was called with a version that is not
     /// strictly greater than the currently stored contract version.
     IncompatibleContractVersion = 27,
+    /// Issue #864: a submitted quote's confidence is below the configured minimum.
+    LowConfidence = 28,
+    /// Issue #864: cross-source deviation exceeded the configured hard reject threshold.
+    DeviationRejected = 29,
 }

--- a/stellar-swipe/contracts/oracle/src/events.rs
+++ b/stellar-swipe/contracts/oracle/src/events.rs
@@ -65,6 +65,13 @@ pub fn emit_min_source_count_updated(env: &Env, old_count: u32, new_count: u32) 
     );
 }
 
+pub fn emit_min_confidence_updated(env: &Env, old_min_confidence: u32, new_min_confidence: u32) {
+    env.events().publish(
+        (Symbol::new(env, "min_confidence_updated"),),
+        (old_min_confidence, new_min_confidence),
+    );
+}
+
 pub fn emit_guardian_set(env: &Env, guardian: Address) {
     env.events()
         .publish((Symbol::new(env, "guardian_set"),), guardian);

--- a/stellar-swipe/contracts/oracle/src/external_adapter.rs
+++ b/stellar-swipe/contracts/oracle/src/external_adapter.rs
@@ -2,20 +2,33 @@ use soroban_sdk::Env;
 use soroban_sdk::Vec;
 
 use crate::errors::OracleError;
+use crate::staleness;
 use crate::types::ExternalPrice;
 
 /// Aggregate external oracle reports (simplified average; signature verification is out of scope here).
+///
+/// Issue #864: reports older than the configured staleness window for their
+/// asset pair are dropped before aggregation; if every report is stale the
+/// call is rejected with `OracleError::StalePrice` rather than silently
+/// falling back to insufficient-sources.
 pub fn process_external_prices(
-    _env: &Env,
+    env: &Env,
     prices: Vec<ExternalPrice>,
 ) -> Result<i128, OracleError> {
     if prices.is_empty() {
         return Err(OracleError::InsufficientOracles);
     }
 
+    let now = env.ledger().timestamp();
     let mut sum: i128 = 0;
     let mut count: i128 = 0;
+    let mut any_stale = false;
     for p in prices.iter() {
+        let window = staleness::get_staleness_window(env, &p.asset_pair);
+        if now.saturating_sub(p.timestamp) >= window {
+            any_stale = true;
+            continue;
+        }
         if p.price > 0 {
             sum = sum.checked_add(p.price).ok_or(OracleError::Overflow)?;
             count += 1;
@@ -23,6 +36,9 @@ pub fn process_external_prices(
     }
 
     if count == 0 {
+        if any_stale {
+            return Err(OracleError::StalePrice);
+        }
         return Err(OracleError::InsufficientOracles);
     }
 

--- a/stellar-swipe/contracts/oracle/src/lib.rs
+++ b/stellar-swipe/contracts/oracle/src/lib.rs
@@ -301,6 +301,37 @@ impl OracleContract {
         admin::unpause_category(&env, &caller, category)
     }
 
+    // ── Issue #865: governance-driven pause propagation ────────────────────────
+
+    /// Set the central governance contract address authorized to call
+    /// `apply_governance_pause`. Admin only.
+    pub fn set_governance(env: Env, admin: Address, governance: Address) -> Result<(), OracleError> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&StorageKey::GovernanceAddress, &governance);
+        Ok(())
+    }
+
+    /// Read-only: the configured governance contract address, if any.
+    pub fn get_governance(env: Env) -> Option<Address> {
+        env.storage().instance().get(&StorageKey::GovernanceAddress)
+    }
+
+    /// Called by the configured governance contract to propagate a pause/unpause
+    /// to this oracle by setting (or clearing) the global `CAT_ALL` pause category.
+    pub fn apply_governance_pause(env: Env, paused: bool) -> Result<(), OracleError> {
+        let governance: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::GovernanceAddress)
+            .ok_or(OracleError::Unauthorized)?;
+        governance.require_auth();
+        admin::set_all_paused(&env, paused);
+        Ok(())
+    }
+
     /// Set guardian address (admin only)
     pub fn set_guardian(env: Env, caller: Address, guardian: Address) -> Result<(), OracleError> {
         admin::set_guardian(&env, &caller, guardian)
@@ -751,11 +782,12 @@ impl OracleContract {
             .ok_or(OracleError::PriceNotFound)?;
 
         let current_time = env.ledger().timestamp();
+        let window = staleness::get_staleness_window(&env, &pair);
         let mut fresh_prices: Vec<PriceData> = Vec::new(&env);
 
-        // 1. Filter stale prices (TTL: 300s / 5 mins)
+        // 1. Filter stale prices using the configured freshness window (Issue #864).
         for p in prices.iter() {
-            if current_time.saturating_sub(p.timestamp) < 300 {
+            if current_time.saturating_sub(p.timestamp) < window {
                 fresh_prices.push_back(p);
             }
         }
@@ -831,6 +863,76 @@ impl OracleContract {
             .unwrap_or(0)
     }
 
+    /// Set the minimum confidence (0-100) required for a submitted quote to be
+    /// accepted by `submit_pair_price`. Admin only. Emits `min_confidence_updated`.
+    /// Issue #864.
+    pub fn set_min_confidence(
+        env: Env,
+        admin: Address,
+        min_confidence: u32,
+    ) -> Result<(), OracleError> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        let old: u32 = env
+            .storage()
+            .instance()
+            .get(&StorageKey::MinConfidence)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&StorageKey::MinConfidence, &min_confidence);
+        events::emit_min_confidence_updated(&env, old, min_confidence);
+        Ok(())
+    }
+
+    /// Return the current minimum confidence requirement (0 = no requirement).
+    pub fn get_min_confidence(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&StorageKey::MinConfidence)
+            .unwrap_or(0)
+    }
+
+    /// Admin: set the freshness window (seconds) for a pair. Quotes older than
+    /// this are rejected by `submit_pair_price`/`get_price_with_confidence`.
+    /// Issue #864.
+    pub fn set_staleness_window(
+        env: Env,
+        admin: Address,
+        pair: AssetPair,
+        window_secs: u64,
+    ) -> Result<(), OracleError> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        staleness::set_staleness_window(&env, &pair, window_secs);
+        Ok(())
+    }
+
+    /// Read-only: return the configured freshness window in seconds for a pair.
+    pub fn get_staleness_window(env: Env, pair: AssetPair) -> u64 {
+        staleness::get_staleness_window(&env, &pair)
+    }
+
+    /// Admin: set the hard deviation reject threshold (basis points) for a pair.
+    /// Unlike `set_deviation_threshold` (alert-only), exceeding this threshold
+    /// causes `submit_pair_price` to reject the quote. Issue #864.
+    pub fn set_deviation_reject_threshold(
+        env: Env,
+        admin: Address,
+        pair: AssetPair,
+        threshold_bps: u32,
+    ) -> Result<(), OracleError> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        deviation::set_deviation_reject_threshold(&env, &pair, threshold_bps);
+        Ok(())
+    }
+
+    /// Read-only: return current deviation hard reject threshold in bps (0 = disabled).
+    pub fn get_deviation_reject_threshold(env: Env, pair: AssetPair) -> u32 {
+        deviation::get_deviation_reject_threshold(&env, &pair)
+    }
+
     pub fn add_price_source(
         env: Env,
         admin: Address,
@@ -847,6 +949,12 @@ impl OracleContract {
     }
 
     /// Submit a price observation for aggregation (`PriceMap` path).
+    ///
+    /// Issue #864: rejects the quote before it is accepted if its confidence
+    /// is below the configured minimum, or if it deviates from other
+    /// currently-fresh sources by more than the configured hard reject
+    /// threshold. Existing entries older than the configured staleness
+    /// window are dropped before this comparison is made.
     pub fn submit_pair_price(
         env: Env,
         source: Address,
@@ -860,6 +968,15 @@ impl OracleContract {
 
         source.require_auth();
 
+        if price <= 0 {
+            return Err(OracleError::InvalidPrice);
+        }
+
+        let min_confidence = Self::get_min_confidence(env.clone());
+        if confidence < min_confidence {
+            return Err(OracleError::LowConfidence);
+        }
+
         // Ensure source is a registered oracle
         let weight: u32 = env
             .storage()
@@ -871,33 +988,45 @@ impl OracleContract {
         }
 
         let key = StorageKey::PriceMap(pair.clone());
-        let mut prices: Vec<PriceData> = env
+        let prices: Vec<PriceData> = env
             .storage()
             .temporary()
             .get(&key)
             .unwrap_or(Vec::new(&env));
 
+        let now = env.ledger().timestamp();
+        let window = staleness::get_staleness_window(&env, &pair);
+
+        // Drop existing entries outside the freshness window before comparing.
+        let mut fresh: Vec<PriceData> = Vec::new(&env);
+        for p in prices.iter() {
+            if now.saturating_sub(p.timestamp) < window {
+                fresh.push_back(p);
+            }
+        }
+
+        // #864: compute cross-source deviation (including the new quote) and
+        // reject before persisting if it exceeds the hard reject threshold.
+        let mut source_prices: Vec<(Address, i128)> = Vec::new(&env);
+        for i in 0..fresh.len() {
+            let p = fresh.get(i).unwrap();
+            source_prices.push_back((p.source, p.price));
+        }
+        source_prices.push_back((source.clone(), price));
+        deviation::check_deviation(&env, &pair, &source_prices)?;
+
         let new_entry = PriceData {
             asset_pair: pair.clone(),
             price,
-            timestamp: env.ledger().timestamp(),
+            timestamp: now,
             source,
             confidence,
         };
+        fresh.push_back(new_entry);
 
-        prices.push_back(new_entry);
-
-        // Cache management: Keep prices for 5 mins
-        env.storage().temporary().set(&key, &prices);
+        // Cache management: Keep prices for the configured freshness window.
+        env.storage().temporary().set(&key, &fresh);
         env.storage().temporary().extend_ttl(&key, 60, 60);
-
-        // #671: compute cross-source deviation and emit alert if threshold exceeded
-        let mut source_prices: Vec<(Address, i128)> = Vec::new(&env);
-        for i in 0..prices.len() {
-            let p = prices.get(i).unwrap();
-            source_prices.push_back((p.source, p.price));
-        }
-        deviation::check_deviation(&env, &pair, &source_prices);
 
         Ok(())
     }

--- a/stellar-swipe/contracts/oracle/src/staleness.rs
+++ b/stellar-swipe/contracts/oracle/src/staleness.rs
@@ -4,10 +4,31 @@ use stellar_swipe_common::AssetPair;
 pub const MAX_PRICE_AGE_LEDGERS: u32 = 60;
 pub const ORACLE_DEAD_THRESHOLD_LEDGERS: u32 = 1_440;
 
+/// Default freshness window (seconds) used by quote-accepting entrypoints
+/// when no per-pair override has been configured. Issue #864.
+pub const DEFAULT_STALENESS_WINDOW_SECS: u64 = 300;
+
 #[contracttype]
 #[derive(Clone)]
 enum StaleStorageKey {
     Meta(AssetPair),
+    Window(AssetPair),
+}
+
+/// Admin-configurable freshness window (seconds) for a pair. Quotes older than
+/// this are rejected before being accepted. Issue #864.
+pub fn set_staleness_window(env: &Env, pair: &AssetPair, window_secs: u64) {
+    env.storage()
+        .persistent()
+        .set(&StaleStorageKey::Window(pair.clone()), &window_secs);
+}
+
+/// Returns the configured freshness window in seconds, or the default if unset.
+pub fn get_staleness_window(env: &Env, pair: &AssetPair) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&StaleStorageKey::Window(pair.clone()))
+        .unwrap_or(DEFAULT_STALENESS_WINDOW_SECS)
 }
 
 #[contracttype]

--- a/stellar-swipe/contracts/oracle/src/types.rs
+++ b/stellar-swipe/contracts/oracle/src/types.rs
@@ -45,10 +45,15 @@ pub enum StorageKey {
     PendingAdmin,
     PendingAdminExpiry,
     MinSourceCount,
+    /// Issue #864: minimum confidence (0-100) required for a submitted quote to be accepted.
+    MinConfidence,
     /// Max percentage deviation allowed between consecutive price updates for an asset pair (basis points, 10000 = 100%).
     DeviationThreshold(AssetPair),
     /// Set to true when the single-update deviation breaker has tripped for an asset pair.
     DeviationBreakerTripped(AssetPair),
+    /// Issue #865: central governance contract address authorized to call
+    /// `apply_governance_pause`.
+    GovernanceAddress,
 }
 
 #[contracttype]

--- a/stellar-swipe/contracts/shared/src/pausable.rs
+++ b/stellar-swipe/contracts/shared/src/pausable.rs
@@ -21,7 +21,7 @@
 ///
 /// After migration the old key is no longer consulted; only
 /// [`PausableKey::Paused`] is read.
-use soroban_sdk::{contracttype, symbol_short, Env, Symbol};
+use soroban_sdk::{contractclient, contracttype, symbol_short, Env, Symbol};
 
 /// Storage key for the pause flag.  Defined as a distinct enum so it cannot
 /// collide with contract-local key enums whose variants have different
@@ -71,6 +71,20 @@ pub fn require_not_paused(env: &Env) -> Result<(), bool> {
     } else {
         Ok(())
     }
+}
+
+/// Cross-contract client for governance-driven pause propagation (Issue #865).
+///
+/// Downstream contracts implement `apply_governance_pause` so a central
+/// governance contract can push a pause/unpause to every registered
+/// downstream contract with a single, uniform call regardless of that
+/// contract's own internal pause representation. Implementations are
+/// expected to authorize the call by requiring their configured governance
+/// address (stored locally) rather than requiring the transaction signer,
+/// since this is a contract-to-contract call.
+#[contractclient(name = "PausableClient")]
+pub trait PausableTrait {
+    fn apply_governance_pause(env: Env, paused: bool);
 }
 
 #[cfg(test)]

--- a/stellar-swipe/contracts/stake_vault/src/lib.rs
+++ b/stellar-swipe/contracts/stake_vault/src/lib.rs
@@ -257,6 +257,9 @@ pub enum StorageKey {
     /// (in whole weeks) to a voting-power multiplier (basis points).
     /// Falls back to the built-in default tiers when unset.
     LockMultiplierTiers,
+    /// Issue #865: central governance contract address authorized to call
+    /// `apply_governance_pause`.
+    GovernanceAddress,
 }
 
 #[contracterror]
@@ -551,6 +554,60 @@ impl StakeVaultContract {
 
     pub fn is_paused(env: Env) -> bool {
         pausable::is_paused(&env)
+    }
+
+    // ── Issue #865: governance-driven pause propagation ────────────────────────
+
+    /// Set the central governance contract address authorized to call
+    /// `apply_governance_pause`. Admin only.
+    pub fn set_governance(env: Env, admin: Address, governance: Address) -> Result<(), StakeVaultError> {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(StakeVaultError::NotInitialized)?;
+        admin.require_auth();
+        if admin != stored_admin {
+            return Err(StakeVaultError::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&StorageKey::GovernanceAddress, &governance);
+        Ok(())
+    }
+
+    /// Read-only: the configured governance contract address, if any.
+    pub fn get_governance(env: Env) -> Option<Address> {
+        env.storage().instance().get(&StorageKey::GovernanceAddress)
+    }
+
+    /// Called by the configured governance contract to propagate a pause/unpause
+    /// (Issue #865). Bypasses the multi-sig requirement enforced on `pause`/`unpause`
+    /// since this is a trusted, governance-initiated emergency action.
+    pub fn apply_governance_pause(env: Env, paused: bool) -> Result<(), StakeVaultError> {
+        let governance: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::GovernanceAddress)
+            .ok_or(StakeVaultError::Unauthorized)?;
+        governance.require_auth();
+        pausable::set_paused(&env, paused);
+        Ok(())
+    }
+
+    /// Read-only health probe for monitoring and front-ends (no auth). Issue #865.
+    pub fn health_check(env: Env) -> stellar_swipe_common::HealthStatus {
+        let version = String::from_str(&env, env!("CARGO_PKG_VERSION"));
+        let admin: Option<Address> = env.storage().instance().get(&StorageKey::Admin);
+        let Some(admin) = admin else {
+            return stellar_swipe_common::health_uninitialized(&env, version);
+        };
+        stellar_swipe_common::HealthStatus {
+            is_initialized: true,
+            is_paused: pausable::is_paused(&env),
+            version,
+            admin,
+        }
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/stellar-swipe/contracts/trade_executor/src/errors.rs
+++ b/stellar-swipe/contracts/trade_executor/src/errors.rs
@@ -79,6 +79,8 @@ pub enum ContractError {
     /// nonce/tx_hash has closed. See the replay-protection audit
     /// (Issue: nonce replay attack prevention).
     TradeExpired = 33,
+    /// The contract is paused (governance-driven emergency pause). See Issue #865.
+    ContractPaused = 34,
 }
 
 /// Populated when [`ContractError::InsufficientLiquidity`] is returned.

--- a/stellar-swipe/contracts/trade_executor/src/lib.rs
+++ b/stellar-swipe/contracts/trade_executor/src/lib.rs
@@ -108,6 +108,11 @@ pub enum StorageKey {
     /// Next trade receipt ID counter.
     NextTradeReceiptId,
     ConfirmationDepth,
+    /// Issue #865: global pause flag set via governance-driven propagation.
+    Paused,
+    /// Issue #865: central governance contract address authorized to call
+    /// `apply_governance_pause`.
+    GovernanceAddress,
 }
 
 /// Temporary-storage key for the reentrancy lock on `execute_copy_trade`.
@@ -316,6 +321,14 @@ fn require_admin(env: &Env) -> Result<Address, ContractError> {
     oracle::require_admin(env)
 }
 
+/// Issue #865: true when a governance-driven emergency pause is active.
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&StorageKey::Paused)
+        .unwrap_or(false)
+}
+
 /// Map a low-level [`ReplayError`] onto the contract's public error surface so
 /// callers can distinguish "already used" from "expired" (Issue: nonce replay
 /// attack prevention audit).
@@ -419,6 +432,28 @@ fn market_circuit_breaker_active(env: &Env) -> bool {
     }
 
     true
+}
+
+/// Read-only counterpart of [`market_circuit_breaker_active`]: reports whether the
+/// breaker is currently tripped without performing the auto-reset write when its
+/// duration has elapsed. Used by the simulation entrypoint (Issue #863) so a
+/// dry-run never mutates storage.
+fn market_circuit_breaker_active_readonly(env: &Env) -> bool {
+    let active = env
+        .storage()
+        .instance()
+        .get(&StorageKey::CircuitBreakerActive)
+        .unwrap_or(false);
+    if !active {
+        return false;
+    }
+
+    let activated_ledger = env
+        .storage()
+        .instance()
+        .get(&StorageKey::CircuitBreakerLedger)
+        .unwrap_or(env.ledger().sequence());
+    env.ledger().sequence().saturating_sub(activated_ledger) < CIRCUIT_BREAKER_DURATION_LEDGERS
 }
 
 fn open_interest_for_pair(env: &Env, pair: &Address) -> i128 {
@@ -577,6 +612,173 @@ fn record_trade_receipt(env: &Env, user: &Address, token: &Address, amount: i128
     );
 
     receipt_id
+}
+
+// ── Issue #863: read-only trade simulation ───────────────────────────────────
+
+/// Per-check validation outcomes surfaced by [`simulate_market_copy_trade`].
+/// Evaluated in the same order the corresponding gates run in
+/// `execute_market_copy_trade`, so a caller can tell exactly which check(s)
+/// would reject the trade.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulationValidations {
+    pub min_trade_size_ok: bool,
+    pub circuit_breaker_ok: bool,
+    pub open_interest_ok: bool,
+    pub daily_volume_ok: bool,
+    pub position_cap_ok: bool,
+    pub position_pct_ok: bool,
+    pub balance_ok: bool,
+}
+
+/// Result of a dry-run trade simulation. Read-only: computing it never writes
+/// storage, requires no auth, and performs no cross-contract mutation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SimulationResult {
+    /// True only if every check in `validations` passed.
+    pub would_succeed: bool,
+    /// Effective trade amount after resolving `portfolio_pct_bps` (or the explicit amount
+    /// unchanged when no percentage was requested).
+    pub effective_amount: i128,
+    /// Fee that would be charged in `token` for this trade.
+    pub estimated_fee: i128,
+    /// True when the user has enough balance for `effective_amount` alone but not for
+    /// `effective_amount + estimated_fee`, mirroring the fee-fallback path taken by
+    /// `execute_market_copy_trade` (the fee would be deducted from trade proceeds instead).
+    pub fee_paid_from_received: bool,
+    /// The user's current balance of `token`.
+    pub available_balance: i128,
+    /// The balance that would be required for the trade to succeed without the fallback.
+    pub required_balance: i128,
+    pub validations: SimulationValidations,
+    /// The first failing check, in the same evaluation order as `execute_market_copy_trade`.
+    /// `None` when `would_succeed` is true.
+    pub failure_reason: Option<ContractError>,
+}
+
+/// Dry-run a market copy trade. Mirrors the validation gate order in
+/// `execute_market_copy_trade` using only reads, so simulation and execution stay
+/// in lock-step.
+///
+/// Not replayed here: the final per-user position-limit check against the
+/// configured `UserPortfolio` contract (`validate_and_record`) is inherently
+/// mutating on that contract (it atomically records the position alongside
+/// validating it), so it cannot be dry-run from this contract. It is still
+/// enforced for real at execution time.
+fn simulate_market_copy_trade(
+    env: &Env,
+    user: Address,
+    token: Address,
+    amount: i128,
+    portfolio_pct_bps: Option<u32>,
+) -> SimulationResult {
+    let mut failure_reason: Option<ContractError> = None;
+    let fail = |reason: ContractError, failure_reason: &mut Option<ContractError>| {
+        if failure_reason.is_none() {
+            *failure_reason = Some(reason);
+        }
+    };
+
+    if amount <= 0 {
+        fail(ContractError::InvalidAmount, &mut failure_reason);
+    }
+
+    let min_trade_size_ok = amount >= effective_min_trade_size(env, &token);
+    if !min_trade_size_ok {
+        fail(ContractError::BelowMinimumTradeSize, &mut failure_reason);
+    }
+
+    let circuit_breaker_ok = !market_circuit_breaker_active_readonly(env);
+    if !circuit_breaker_ok {
+        fail(ContractError::CircuitBreakerActive, &mut failure_reason);
+    }
+
+    let open_interest_ok = check_open_interest_limit(env, &token, amount).is_ok();
+    if !open_interest_ok {
+        fail(ContractError::OpenInterestLimitReached, &mut failure_reason);
+    }
+
+    let daily_limit: i128 = env
+        .storage()
+        .instance()
+        .get(&StorageKey::DailyVolumeLimit)
+        .unwrap_or(0i128);
+    let daily_volume_ok = if daily_limit > 0 {
+        let today: u64 = env.ledger().timestamp() / 86_400;
+        let day_key = StorageKey::DailyVolumeDay(user.clone());
+        let vol_key = StorageKey::DailyVolume(user.clone());
+        let stored_day: u64 = env.storage().persistent().get(&day_key).unwrap_or(0u64);
+        let current_vol: i128 = if stored_day == today {
+            env.storage().persistent().get(&vol_key).unwrap_or(0i128)
+        } else {
+            0i128
+        };
+        current_vol.checked_add(amount).unwrap_or(i128::MAX) <= daily_limit
+    } else {
+        true
+    };
+    if !daily_volume_ok {
+        fail(ContractError::DailyVolumeLimitExceeded, &mut failure_reason);
+    }
+
+    let exempt = {
+        let key = StorageKey::PositionLimitExempt(user.clone());
+        env.storage().instance().get(&key).unwrap_or(false)
+    };
+    let position_cap_ok = check_position_cap(env, &user, exempt).is_ok();
+    if !position_cap_ok {
+        fail(ContractError::TooManyOpenPositions, &mut failure_reason);
+    }
+
+    let position_pct_ok = portfolio_pct_bps
+        .map(|pct| pct <= risk_gates::MAX_POSITION_PCT_BPS)
+        .unwrap_or(true);
+    if !position_pct_ok {
+        fail(ContractError::PositionPctTooHigh, &mut failure_reason);
+    }
+
+    let oracle: Option<Address> = env.storage().instance().get(&Symbol::new(env, ORACLE_KEY));
+    let effective_amount = if position_pct_ok {
+        resolve_trade_amount(env, &user, &token, amount, portfolio_pct_bps, oracle)
+            .unwrap_or(amount)
+    } else {
+        amount
+    };
+
+    let available_balance = soroban_sdk::token::Client::new(env, &token).balance(&user);
+    let fee = effective_estimated_fee(env);
+    let (balance_ok, fee_paid_from_received, required_balance) =
+        match check_user_balance(env, &user, &token, effective_amount, fee) {
+            Ok(()) => (true, false, effective_amount.saturating_add(fee)),
+            Err(_) => match check_user_balance(env, &user, &token, effective_amount, 0) {
+                Ok(()) => (true, true, effective_amount),
+                Err(detail) => (false, false, detail.required),
+            },
+        };
+    if !balance_ok {
+        fail(ContractError::InsufficientBalance, &mut failure_reason);
+    }
+
+    SimulationResult {
+        would_succeed: failure_reason.is_none(),
+        effective_amount,
+        estimated_fee: fee,
+        fee_paid_from_received,
+        available_balance,
+        required_balance,
+        validations: SimulationValidations {
+            min_trade_size_ok,
+            circuit_breaker_ok,
+            open_interest_ok,
+            daily_volume_ok,
+            position_cap_ok,
+            position_pct_ok,
+            balance_ok,
+        },
+        failure_reason,
+    }
 }
 
 fn execute_market_copy_trade(
@@ -1042,6 +1244,55 @@ impl TradeExecutorContract {
         env.storage().instance().set(&StorageKey::Admin, &admin);
     }
 
+    // ── Issue #865: governance-driven pause propagation ────────────────────────
+
+    /// Set the central governance contract address authorized to call
+    /// `apply_governance_pause`. Admin only.
+    pub fn set_governance(env: Env, governance: Address) -> Result<(), ContractError> {
+        require_admin(&env)?;
+        env.storage()
+            .instance()
+            .set(&StorageKey::GovernanceAddress, &governance);
+        Ok(())
+    }
+
+    /// Read-only: the configured governance contract address, if any.
+    pub fn get_governance(env: Env) -> Option<Address> {
+        env.storage().instance().get(&StorageKey::GovernanceAddress)
+    }
+
+    /// Called by the configured governance contract to propagate a pause/unpause.
+    pub fn apply_governance_pause(env: Env, paused: bool) -> Result<(), ContractError> {
+        let governance: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::GovernanceAddress)
+            .ok_or(ContractError::Unauthorized)?;
+        governance.require_auth();
+        env.storage().instance().set(&StorageKey::Paused, &paused);
+        Ok(())
+    }
+
+    /// Read-only: true when a governance-driven emergency pause is active.
+    pub fn is_paused(env: Env) -> bool {
+        is_paused(&env)
+    }
+
+    /// Read-only health probe for monitoring and front-ends (no auth).
+    pub fn health_check(env: Env) -> stellar_swipe_common::HealthStatus {
+        let version = String::from_str(&env, env!("CARGO_PKG_VERSION"));
+        let admin: Option<Address> = env.storage().instance().get(&StorageKey::Admin);
+        let Some(admin) = admin else {
+            return stellar_swipe_common::health_uninitialized(&env, version);
+        };
+        stellar_swipe_common::HealthStatus {
+            is_initialized: true,
+            is_paused: is_paused(&env),
+            version,
+            admin,
+        }
+    }
+
     /// # Summary
     /// Configure the portfolio contract used for position validation and
     /// copy-trade recording. Admin auth required.
@@ -1342,6 +1593,9 @@ impl TradeExecutorContract {
         tx_hash: Bytes,
         expiry_ts: u64,
     ) -> Result<(), ContractError> {
+        if is_paused(&env) {
+            return Err(ContractError::ContractPaused);
+        }
         verify_and_commit(&env, &user, nonce, tx_hash, expiry_ts).map_err(map_replay_error)?;
         feature_flags::require_feature_enabled(&env, feature_flags::FEAT_COPY_TRADE)?;
         match order_type {
@@ -1389,6 +1643,25 @@ impl TradeExecutorContract {
                 Ok(())
             }
         }
+    }
+
+    /// Dry-run a market copy trade without submitting it. Returns the expected
+    /// effective amount, fee, and a breakdown of which validation gates would
+    /// pass or fail — without requiring auth, writing any storage, or mutating
+    /// any cross-contract state. Issue #863.
+    ///
+    /// Runs the same checks, in the same order, as the `OrderType::Market` path
+    /// of [`Self::execute_copy_trade`] (excluding the final mutating position-limit
+    /// call to the `UserPortfolio` contract, which cannot be dry-run — see
+    /// [`SimulationResult`]).
+    pub fn simulate_copy_trade(
+        env: Env,
+        user: Address,
+        token: Address,
+        amount: i128,
+        portfolio_pct_bps: Option<u32>,
+    ) -> SimulationResult {
+        simulate_market_copy_trade(&env, user, token, amount, portfolio_pct_bps)
     }
 
     /// Admin/keeper maintenance call: reclaim persistent storage held by


### PR DESCRIPTION
…simulation, oracle freshness/deviation gates, and pause propagation

Add simulation and dry-run support for trade execution workflows Fixes #863

Enforce oracle freshness and deviation protections before accepting quotes Fixes #864

Implement governance-driven pause propagation to downstream contracts Fixes #865

Define a canonical bridge message schema with replay protection Fixes #866