### PR TITLE
Add deterministic ordering and replay semantics scaffold for analytics events

### DIFF
--- a/contracts/signal_registry/src/event_ordering.rs
+++ b/contracts/signal_registry/src/event_ordering.rs
@@ -1,0 +1,84 @@
+//! Initial scaffold for deterministic ordering and replay semantics on analytics
+//! event streams (#918). Defines an OrderedEvent envelope with a strictly
+//! increasing sequence number per stream, and a replay validator that detects
+//! out-of-order or duplicate sequences so replays are stable and testable.
+//! Follow-up work: wire sequence assignment into the live analytics emission
+//! path in analytics_engine.rs.
+
+use soroban_sdk::contracttype;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct OrderedEvent {
+    pub stream_id: u64,
+    pub sequence: u64,
+    pub payload_hash: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplayError {
+    OutOfOrder { expected: u64, got: u64 },
+    DuplicateSequence(u64),
+}
+
+/// Validates that `events` for a single stream form a strictly increasing,
+/// gap-tolerant-but-monotonic sequence, so replaying them always yields the
+/// same order regardless of the order they were received off-chain.
+pub fn validate_replay_order(events: &[OrderedEvent]) -> Result<(), ReplayError> {
+    let mut last_seen: Option<u64> = None;
+    for event in events {
+        if let Some(prev) = last_seen {
+            if event.sequence == prev {
+                return Err(ReplayError::DuplicateSequence(event.sequence));
+            }
+            if event.sequence < prev {
+                return Err(ReplayError::OutOfOrder { expected: prev + 1, got: event.sequence });
+            }
+        }
+        last_seen = Some(event.sequence);
+    }
+    Ok(())
+}
+
+/// Sorts events by (stream_id, sequence) so a batch received in any order
+/// replays deterministically.
+pub fn deterministic_sort(mut events: Vec<OrderedEvent>) -> Vec<OrderedEvent> {
+    events.sort_by(|a, b| (a.stream_id, a.sequence).cmp(&(b.stream_id, b.sequence)));
+    events
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn ev(stream_id: u64, sequence: u64) -> OrderedEvent {
+        OrderedEvent { stream_id, sequence, payload_hash: 0 }
+    }
+
+    #[test]
+    fn accepts_strictly_increasing_sequence() {
+        let events = vec![ev(1, 1), ev(1, 2), ev(1, 3)];
+        assert_eq!(validate_replay_order(&events), Ok(()));
+    }
+
+    #[test]
+    fn rejects_duplicate_sequence() {
+        let events = vec![ev(1, 1), ev(1, 1)];
+        assert_eq!(validate_replay_order(&events), Err(ReplayError::DuplicateSequence(1)));
+    }
+
+    #[test]
+    fn rejects_out_of_order_sequence() {
+        let events = vec![ev(1, 2), ev(1, 1)];
+        assert_eq!(validate_replay_order(&events), Err(ReplayError::OutOfOrder { expected: 3, got: 1 }));
+    }
+
+    #[test]
+    fn deterministic_sort_produces_stable_order_regardless_of_input_order() {
+        let a = deterministic_sort(vec![ev(2, 1), ev(1, 2), ev(1, 1)]);
+        let b = deterministic_sort(vec![ev(1, 1), ev(1, 2), ev(2, 1)]);
+        let seq_a: Vec<(u64, u64)> = a.iter().map(|e| (e.stream_id, e.sequence)).collect();
+        let seq_b: Vec<(u64, u64)> = b.iter().map(|e| (e.stream_id, e.sequence)).collect();
+        assert_eq!(seq_a, seq_b);
+    }
+}


### PR DESCRIPTION
## Summary
Adds an initial deterministic ordering model for analytics event streams: an OrderedEvent envelope keyed by (stream_id, sequence), a validate_replay_order() check that flags out-of-order or duplicate sequences, and a deterministic_sort() helper so a batch of events replays identically regardless of the order it was received in.

## Context / before-after
- Before: event ordering could vary across execution paths, so replaying analytics events did not reliably reproduce the same order.
- After: contracts/signal_registry/src/event_ordering.rs gives replay/ordering a single source of truth: sort by (stream_id, sequence), then validate strict monotonicity per stream.
- Scope note: this is an initial scaffold (ordering/validation logic only), not yet wired into the live event emission path in analytics_engine.rs, this is flagged as follow-up work in the file header.

## Testing
Added unit tests covering:
- Strictly increasing sequences validate cleanly
- Duplicate sequence numbers are rejected
- Out-of-order sequences are rejected with the expected/got values
- Sorting the same events in two different input orders produces identical output order

Run with cargo test inside contracts/signal_registry.

Closes #918