### PR TITLE
feat: read-only portfolio export interface for analytics

### DIFF
--- a/stellar-swipe/Cargo.lock
+++ b/stellar-swipe/Cargo.lock
@@ -806,6 +806,7 @@ version = "0.0.0"
 dependencies = [
  "fee_collector",
  "proptest",
+ "shared",
  "signal_registry",
  "soroban-sdk",
  "stake_vault",

--- a/stellar-swipe/contracts/signal_registry/src/provider_onboarding.rs
+++ b/stellar-swipe/contracts/signal_registry/src/provider_onboarding.rs
@@ -151,7 +151,7 @@ pub fn request_reverification(env: &Env, provider: &Address) {
     set_record(env, &record);
     emit(
         env,
-        symbol_short!("ob_reverif"),
+        symbol_short!("ob_rverf"),
         provider,
         &OnboardingStatus::Pending,
     );

--- a/stellar-swipe/contracts/user_portfolio/src/lib.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/lib.rs
@@ -213,6 +213,30 @@ pub struct Portfolio {
     pub closed_position_ids: Vec<u64>,
 }
 
+/// Complete portfolio state export for off-chain analytics, dashboards, and indexers.
+/// All fields are read-only snapshots derived from existing on-chain state.
+/// Consumers can rely on this stable format without reverse-engineering storage keys.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortfolioExport {
+    /// Sum of all realized P&L from closed positions.
+    pub realized_pnl: i128,
+    /// Unrealized P&L from open positions (`None` when oracle is unavailable).
+    pub unrealized_pnl: Option<i128>,
+    /// Total P&L (realized + unrealized, when available).
+    pub total_pnl: i128,
+    /// Return on investment in basis points (total_pnl * 10_000 / total_invested).
+    pub roi_bps: i32,
+    /// Number of currently open positions.
+    pub open_position_count: u32,
+    /// Number of closed positions.
+    pub closed_position_count: u32,
+    /// Number of portfolio snapshots recorded for this user.
+    pub snapshot_count: u32,
+    /// Current open positions with full state.
+    pub open_positions: Vec<PortfolioPosition>,
+}
+
 soroban_sdk::contractmeta!(key = "SourceHash", val = env!("STELLAR_SOURCE_HASH"));
 soroban_sdk::contractmeta!(key = "GitCommit", val = env!("STELLAR_GIT_COMMIT"));
 
@@ -1185,6 +1209,69 @@ impl UserPortfolio {
             }
         }
         result
+    }
+
+    // ── Portfolio export for off-chain analytics ───────────────────────────────
+
+    /// Read-only export of the user's full portfolio state for off-chain analytics,
+    /// dashboards, and indexers. Returns a stable `PortfolioExport` struct that
+    /// bundles P&L, position counts, open positions, and metadata in one call.
+    ///
+    /// This is a compose query — it calls `get_pnl`, reads position indexes, and
+    /// counts snapshots — but performs no writes. The returned format is documented
+    /// and guaranteed stable within the same major contract version.
+    pub fn export_portfolio(env: Env, user: Address) -> PortfolioExport {
+        let pnl = queries::compute_get_pnl(&env, user.clone());
+
+        let open_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserOpenPositions(user.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut open_positions = Vec::new(&env);
+        for i in 0..open_ids.len() {
+            let Some(position_id) = open_ids.get(i) else {
+                continue;
+            };
+            let Some(position) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Position>(&DataKey::Position(position_id))
+            else {
+                continue;
+            };
+            if position.status == PositionStatus::Open {
+                open_positions.push_back(PortfolioPosition {
+                    position_id,
+                    position,
+                });
+            }
+        }
+
+        let closed_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserClosedPositions(user.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let snapshot_count: u32 = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Vec<u64>>(&DataKey::UserSnapshotTimestamps(user))
+            .map(|v| v.len() as u32)
+            .unwrap_or(0);
+
+        PortfolioExport {
+            realized_pnl: pnl.realized_pnl,
+            unrealized_pnl: pnl.unrealized_pnl,
+            total_pnl: pnl.total_pnl,
+            roi_bps: pnl.roi_bps,
+            open_position_count: open_positions.len() as u32,
+            closed_position_count: closed_ids.len() as u32,
+            snapshot_count,
+            open_positions,
+        }
     }
 
     // ── Portfolio concentration risk (Issue #684) ──────────────────────────────

--- a/stellar-swipe/contracts/user_portfolio/src/tests/mod.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod property_tests;
 pub mod test_pnl;
+pub mod test_portfolio_export;
 pub mod test_tax_event;

--- a/stellar-swipe/contracts/user_portfolio/src/tests/test_portfolio_export.rs
+++ b/stellar-swipe/contracts/user_portfolio/src/tests/test_portfolio_export.rs
@@ -1,0 +1,186 @@
+#![cfg(test)]
+//! Unit tests for portfolio export (Issue #912).
+//!
+//! Covers:
+//! - Empty portfolio export returns zero counts and empty positions
+//! - Export with open positions reflects correct counts and P&L
+//! - Export with closed positions shows correct closed count
+//! - Snapshot count is included in export
+//! - Export is read-only (no state mutation)
+
+use crate::{PortfolioExport, UserPortfolio, UserPortfolioClient};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, Ledger as _},
+    Address, Env, Vec,
+};
+
+// ── Mock oracle (always panics — positions don't need oracle for these tests) ──
+
+#[contract]
+struct OracleDummy;
+
+#[contractimpl]
+impl OracleDummy {
+    pub fn get_price(_env: Env, _asset_pair: u32) -> stellar_swipe_common::OraclePrice {
+        panic!("oracle not used in export tests")
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let oracle = env.register(OracleDummy, ());
+    let contract_id = env.register(UserPortfolio, ());
+    let client = UserPortfolioClient::new(env, &contract_id);
+    client.initialize(&admin, &oracle);
+    (admin, contract_id)
+}
+
+fn provider(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Empty portfolio: all counts are zero, no open positions.
+#[test]
+fn export_empty_portfolio() {
+    let env = Env::default();
+    let (_admin, contract_id) = setup(&env);
+    let client = UserPortfolioClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    let export = client.export_portfolio(&user);
+
+    assert_eq!(export.realized_pnl, 0);
+    assert_eq!(export.unrealized_pnl, Some(0));
+    assert_eq!(export.total_pnl, 0);
+    assert_eq!(export.roi_bps, 0);
+    assert_eq!(export.open_position_count, 0);
+    assert_eq!(export.closed_position_count, 0);
+    assert_eq!(export.snapshot_count, 0);
+    assert_eq!(export.open_positions.len(), 0);
+}
+
+/// Portfolio with open positions: counts and P&L reflect the open state.
+#[test]
+fn export_with_open_positions() {
+    let env = Env::default();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let (_admin, contract_id) = setup(&env);
+    let client = UserPortfolioClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    client.open_position(&user, &100, &1_000);
+    client.open_position(&user, &200, &500);
+
+    let export = client.export_portfolio(&user);
+
+    assert_eq!(export.realized_pnl, 0);
+    // Oracle dummy panics, so unrealized is None for open positions.
+    assert_eq!(export.total_pnl, 0);
+    assert_eq!(export.roi_bps, 0);
+    assert_eq!(export.open_position_count, 2);
+    assert_eq!(export.closed_position_count, 0);
+    assert_eq!(export.snapshot_count, 0);
+    assert_eq!(export.open_positions.len(), 2);
+
+    // First position
+    let p0 = export.open_positions.get(0).unwrap();
+    assert_eq!(p0.position_id, 1);
+    assert_eq!(p0.position.entry_price, 100);
+    assert_eq!(p0.position.amount, 1_000);
+
+    // Second position
+    let p1 = export.open_positions.get(1).unwrap();
+    assert_eq!(p1.position_id, 2);
+    assert_eq!(p1.position.entry_price, 200);
+    assert_eq!(p1.position.amount, 500);
+}
+
+/// Portfolio with closed positions: closed count is reflected in export.
+#[test]
+fn export_with_closed_positions() {
+    let env = Env::default();
+    env.ledger().with_mut(|l| l.timestamp = 1_000);
+    let (_admin, contract_id) = setup(&env);
+    let client = UserPortfolioClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+    let p = provider(&env);
+
+    client.open_position(&user, &100, &1_000);
+    client.open_position(&user, &100, &500);
+
+    env.ledger().with_mut(|l| l.timestamp = 2_000);
+    client.close_position(&user, &1, &150, &110i128, &1u32, &p, &0u64);
+
+    let export = client.export_portfolio(&user);
+
+    assert_eq!(export.realized_pnl, 150);
+    assert_eq!(export.open_position_count, 1);
+    assert_eq!(export.closed_position_count, 1);
+    assert_eq!(export.open_positions.len(), 1);
+
+    // Only the open position remains in open_positions
+    let pos = export.open_positions.get(0).unwrap();
+    assert_eq!(pos.position_id, 2);
+}
+
+/// Snapshot count is reflected in the export.
+#[test]
+fn export_includes_snapshot_count() {
+    let env = Env::default();
+    let (_admin, contract_id) = setup(&env);
+    let client = UserPortfolioClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    env.ledger().with_mut(|l| l.timestamp = 100);
+    client.take_snapshot(&user);
+    env.ledger().with_mut(|l| l.timestamp = 200);
+    client.take_snapshot(&user);
+    env.ledger().with_mut(|l| l.timestamp = 300);
+    client.take_snapshot(&user);
+
+    let export = client.export_portfolio(&user);
+
+    assert_eq!(export.snapshot_count, 3);
+}
+
+/// Export is read-only: calling it does not mutate storage.
+#[test]
+fn export_is_read_only() {
+    let env = Env::default();
+    let (_admin, contract_id) = setup(&env);
+    let client = UserPortfolioClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+
+    // Export before any state changes.
+    let before = client.export_portfolio(&user);
+    assert_eq!(before.snapshot_count, 0);
+
+    // Export again — state should be identical (no writes from export).
+    let after = client.export_portfolio(&user);
+    assert_eq!(after.snapshot_count, 0);
+    assert_eq!(after.open_position_count, 0);
+}
+
+/// Two users' exports are isolated from each other.
+#[test]
+fn export_is_isolated_per_user() {
+    let env = Env::default();
+    let (_admin, contract_id) = setup(&env);
+    let client = UserPortfolioClient::new(&env, &contract_id);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.open_position(&user_a, &100, &1_000);
+
+    let export_a = client.export_portfolio(&user_a);
+    let export_b = client.export_portfolio(&user_b);
+
+    assert_eq!(export_a.open_position_count, 1);
+    assert_eq!(export_b.open_position_count, 0);
+}


### PR DESCRIPTION
Summary
Added a PortfolioExport struct and export_portfolio read-only query that bundles P&L, open/closed position counts, snapshot count, and open positions into a single stable response for off-chain analytics and indexers. Previously consumers had to compose multiple queries and reverse-engineer storage to reconstruct portfolio state.
Test plan
- cargo test -p user_portfolio --lib — all 124 tests pass (6 new export tests + all existing)
- cargo check -p user_portfolio — clean compile, no new warnings
- Tests cover: empty portfolio, open positions, closed positions, snapshot count inclusion, read-only guarantee, per-user isolation
Security review checklist
- This PR does not touch contracts/ or contract-consumed shared crates, or it does, and
    docs/security/release_security_checklist.md (../docs/security/release_security_checklist.md)
    was reviewed against this change (Logic, Access control, Upgrades,
    Arithmetic categories as applicable).
Related issue
Closes #916 
